### PR TITLE
agent: build a statically-linked binary

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -14,7 +14,7 @@
 all: agent
 
 agent: *.go
-	go build -o agent
+	CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "-s" -o agent
 
 clean:
 	- rm -f agent


### PR DESCRIPTION
*Description of changes:*

The agent runs inside an arbitrary rootfs and may not have glibc available.  Build a statically-linked binary so it can be run in a rootfs that lacks glibc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
