### PR TITLE
snapshotter: Fix Makefile target

### DIFF
--- a/snapshotter/Makefile
+++ b/snapshotter/Makefile
@@ -11,9 +11,9 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-all: naive
+all: naive_snapshotter
 
-naive: *.go
+naive_snapshotter: *.go
 	go build -o naive_snapshotter ./cmd/naive
 
 clean:


### PR DESCRIPTION
Naming the target naive clashes with the sub directory name and prevents
from the executable being built.

Use the actual file name so the make target check works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
