### PR TITLE
Fix some imports  so make works

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/firecracker-microvm/containerd-firecracker
+module github.com/firecracker-microvm/firecracker-containerd
 
 require (
 	github.com/Microsoft/go-winio v0.4.11 // indirect

--- a/snapshotter/cmd/snapshotter/main.go
+++ b/snapshotter/cmd/snapshotter/main.go
@@ -20,10 +20,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/awslabs/containerd-firecracker/snapshotter"
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/contrib/snapshotservice"
 	"github.com/containerd/containerd/log"
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )


### PR DESCRIPTION
Signed-off-by: Cody Roseborough <crrosebo@amazon.com>

*Issue #, if available:*
Make was failing due to some bad import paths.

*Description of changes:*
- Modified go.Mod to have the correct module name (firecracker-containerd instead of containerd-firecracker).
- Updated import in snapshotter/cmd/snapshotter/main.go to use the firecracker-containerd path instead of awslabs path.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
