### PR TITLE
(More) Graceful Agent shutdown 

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -68,7 +68,7 @@ func main() {
 		log.G(ctx).WithError(err).Fatal("failed to create runc shim")
 	}
 
-	taskService := NewTaskService(runcTaskService)
+	taskService := NewTaskService(runcTaskService, cancel)
 
 	server, err := ttrpc.NewServer()
 	if err != nil {
@@ -119,5 +119,8 @@ func main() {
 		log.G(ctx).WithError(err).Warn("shim error")
 	}
 
-	log.G(ctx).Info("done")
+	log.G(ctx).Info("shutting down agent")
+	if _, err := runcTaskService.Shutdown(ctx, &shimapi.ShutdownRequest{ID: id, Now: true}); err != nil {
+		log.G(ctx).WithError(err).Error("runc shutdown error")
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/godbus/dbus v0.0.0-20181025153459-66d97aec3384 // indirect
 	github.com/gogo/protobuf v1.1.1
 	github.com/google/go-cmp v0.2.0 // indirect
-	github.com/mdlayher/vsock v0.0.0-20180806202057-2b18bec03226
+	github.com/mdlayher/vsock v0.0.0-20181130155850-676f733b747c
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opencontainers/runtime-spec v0.1.2-0.20181106065543-31e0d16c1cb7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mdlayher/vsock v0.0.0-20180806202057-2b18bec03226 h1:wmDoXXxeJjiMN+cTPVRGfCEg/Fm+30c01blxf72T+rQ=
-github.com/mdlayher/vsock v0.0.0-20180806202057-2b18bec03226/go.mod h1:6jTswHH8nM7Qjq0vwYcUamAuc5hxX9fUqpANJXx05lc=
+github.com/mdlayher/vsock v0.0.0-20181130155850-676f733b747c h1:iyuTD7VKmLNdKySmh0rYWRScafbPcJRiKRbNDXpldYo=
+github.com/mdlayher/vsock v0.0.0-20181130155850-676f733b747c/go.mod h1:gLmzC7yBmdxKztR5gDQz8FyFUMHvOK5H0gQEbKQGIMA=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=


### PR DESCRIPTION
*Issue #, if available:*'
fixes #25 

*Description of changes:*
- This implements graceful shutdown on agent side
- Minor code cleanup (we don't need `StartShim` on agent side)

How it was before:
- runtime calls agent.Shutdown
- agent calls runc.Shutdown (which calls os.Exit behind)
- runtime gets an error `connection closed` from agent.Shutdown

How it works now:
- runtime calls agent.Shutdown
- agent initiates graceful shutdown and responds OK to runtime
- agent shutdowns ttrpc and closes all connections
- agent calls runc.Shutdown (which calls os.Exit behind) and exits
- after agent exits, we need to call `reboot` in order to shutdown Firecracker VM properly. At this point we agreed with @nmeyerhans to use shell script wrapper.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.