### PR TITLE
Validate commit messages and file headers

### DIFF
--- a/.headers/go.txt
+++ b/.headers/go.txt
@@ -1,0 +1,12 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.

--- a/.headers/makefile.txt
+++ b/.headers/makefile.txt
@@ -1,0 +1,12 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To send us a pull request, please:
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages. Make sure your commits are signed (just add a line to every git commit message: `Signed-off-by: John Doe <john.doe@mail.com>` or use `git commit -s`)
+4. Commit to your fork using clear commit messages. Make sure your commits are signed off (just add a line to every git commit message: `Signed-off-by: John Doe <john.doe@mail.com>` or use `git commit -s`)
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To send us a pull request, please:
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
+4. Commit to your fork using clear commit messages. Make sure your commits are signed (just add a line to every git commit message: `Signed-off-by: John Doe <john.doe@mail.com>` or use `git commit -s`)
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,11 @@ clean:
 deps:
 	test -n "$(GOPATH)" # Make sure GOPATH defined
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ${GOPATH}/bin v1.12.3
+	go get -u github.com/vbatts/git-validation
 
 lint:
 	golangci-lint run
+	git-validation -run DCO,dangling-whitespace,short-subject -range dd78e4f0182dfff8ef33e5eb7dc925d5f6e84301..HEAD
 
 install:
 	for d in $(SUBDIRS); do $(MAKE) -C $$d install; done

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,12 @@ deps:
 	test -n "$(GOPATH)" # Make sure GOPATH defined
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ${GOPATH}/bin v1.12.3
 	go get -u github.com/vbatts/git-validation
+	go get -u github.com/kunalkushwaha/ltag
 
 lint:
-	golangci-lint run
+	ltag -t ./.headers -check -v
 	git-validation -run DCO,dangling-whitespace,short-subject -range dd78e4f0182dfff8ef33e5eb7dc925d5f6e84301..HEAD
+	golangci-lint run
 
 install:
 	for d in $(SUBDIRS); do $(MAKE) -C $$d install; done

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ clean:
 deps:
 	test -n "$(GOPATH)" # Make sure GOPATH defined
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ${GOPATH}/bin v1.12.3
-	go get -u github.com/vbatts/git-validation
-	go get -u github.com/kunalkushwaha/ltag
+	GO111MODULE=off go get -u github.com/vbatts/git-validation
+	GO111MODULE=off go get -u github.com/kunalkushwaha/ltag
 
 lint:
 	ltag -t ./.headers -check -v


### PR DESCRIPTION
Signed-off-by: Maksym Pavlenko <makpav@amazon.com>

This will lint commit messages:
- DCO - require `signed off`
- dangling-whitespace - prevent dangling whitespaces on line endings
- short-subject - required <90 

Note: I've added `-range` flag since there are already a lot of invalid commit messages in master branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.