### PR TITLE
Implement metadata store for devmapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.2.0
 	github.com/stretchr/testify v1.2.2
-	go.etcd.io/bbolt v1.3.0 // indirect
+	go.etcd.io/bbolt v1.3.0
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
 	golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8
 	google.golang.org/genproto v0.0.0-20181109154231-b5d43981345b // indirect

--- a/snapshotter/devmapper/devmapper_test.go
+++ b/snapshotter/devmapper/devmapper_test.go
@@ -24,11 +24,9 @@ import (
 
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/testsuite"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 
 	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/losetup"
 )
@@ -60,16 +58,7 @@ func TestSnapshotterSuite(t *testing.T) {
 
 		// Remove device mapper pool after test completes
 		removePool := func() error {
-			if err := snap.pool.RemovePool(ctx); err != nil {
-				// Some tests call 'Close' twice, so ignore ErrDatabaseNotOpen
-				if errors.Cause(err) == bolt.ErrDatabaseNotOpen {
-					return nil
-				}
-
-				return err
-			}
-
-			return nil
+			return snap.pool.RemovePool(ctx)
 		}
 
 		// Pool cleanup should be called before closing metadata store (as we need to retrieve device names)

--- a/snapshotter/devmapper/devmapper_test.go
+++ b/snapshotter/devmapper/devmapper_test.go
@@ -58,6 +58,7 @@ func TestSnapshotterSuite(t *testing.T) {
 			return nil, nil, err
 		}
 
+		// Remove device mapper pool after test completes
 		removePool := func() error {
 			if err := snap.pool.RemovePool(ctx); err != nil {
 				// Some tests call 'Close' twice, so ignore ErrDatabaseNotOpen

--- a/snapshotter/devmapper/metadata.go
+++ b/snapshotter/devmapper/metadata.go
@@ -1,0 +1,312 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package devmapper
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"go.etcd.io/bbolt"
+)
+
+// DeviceInfo represents metadata for thin device within thin-pool
+type DeviceInfo struct {
+	// 24-bit number assigned to a device within thin-pool device
+	DeviceID int `json:"device_id"`
+	// thin device size
+	Size uint64 `json:"size"`
+	// Device name to be used in /dev/mapper/
+	Name string `json:"name"`
+	// Name of parent device (if snapshot)
+	ParentName string `json:"parent_name"`
+	// true if thin device was actived
+	IsActivated bool `json:"is_active"`
+}
+
+type (
+	DeviceIDCallback   func(deviceID int) error
+	DeviceInfoCallback func(deviceInfo *DeviceInfo) error
+)
+
+const (
+	maxDeviceID = 0xffffff // Device IDs are 24-bit numbers
+	deviceFree  = byte(0)
+	deviceTaken = byte(1)
+)
+
+// Bucket names
+var (
+	devicesBucketName  = []byte("devices")    // Contains thin devices metadata <device_name>=<DeviceInfo>
+	deviceIDBucketName = []byte("device_ids") // Tracks used device ids <device_id_[0..maxDeviceID)>=<byte_[0/1]>
+)
+
+var (
+	ErrNotFound      = errors.New("not found")
+	ErrAlreadyExists = errors.New("object already exists")
+)
+
+// PoolMetadata keeps device info for the given thin-pool device, it also reponsible for
+// generating next available device ids and tracking devmapper transaction numbers
+type PoolMetadata struct {
+	db *bolt.DB
+}
+
+func NewPoolMetadata(dbfile string) (*PoolMetadata, error) {
+	db, err := bolt.Open(dbfile, 0600, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := &PoolMetadata{db: db}
+	if err := metadata.ensureDatabaseInitialized(); err != nil {
+		return nil, errors.Wrap(err, "failed to initialize database")
+	}
+
+	return metadata, nil
+}
+
+func (m *PoolMetadata) ensureDatabaseInitialized() error {
+	return m.db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists(devicesBucketName); err != nil {
+			return err
+		}
+
+		if _, err := tx.CreateBucketIfNotExists(deviceIDBucketName); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+// AddDevice saves device info to database.
+// Callback should be used to aquire device ID or to rollback transaction in case of error.
+func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo, fn DeviceIDCallback) error {
+	return m.db.Update(func(tx *bolt.Tx) error {
+		devicesBucket := tx.Bucket(devicesBucketName)
+
+		// Make sure device name is unique
+		if err := getObject(devicesBucket, info.Name, nil); err == nil {
+			return ErrAlreadyExists
+		}
+
+		// Find next available device ID
+		deviceID, err := getNextDeviceID(tx)
+		if err != nil {
+			return err
+		}
+
+		if err := fn(deviceID); err != nil {
+			return err
+		}
+
+		info.DeviceID = deviceID
+
+		if err := putObject(devicesBucket, info.Name, info, false); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func getNextDeviceID(tx *bolt.Tx) (int, error) {
+	bucket := tx.Bucket(deviceIDBucketName)
+	cursor := bucket.Cursor()
+
+	// Check if any device id can be reused.
+	// Bolt stores its keys in byte-sorted order within a bucket.
+	// This makes sequential iteration extremely fast.
+	for key, taken := cursor.First(); key != nil; key, taken = cursor.Next() {
+		isFree := taken[0] == deviceFree
+		if isFree {
+			id, err := strconv.Atoi(string(key))
+			if err != nil {
+				return 0, err
+			}
+
+			if err := markDeviceID(tx, id, deviceTaken); err != nil {
+				return 0, err
+			}
+
+			return id, nil
+		}
+	}
+
+	// Try allocate new device ID
+	seq, err := bucket.NextSequence()
+	if err != nil {
+		return 0, err
+	}
+
+	if seq >= maxDeviceID {
+		return 0, errors.Errorf("couldn't find free device key")
+	}
+
+	id := int(seq)
+	if err := markDeviceID(tx, id, deviceTaken); err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+func markDeviceID(tx *bolt.Tx, deviceID int, state byte) error {
+	var (
+		bucket = tx.Bucket(deviceIDBucketName)
+		key    = strconv.Itoa(deviceID)
+		value  = []byte{state}
+	)
+
+	if err := bucket.Put([]byte(key), value); err != nil {
+		return errors.Wrapf(err, "failed to free device id %q", key)
+	}
+
+	return nil
+}
+
+// UpdateDevice updates device info in metadata store.
+// Callback should be used to modify device properties or to rollback update transaction.
+// Name and Device ID couldn't be changed and will be ignored.
+func (m *PoolMetadata) UpdateDevice(ctx context.Context, name string, fn DeviceInfoCallback) error {
+	return m.db.Update(func(tx *bolt.Tx) error {
+		var (
+			device = &DeviceInfo{}
+			bucket = tx.Bucket(devicesBucketName)
+		)
+
+		if err := getObject(bucket, name, device); err != nil {
+			return err
+		}
+
+		// Don't allow changing these values, keep things in sync with devmapper
+		name := device.Name
+		devID := device.DeviceID
+
+		if err := fn(device); err != nil {
+			return err
+		}
+
+		device.Name = name
+		device.DeviceID = devID
+
+		return putObject(bucket, name, device, true)
+	})
+}
+
+// GetDevice retrieves device info by name from database
+func (m *PoolMetadata) GetDevice(ctx context.Context, name string) (*DeviceInfo, error) {
+	var (
+		dev DeviceInfo
+		err error
+	)
+
+	err = m.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(devicesBucketName)
+		return getObject(bucket, name, &dev)
+	})
+
+	return &dev, err
+}
+
+// RemoveDevice removes device info from store
+func (m *PoolMetadata) RemoveDevice(ctx context.Context, name string, fn DeviceInfoCallback) error {
+	return m.db.Update(func(tx *bolt.Tx) error {
+		var (
+			device = &DeviceInfo{}
+			bucket = tx.Bucket(devicesBucketName)
+		)
+
+		if err := getObject(bucket, name, device); err != nil {
+			return err
+		}
+
+		if err := bucket.Delete([]byte(name)); err != nil {
+			return errors.Wrapf(err, "failed to delete device info for %q", name)
+		}
+
+		if err := markDeviceID(tx, device.DeviceID, deviceFree); err != nil {
+			return err
+		}
+
+		return fn(device)
+	})
+}
+
+// GetDeviceNames retrieves the list of device names currently stored in database
+func (m *PoolMetadata) GetDeviceNames(ctx context.Context) ([]string, error) {
+	var (
+		names []string
+		err   error
+	)
+
+	err = m.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(devicesBucketName)
+		return bucket.ForEach(func(k, _ []byte) error {
+			names = append(names, string(k))
+			return nil
+		})
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return names, nil
+}
+
+// Close closes metadata store
+func (m *PoolMetadata) Close() error {
+	if err := m.db.Close(); err != nil && err != bolt.ErrDatabaseNotOpen {
+		return err
+	}
+
+	return nil
+}
+
+func putObject(bucket *bolt.Bucket, key string, obj interface{}, overwrite bool) error {
+	keyBytes := []byte(key)
+
+	if !overwrite && bucket.Get(keyBytes) != nil {
+		return errors.Errorf("object with key %q already exists", key)
+	}
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal object with key %q", key)
+	}
+
+	if err := bucket.Put(keyBytes, data); err != nil {
+		return errors.Wrapf(err, "failed to insert object with key %q", key)
+	}
+
+	return nil
+}
+
+func getObject(bucket *bolt.Bucket, key string, obj interface{}) error {
+	data := bucket.Get([]byte(key))
+	if data == nil {
+		return ErrNotFound
+	}
+
+	if obj != nil {
+		if err := json.Unmarshal(data, obj); err != nil {
+			return errors.Wrapf(err, "failed to unmarshal object with key %q", key)
+		}
+	}
+
+	return nil
+}

--- a/snapshotter/devmapper/metadata.go
+++ b/snapshotter/devmapper/metadata.go
@@ -58,7 +58,7 @@ var (
 	ErrAlreadyExists = errors.New("object already exists")
 )
 
-// PoolMetadata keeps device info for the given thin-pool device, it also reponsible for
+// PoolMetadata keeps device info for the given thin-pool device, it also responsible for
 // generating next available device ids and tracking devmapper transaction numbers
 type PoolMetadata struct {
 	db *bolt.DB
@@ -93,7 +93,7 @@ func (m *PoolMetadata) ensureDatabaseInitialized() error {
 }
 
 // AddDevice saves device info to database.
-// Callback should be used to aquire device ID or to rollback transaction in case of error.
+// Callback should be used to acquire device ID or to rollback transaction in case of error.
 func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo, fn DeviceIDCallback) error {
 	return m.db.Update(func(tx *bolt.Tx) error {
 		devicesBucket := tx.Bucket(devicesBucketName)

--- a/snapshotter/devmapper/metadata_test.go
+++ b/snapshotter/devmapper/metadata_test.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	testCtx             = context.Background()
-	testDevIDCallback   = func(int) error { return nil }
+	testDevIDCallback   = func(uint32) error { return nil }
 	testDevInfoCallback = func(*DeviceInfo) error { return nil }
 )
 
@@ -61,7 +61,7 @@ func TestPoolMetadata_AddDeviceRollback(t *testing.T) {
 	defer cleanupStore(t, tempDir, store)
 
 	expectedErr := errors.New("add failed")
-	err := store.AddDevice(testCtx, &DeviceInfo{Name: "test2"}, func(int) error { return expectedErr })
+	err := store.AddDevice(testCtx, &DeviceInfo{Name: "test2"}, func(uint32) error { return expectedErr })
 	assert.Equal(t, expectedErr, err)
 
 	_, err = store.GetDevice(testCtx, "test2")
@@ -136,7 +136,6 @@ func TestPoolMetadata_UpdateDevice(t *testing.T) {
 		info.ParentName = "test5"
 		info.Size = 6
 		info.IsActivated = false
-		info.Name = "test4"
 		return nil
 	})
 

--- a/snapshotter/devmapper/metadata_test.go
+++ b/snapshotter/devmapper/metadata_test.go
@@ -1,0 +1,189 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package devmapper
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testCtx             = context.Background()
+	testDevIDCallback   = func(int) error { return nil }
+	testDevInfoCallback = func(*DeviceInfo) error { return nil }
+)
+
+func TestPoolMetadata_AddDevice(t *testing.T) {
+	tempDir, store := createStore(t)
+	defer cleanupStore(t, tempDir, store)
+
+	expected := &DeviceInfo{
+		Name:        "test2",
+		ParentName:  "test1",
+		Size:        1,
+		IsActivated: true,
+	}
+
+	err := store.AddDevice(testCtx, expected, testDevIDCallback)
+	assert.NoError(t, err)
+
+	result, err := store.GetDevice(testCtx, "test2")
+	assert.NoError(t, err)
+
+	assert.Equal(t, expected.Name, result.Name)
+	assert.Equal(t, expected.ParentName, result.ParentName)
+	assert.Equal(t, expected.Size, result.Size)
+	assert.Equal(t, expected.IsActivated, result.IsActivated)
+	assert.NotZero(t, result.DeviceID)
+	assert.Equal(t, expected.DeviceID, result.DeviceID)
+}
+
+func TestPoolMetadata_AddDeviceRollback(t *testing.T) {
+	tempDir, store := createStore(t)
+	defer cleanupStore(t, tempDir, store)
+
+	expectedErr := errors.New("add failed")
+	err := store.AddDevice(testCtx, &DeviceInfo{Name: "test2"}, func(int) error { return expectedErr })
+	assert.Equal(t, expectedErr, err)
+
+	_, err = store.GetDevice(testCtx, "test2")
+	assert.Equal(t, ErrNotFound, err)
+}
+
+func TestPoolMetadata_AddDeviceDuplicate(t *testing.T) {
+	tempDir, store := createStore(t)
+	defer cleanupStore(t, tempDir, store)
+
+	err := store.AddDevice(testCtx, &DeviceInfo{Name: "test"}, testDevIDCallback)
+	assert.NoError(t, err)
+
+	err = store.AddDevice(testCtx, &DeviceInfo{Name: "test"}, testDevIDCallback)
+	assert.Equal(t, ErrAlreadyExists, err)
+}
+
+func TestPoolMetadata_ReuseDeviceID(t *testing.T) {
+	tempDir, store := createStore(t)
+	defer cleanupStore(t, tempDir, store)
+
+	info1 := &DeviceInfo{Name: "test1"}
+	err := store.AddDevice(testCtx, info1, testDevIDCallback)
+	assert.NoError(t, err)
+
+	info2 := &DeviceInfo{Name: "test2"}
+	err = store.AddDevice(testCtx, info2, testDevIDCallback)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, info1.DeviceID, info2.DeviceID)
+	assert.NotZero(t, info1.DeviceID)
+
+	err = store.RemoveDevice(testCtx, info2.Name, testDevInfoCallback)
+	assert.NoError(t, err)
+
+	info3 := &DeviceInfo{Name: "test3"}
+	err = store.AddDevice(testCtx, info3, testDevIDCallback)
+	assert.NoError(t, err)
+
+	assert.Equal(t, info2.DeviceID, info3.DeviceID)
+}
+
+func TestPoolMetadata_RemoveDevice(t *testing.T) {
+	tempDir, store := createStore(t)
+	defer cleanupStore(t, tempDir, store)
+
+	err := store.AddDevice(testCtx, &DeviceInfo{Name: "test"}, testDevIDCallback)
+	assert.NoError(t, err)
+
+	err = store.RemoveDevice(testCtx, "test", testDevInfoCallback)
+	assert.NoError(t, err)
+
+	_, err = store.GetDevice(testCtx, "test")
+	assert.Equal(t, ErrNotFound, err)
+}
+
+func TestPoolMetadata_UpdateDevice(t *testing.T) {
+	tempDir, store := createStore(t)
+	defer cleanupStore(t, tempDir, store)
+
+	oldInfo := &DeviceInfo{
+		Name:        "test1",
+		ParentName:  "test2",
+		Size:        3,
+		IsActivated: true,
+	}
+
+	err := store.AddDevice(testCtx, oldInfo, testDevIDCallback)
+	assert.NoError(t, err)
+
+	err = store.UpdateDevice(testCtx, oldInfo.Name, func(info *DeviceInfo) error {
+		info.ParentName = "test5"
+		info.Size = 6
+		info.IsActivated = false
+		info.Name = "test4"
+		return nil
+	})
+
+	assert.NoError(t, err)
+
+	newInfo, err := store.GetDevice(testCtx, "test1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test1", newInfo.Name)
+	assert.Equal(t, "test5", newInfo.ParentName)
+	assert.EqualValues(t, 6, newInfo.Size)
+	assert.False(t, newInfo.IsActivated)
+}
+
+func TestPoolMetadata_GetDeviceNames(t *testing.T) {
+	tempDir, store := createStore(t)
+	defer cleanupStore(t, tempDir, store)
+
+	err := store.AddDevice(testCtx, &DeviceInfo{Name: "test1"}, testDevIDCallback)
+	assert.NoError(t, err)
+
+	err = store.AddDevice(testCtx, &DeviceInfo{Name: "test2"}, testDevIDCallback)
+	assert.NoError(t, err)
+
+	names, err := store.GetDeviceNames(testCtx)
+	assert.NoError(t, err)
+	require.Len(t, names, 2)
+
+	assert.Equal(t, "test1", names[0])
+	assert.Equal(t, "test2", names[1])
+}
+
+func createStore(t *testing.T) (tempDir string, store *PoolMetadata) {
+	tempDir, err := ioutil.TempDir("", "pool-metadata-")
+	require.NoErrorf(t, err, "couldn't create temp directory for metadata tests")
+
+	path := filepath.Join(tempDir, "test.db")
+	metadata, err := NewPoolMetadata(path)
+	require.NoError(t, err)
+
+	return tempDir, metadata
+}
+
+func cleanupStore(t *testing.T, tempDir string, store *PoolMetadata) {
+	err := store.Close()
+	assert.NoErrorf(t, err, "failed to close metadata store")
+
+	err = os.RemoveAll(tempDir)
+	assert.NoErrorf(t, err, "failed to cleanup temp directory")
+}

--- a/snapshotter/devmapper/pool_device.go
+++ b/snapshotter/devmapper/pool_device.go
@@ -80,7 +80,7 @@ func (p *PoolDevice) CreateThinDevice(ctx context.Context, deviceName string, vi
 	}
 
 	// Create thin device and save metadata
-	err := p.metadata.AddDevice(ctx, deviceInfo, func(devID int) error {
+	err := p.metadata.AddDevice(ctx, deviceInfo, func(devID uint32) error {
 		return dmsetup.CreateDevice(p.poolName, devID)
 	})
 
@@ -117,7 +117,7 @@ func (p *PoolDevice) CreateSnapshotDevice(ctx context.Context, deviceName string
 		ParentName: deviceName,
 	}
 
-	err = p.metadata.AddDevice(ctx, snapshotDeviceInfo, func(devID int) error {
+	err = p.metadata.AddDevice(ctx, snapshotDeviceInfo, func(devID uint32) error {
 		return dmsetup.CreateSnapshot(p.poolName, devID, baseDeviceInfo.DeviceID)
 	})
 

--- a/snapshotter/pkg/dmsetup/dmsetup.go
+++ b/snapshotter/pkg/dmsetup/dmsetup.go
@@ -110,20 +110,20 @@ func makeThinPoolMapping(dataFile, metaFile string, blockSizeSectors uint32) (st
 }
 
 // CreateDevice sends "create_thin <deviceID>" message to the given thin-pool
-func CreateDevice(poolName string, deviceID int) error {
+func CreateDevice(poolName string, deviceID uint32) error {
 	_, err := dmsetup("message", poolName, "0", fmt.Sprintf("create_thin %d", deviceID))
 	return err
 }
 
 // ActivateDevice activates the given thin-device using the 'thin' target
-func ActivateDevice(poolName string, deviceName string, deviceID int, size uint64, external string) error {
+func ActivateDevice(poolName string, deviceName string, deviceID uint32, size uint64, external string) error {
 	mapping := makeThinMapping(poolName, deviceID, size, external)
 	_, err := dmsetup("create", deviceName, "--table", mapping)
 	return err
 }
 
 // makeThinMapping makes thin target table entry
-func makeThinMapping(poolName string, deviceID int, sizeBytes uint64, externalOriginDevice string) string {
+func makeThinMapping(poolName string, deviceID uint32, sizeBytes uint64, externalOriginDevice string) string {
 	lengthSectors := sizeBytes / SectorSize
 
 	// Thin target has the following format:
@@ -155,7 +155,7 @@ func Table(deviceName string) (string, error) {
 
 // CreateSnapshot sends "create_snap" message to the given thin-pool.
 // Caller needs to suspend and resume device if it is active.
-func CreateSnapshot(poolName string, deviceID int, baseDeviceID int) error {
+func CreateSnapshot(poolName string, deviceID uint32, baseDeviceID uint32) error {
 	_, err := dmsetup("message", poolName, "0", fmt.Sprintf("create_snap %d %d", deviceID, baseDeviceID))
 	return err
 }


### PR DESCRIPTION
*Description of changes:*
This PR implements metadata store for devmapper using `boltdb`

A few pros I see here:
- It's thread safe, so no worries about parallel calls to snapshotter
- Supports transactions, so metadata always in sync with `devmapper`
- Already used by `containerd`, so no new dependencies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
