### PR TITLE
Add stdio proxying between container, agent, runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50 // indirect
 	github.com/containerd/containerd v1.2.0
 	github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac
-	github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260 // indirect
+	github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260
 	github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3 // indirect
 	github.com/containerd/ttrpc v0.0.0-20181001154009-f51df4475b76
 	github.com/containerd/typeurl v0.0.0-20181015155603-461401dc8f19 // indirect

--- a/internal/common.go
+++ b/internal/common.go
@@ -16,4 +16,12 @@ package internal
 const (
 	SnapshotterMountType = "firecracker-snapshotter"
 	SnapshotterImageKey  = "firecracker-image"
+
+	// vsock ports to use for stdio
+	StdinPort  = 11000
+	StdoutPort = 11001
+	StderrPort = 11002
+
+	// Default buffer size for io in bytes
+	DefaultBufferSize = 1024
 )


### PR DESCRIPTION
Add stdio proxying from the container fifos to the agent, from the agent over
vsock to the runtime, and from the runtime to the fifo's specified by
containerd.

*Issue #, if available:*
closes #17 
*Description of changes:*
Proxies the stdout of the container over vsock to the runtime where it is re-written to the fifo's that containerd expects the output to be written.


Tested by running alpine /bin/sh and was able to use it interactively.
```
% sudo ./ctr run --runtime aws.firecracker --snapshotter firecracker-snapshotter docker.io/library/alpine:latest 2123 /bin/sh
ps
PID   USER     TIME  COMMAND
    1 root      0:00 /bin/sh
    6 root      0:00 ps
ls -al
total 16
drwxr-xr-x   18 root     root          1024 Nov 29 00:31 .
drwxr-xr-x   18 root     root          1024 Nov 29 00:31 ..
drwxr-xr-x    2 root     root          3072 Nov 29 00:31 bin
drwxr-xr-x    5 root     root           320 Nov 29 00:32 dev
drwxr-xr-x   15 root     root          1024 Nov 29 00:31 etc
drwxr-xr-x    2 root     root          1024 Sep 11 20:23 home
drwxr-xr-x    5 root     root          1024 Nov 29 00:31 lib
drwxr-xr-x    5 root     root          1024 Nov 29 00:31 media
drwxr-xr-x    2 root     root          1024 Sep 11 20:23 mnt
dr-xr-xr-x   64 root     root             0 Nov 29 00:32 proc
drwx------    2 root     root          1024 Sep 11 20:23 root
drwxr-xr-x    2 root     root            40 Nov 29 00:32 run
drwxr-xr-x    2 root     root          1024 Nov 29 00:31 sbin
drwxr-xr-x    2 root     root          1024 Sep 11 20:23 srv
dr-xr-xr-x   11 root     root             0 Nov 29 00:32 sys
drwxrwxrwt    2 root     root          1024 Sep 11 20:23 tmp
drwxr-xr-x    7 root     root          1024 Nov 29 00:31 usr
drwxr-xr-x   11 root     root          1024 Nov 29 00:31 var
```
There is still an error related to how we shut down the container/agent/runtime: 
`ctr: rpc error: code = Unknown desc = ttrpc: client shutting down: read vsock:host(2):1222: transport endpoint is not connected: unknown`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
