### PR TITLE
Support optional generation of a statically linked agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
 
 SUBDIRS:=agent runtime snapshotter
 export INSTALLROOT?=/usr/local
+export STATIC_AGENT
 
 all: $(SUBDIRS)
 

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -14,7 +14,11 @@
 all: agent
 
 agent: *.go
+ifneq ($(STATIC_AGENT),)
+	CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "-s" -o agent
+else
 	go build -o agent
+endif
 
 clean:
 	- rm -f agent


### PR DESCRIPTION
In order to support a minimal microvm, e.g. based on Alpine, OpenWRT, or similar, we support the generation of a statically linked agent binary.

Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
