### PR TITLE
Add mkfs to force option

### DIFF
--- a/snapshotter/firecracker.go
+++ b/snapshotter/firecracker.go
@@ -343,7 +343,7 @@ func (s *Snapshotter) createImage(ctx context.Context, imagePath string, fileSiz
 
 	// Build a Linux filesystem
 	log.G(ctx).WithField("image", file.Name()).Info("building file system")
-	if err := run("mkfs", "-t", "ext4", file.Name()); err != nil {
+	if err := run("mkfs", "-t", "ext4", "-F", file.Name()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

When I run `go test` in snapshotter directory, executing `mkfs -t ext4 <file>` failed.

```
$ sudo -E env "PATH=$PATH" go test
~~
INFO[0000] building file system                          image=/tmp/snapshot-suite-Snapshotter-233656583/root/images/1
--- FAIL: TestSnapshotterSuite (0.00s)
    --- FAIL: TestSnapshotterSuite/Basic (0.01s)
        testsuite.go:142: failure reason: exit status 1
            exec failed: mkfs -t ext4 /tmp/snapshot-suite-Snapshotter-453147216/root/images/1
            github.com/firecracker-microvm/firecracker-containerd/snapshotter.run
                /home/centos/firecracker-containerd/snapshotter/firecracker.go:430
            github.com/firecracker-microvm/firecracker-containerd/snapshotter.(*Snapshotter).createImage
                /home/centos/firecracker-containerd/snapshotter/firecracker.go:346
            github.com/firecracker-microvm/firecracker-containerd/snapshotter.(*Snapshotter).createSnapshot
                /home/centos/firecracker-containerd/snapshotter/firecracker.go:282
            github.com/firecracker-microvm/firecracker-containerd/snapshotter.(*Snapshotter).Prepare
                /home/centos/firecracker-containerd/snapshotter/firecracker.go:143
            github.com/containerd/containerd/snapshots/testsuite.checkSnapshotterBasic
                /home/centos/go/pkg/mod/github.com/containerd/containerd@v1.2.0/snapshots/testsuite/testsuite.go:140
            github.com/containerd/containerd/snapshots/testsuite.makeTest.func1
                /home/centos/go/pkg/mod/github.com/containerd/containerd@v1.2.0/snapshots/testsuite/testsuite.go:111
            testing.tRunner
                /usr/local/go/src/testing/testing.go:827
            runtime.goexit
                /usr/local/go/src/runtime/asm_amd64.s:1333
~~
```

If mkfs receives a file that is not a block special device, it processes interactively, so it waits for input and fails.

```
$ mkfs -t ext4 hoge
mke2fs 1.42.9 (28-Dec-2013)
hoge is not a block special device.
Proceed anyway? (y,n)
```

*Description of changes:*

Adding the -F flag, Set the answer to the question to yes.
After the change, the test was successful.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
