### PR TITLE
Monitor state of a running container to cleanly shutdown

### DIFF
--- a/agent/service.go
+++ b/agent/service.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"io/ioutil"
 	"path/filepath"
+	"os"
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
@@ -47,23 +48,30 @@ func NewTaskService(runc shim.Shim) shim.Shim {
 func (ts *TaskService) Create(ctx context.Context, req *shimapi.CreateTaskRequest) (*shimapi.CreateTaskResponse, error) {
 	log.G(ctx).WithFields(logrus.Fields{"id": req.ID, "bundle": req.Bundle}).Info("create")
 
-	// Use mount path instead of bundle path inside the VM
-	req.Bundle = bundleMountPath
-
-	// Do not pass any mounts to runc, everything is already mounted for us
-	req.Rootfs = nil
-
 	// Passthrough runcOptions
 	opts, err := unpackBundle(filepath.Join(bundleMountPath, "config.json"), req.Options)
 	if err != nil {
 		return nil, err
 	}
 	req.Options = opts
+	// Use mount path instead of bundle path inside the VM
+	req.Bundle = bundleMountPath
+
+	// Do not pass any mounts to runc, everything is already mounted for us
+	req.Rootfs = nil
+	// TODO: handle stdio
+	req.Stdin = ""
+	req.Stdout = ""
+	req.Stderr = ""
 
 	ctx = namespaces.WithNamespace(ctx, defaultNamespace)
+	// before create call ensure we remove any existing .init.pid file
+	// We can ignore errors since it's valid for the file to not be present
+	os.Remove(".init.pid")
 	resp, err := ts.runc.Create(ctx, req)
+
 	if err != nil {
-		log.G(ctx).WithError(err).Error("create failed")
+		log.G(ctx).WithError(err).Error("error creating container")
 		return nil, err
 	}
 
@@ -327,7 +335,7 @@ func (ts *TaskService) Connect(ctx context.Context, req *shimapi.ConnectRequest)
 
 func (ts *TaskService) Shutdown(ctx context.Context, req *shimapi.ShutdownRequest) (*types.Empty, error) {
 	log.G(ctx).WithFields(logrus.Fields{"id": req.ID, "now": req.Now}).Debug("shutdown")
-
+	ts.runc.Cleanup(ctx)
 	ctx = namespaces.WithNamespace(ctx, defaultNamespace)
 	resp, err := ts.runc.Shutdown(ctx, req)
 	if err != nil {

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -23,11 +23,14 @@ import (
 	"syscall"
 	"time"
 
+	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/shim"
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
 	"github.com/containerd/ttrpc"
@@ -181,7 +184,6 @@ func (s *service) Create(ctx context.Context, request *taskAPI.CreateTaskRequest
 		log.G(ctx).WithError(err).Error("create failed")
 		return nil, err
 	}
-
 	log.G(ctx).Infof("successfully created task with pid %d", resp.Pid)
 	return resp, nil
 }
@@ -192,8 +194,45 @@ func (s *service) Start(ctx context.Context, req *taskAPI.StartRequest) (*taskAP
 	if err != nil {
 		return nil, err
 	}
+	// TODO: Do we need to cancel this at some point?
+	go s.monitorState(ctx, req.ID, req.ExecID, resp.Pid)
 
 	return resp, nil
+}
+
+func (s *service) monitorState(ctx context.Context, id, exec_id string, pid uint32) {
+	ticker := time.NewTicker(time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			//make a state request
+			req := &taskAPI.StateRequest{
+				ID:     id,
+				ExecID: exec_id,
+			}
+			resp, err := s.agentClient.State(ctx, req)
+			if err != nil {
+				log.G(ctx).WithError(err).Error("error monitoring state")
+				continue
+			}
+			// if ending state, stop vm and break
+			if resp.Status == task.StatusStopped {
+				s.publish.Publish(ctx, runtime.TaskExitEventTopic, &eventstypes.TaskExit{
+					ContainerID: s.id,
+					ID:          s.id,
+					Pid:         pid,
+					ExitStatus:  resp.ExitStatus,
+					ExitedAt:    time.Now(),
+				})
+				s.server.Close()
+				s.Shutdown(ctx, &taskAPI.ShutdownRequest{ID: id})
+				return
+			}
+		}
+
+	}
 }
 
 // Delete the initial process and container
@@ -265,11 +304,18 @@ func (s *service) Resume(ctx context.Context, req *taskAPI.ResumeRequest) (*ptyp
 // Kill a process with the provided signal
 func (s *service) Kill(ctx context.Context, req *taskAPI.KillRequest) (*ptypes.Empty, error) {
 	log.G(ctx).WithFields(logrus.Fields{"id": req.ID, "exec_id": req.ExecID}).Debug("kill")
+	// right now we want to kill vm always when kill is called
+	// may not be true in multi-container vm
+	defer func() {
+		log.G(ctx).Debug("Stopping VM during kill")
+		if err := s.stopVM(); err != nil {
+			log.G(ctx).WithError(err).Error("failed to stop VM")
+		}
+	}()
 	resp, err := s.agentClient.Kill(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-
 	return resp, nil
 }
 
@@ -320,10 +366,7 @@ func (s *service) Connect(ctx context.Context, req *taskAPI.ConnectRequest) (*ta
 func (s *service) Shutdown(ctx context.Context, req *taskAPI.ShutdownRequest) (*ptypes.Empty, error) {
 	log.G(ctx).WithFields(logrus.Fields{"id": req.ID, "now": req.Now}).Debug("shutdown")
 
-	if _, err := s.agentClient.Shutdown(ctx, req); err != nil {
-		log.G(ctx).WithError(err).Error("failed to shutdown agent")
-	}
-
+	s.agentClient.Shutdown(ctx, req)
 	if err := s.stopVM(); err != nil {
 		log.G(ctx).WithError(err).Error("failed to stop VM")
 		return nil, err
@@ -516,6 +559,7 @@ func (s *service) startVM(ctx context.Context, request *taskAPI.CreateTaskReques
 
 	log.G(ctx).Info("creating clients")
 	rpcClient := ttrpc.NewClient(conn)
+	rpcClient.OnClose(func() { conn.Close() })
 	apiClient := taskAPI.NewTaskClient(rpcClient)
 
 	return apiClient, nil


### PR DESCRIPTION
Monitor the state of a running container to enable clean shutdown of the
container and vm.

*Description of changes:*

This adds a continuous monitor goroutine that calls agent.State() once per second to see when the container stops and initiate shutdown and publish the taskExit event. The goal is to enable `ctr run` to successfully run the container and exit. To that goal a few other minor changes are here:
* remove a .init.pid file if it exists -- runc leaves this behind
* add a call to runc.Cleanup() before we shutdown the agent
* add empty string values for container stdio
* made calls to runtime.Kill() to also stop the vm

Doing it this way is a little hacky but is (I think) the simplest approach.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
