### PR TITLE
Manage device states, rework device removal

### DIFF
--- a/snapshotter/devmapper/device_info.go
+++ b/snapshotter/devmapper/device_info.go
@@ -13,9 +13,68 @@
 
 package devmapper
 
+import (
+	"fmt"
+)
+
 const (
 	maxDeviceID = 0xffffff // Device IDs are 24-bit numbers
 )
+
+// DeviceState represents current devmapper device state reflected in meta store
+type DeviceState int
+
+const (
+	// Unknown means that device just created and no operations were performed
+	Unknown DeviceState = iota
+	// Creating means that device is going to be created
+	Creating
+	// Created means that devices successfully created
+	Created
+	// Activating means that device is going to be activated
+	Activating
+	// Activated means that device successfully activated
+	Activated
+	// Suspending means that device is going to be suspended
+	Suspending
+	// Suspended means that device successfully suspended
+	Suspended
+	// Resuming means that device is going to be resumed from suspended state
+	Resuming
+	// Resumed means that device successfully resumed
+	Resumed
+	// Deactivating means that device is going to be deactivated
+	Deactivating
+	// Deactivated means that device successfully deactivated
+	Deactivated
+)
+
+func (s DeviceState) String() string {
+	switch s {
+	case Creating:
+		return "Creating"
+	case Created:
+		return "Created"
+	case Activating:
+		return "Activating"
+	case Activated:
+		return "Activated"
+	case Suspending:
+		return "Suspending"
+	case Suspended:
+		return "Suspended"
+	case Resuming:
+		return "Resuming"
+	case Resumed:
+		return "Resumed"
+	case Deactivating:
+		return "Deactivating"
+	case Deactivated:
+		return "Deactivated"
+	default:
+		return fmt.Sprintf("unknown %d", s)
+	}
+}
 
 // DeviceInfo represents metadata for thin device within thin-pool
 type DeviceInfo struct {
@@ -27,6 +86,8 @@ type DeviceInfo struct {
 	Name string `json:"name"`
 	// ParentName is a name of parent device (if snapshot)
 	ParentName string `json:"parent_name"`
-	// IsActivated indicates whether thin device was actived
-	IsActivated bool `json:"is_active"`
+	// State represents current device state
+	State DeviceState `json:"state"`
+	// Error details if device state change failed
+	Error string `json:"error"`
 }

--- a/snapshotter/devmapper/device_info.go
+++ b/snapshotter/devmapper/device_info.go
@@ -1,0 +1,32 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package devmapper
+
+const (
+	maxDeviceID = 0xffffff // Device IDs are 24-bit numbers
+)
+
+// DeviceInfo represents metadata for thin device within thin-pool
+type DeviceInfo struct {
+	// DeviceID is a 24-bit number assigned to a device within thin-pool device
+	DeviceID uint32 `json:"device_id"`
+	// Size is a thin device size
+	Size uint64 `json:"size"`
+	// Name is a device name to be used in /dev/mapper/
+	Name string `json:"name"`
+	// ParentName is a name of parent device (if snapshot)
+	ParentName string `json:"parent_name"`
+	// IsActivated indicates whether thin device was actived
+	IsActivated bool `json:"is_active"`
+}

--- a/snapshotter/devmapper/device_info.go
+++ b/snapshotter/devmapper/device_info.go
@@ -25,7 +25,7 @@ const (
 type DeviceState int
 
 const (
-	// Unknown means that device just created and no operations were performed
+	// Unknown means that device just allocated and no operations were performed
 	Unknown DeviceState = iota
 	// Creating means that device is going to be created
 	Creating
@@ -47,6 +47,10 @@ const (
 	Deactivating
 	// Deactivated means that device successfully deactivated
 	Deactivated
+	// Removing means that device is going to be removed
+	Removing
+	// Removed means that device successfully removed but not yet deleted from meta store
+	Removed
 )
 
 func (s DeviceState) String() string {
@@ -71,6 +75,10 @@ func (s DeviceState) String() string {
 		return "Deactivating"
 	case Deactivated:
 		return "Deactivated"
+	case Removing:
+		return "Removing"
+	case Removed:
+		return "Removed"
 	default:
 		return fmt.Sprintf("unknown %d", s)
 	}

--- a/snapshotter/devmapper/metadata.go
+++ b/snapshotter/devmapper/metadata.go
@@ -228,7 +228,7 @@ func (m *PoolMetadata) GetDevice(ctx context.Context, name string) (*DeviceInfo,
 // RemoveDevice removes device info from store.
 // The callback should be used to indicate whether device removal was successful or not.
 // An error returned from the callback will rollback the remove transaction in the database.
-func (m *PoolMetadata) RemoveDevice(ctx context.Context, name string, fn DeviceInfoCallback) error {
+func (m *PoolMetadata) RemoveDevice(ctx context.Context, name string) error {
 	return m.db.Update(func(tx *bolt.Tx) error {
 		var (
 			device = &DeviceInfo{}
@@ -247,7 +247,7 @@ func (m *PoolMetadata) RemoveDevice(ctx context.Context, name string, fn DeviceI
 			return err
 		}
 
-		return fn(device)
+		return nil
 	})
 }
 

--- a/snapshotter/devmapper/metadata.go
+++ b/snapshotter/devmapper/metadata.go
@@ -91,7 +91,7 @@ func (m *PoolMetadata) ensureDatabaseInitialized() error {
 // The callback should be used to indicate whether device allocation was successful or not.
 // An error returned from the callback will rollback the ID assignment transaction in the database and
 // free it for future use.
-func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo, fn DeviceIDCallback) error {
+func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo) error {
 	return m.db.Update(func(tx *bolt.Tx) error {
 		devicesBucket := tx.Bucket(devicesBucketName)
 
@@ -103,10 +103,6 @@ func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo, fn Devic
 		// Find next available device ID
 		deviceID, err := getNextDeviceID(tx)
 		if err != nil {
-			return err
-		}
-
-		if err := fn(deviceID); err != nil {
 			return err
 		}
 

--- a/snapshotter/devmapper/metadata.go
+++ b/snapshotter/devmapper/metadata.go
@@ -23,20 +23,6 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-// DeviceInfo represents metadata for thin device within thin-pool
-type DeviceInfo struct {
-	// DeviceID is a 24-bit number assigned to a device within thin-pool device
-	DeviceID uint32 `json:"device_id"`
-	// Size is a thin device size
-	Size uint64 `json:"size"`
-	// Name is a device name to be used in /dev/mapper/
-	Name string `json:"name"`
-	// ParentName is a name of parent device (if snapshot)
-	ParentName string `json:"parent_name"`
-	// IsActivated indicates whether thin device was actived
-	IsActivated bool `json:"is_active"`
-}
-
 type (
 	// DeviceIDCallback is a callback used for device ID acquisition
 	DeviceIDCallback func(deviceID uint32) error
@@ -44,14 +30,10 @@ type (
 	DeviceInfoCallback func(deviceInfo *DeviceInfo) error
 )
 
-const (
-	maxDeviceID = 0xffffff // Device IDs are 24-bit numbers
-)
-
-type deviceState byte
+type deviceIDState byte
 
 const (
-	deviceFree deviceState = iota
+	deviceFree deviceIDState = iota
 	deviceTaken
 )
 
@@ -183,7 +165,7 @@ func getNextDeviceID(tx *bolt.Tx) (uint32, error) {
 }
 
 // markDeviceID marks a device as deviceFree or deviceTaken
-func markDeviceID(tx *bolt.Tx, deviceID uint32, state deviceState) error {
+func markDeviceID(tx *bolt.Tx, deviceID uint32, state deviceIDState) error {
 	var (
 		bucket = tx.Bucket(deviceIDBucketName)
 		key    = strconv.FormatUint(uint64(deviceID), 10)

--- a/snapshotter/devmapper/metadata.go
+++ b/snapshotter/devmapper/metadata.go
@@ -24,8 +24,6 @@ import (
 )
 
 type (
-	// DeviceIDCallback is a callback used for device ID acquisition
-	DeviceIDCallback func(deviceID uint32) error
 	// DeviceInfoCallback is a callback used for device updates
 	DeviceInfoCallback func(deviceInfo *DeviceInfo) error
 )
@@ -88,9 +86,6 @@ func (m *PoolMetadata) ensureDatabaseInitialized() error {
 }
 
 // AddDevice saves device info to database.
-// The callback should be used to indicate whether device allocation was successful or not.
-// An error returned from the callback will rollback the ID assignment transaction in the database and
-// free it for future use.
 func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo) error {
 	return m.db.Update(func(tx *bolt.Tx) error {
 		devicesBucket := tx.Bucket(devicesBucketName)
@@ -114,8 +109,8 @@ func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo) error {
 
 // getNextDeviceID finds the next free device ID by taking a cursor
 // through the deviceIDBucketName bucket and finding the next sequentially
-// unassigned ID.  Device ID state is marked by a byte deviceFree or
-// deviceTaken.  Low device IDs will be reused sooner.
+// unassigned ID. Device ID state is marked by a byte deviceFree or
+// deviceTaken. Low device IDs will be reused sooner.
 func getNextDeviceID(tx *bolt.Tx) (uint32, error) {
 	bucket := tx.Bucket(deviceIDBucketName)
 	cursor := bucket.Cursor()
@@ -226,8 +221,6 @@ func (m *PoolMetadata) GetDevice(ctx context.Context, name string) (*DeviceInfo,
 }
 
 // RemoveDevice removes device info from store.
-// The callback should be used to indicate whether device removal was successful or not.
-// An error returned from the callback will rollback the remove transaction in the database.
 func (m *PoolMetadata) RemoveDevice(ctx context.Context, name string) error {
 	return m.db.Update(func(tx *bolt.Tx) error {
 		var (

--- a/snapshotter/devmapper/metadata_test.go
+++ b/snapshotter/devmapper/metadata_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 var (
-	testCtx             = context.Background()
-	testDevInfoCallback = func(*DeviceInfo) error { return nil }
+	testCtx = context.Background()
 )
 
 func TestPoolMetadata_AddDevice(t *testing.T) {
@@ -58,10 +57,10 @@ func TestPoolMetadata_AddDeviceRollback(t *testing.T) {
 	tempDir, store := createStore(t)
 	defer cleanupStore(t, tempDir, store)
 
-	err := store.AddDevice(testCtx, &DeviceInfo{Name: "test2"})
+	err := store.AddDevice(testCtx, &DeviceInfo{Name: ""})
 	assert.Error(t, err)
 
-	_, err = store.GetDevice(testCtx, "test2")
+	_, err = store.GetDevice(testCtx, "")
 	assert.Equal(t, ErrNotFound, err)
 }
 
@@ -91,7 +90,7 @@ func TestPoolMetadata_ReuseDeviceID(t *testing.T) {
 	assert.NotEqual(t, info1.DeviceID, info2.DeviceID)
 	assert.NotZero(t, info1.DeviceID)
 
-	err = store.RemoveDevice(testCtx, info2.Name, testDevInfoCallback)
+	err = store.RemoveDevice(testCtx, info2.Name)
 	assert.NoError(t, err)
 
 	info3 := &DeviceInfo{Name: "test3"}
@@ -108,7 +107,7 @@ func TestPoolMetadata_RemoveDevice(t *testing.T) {
 	err := store.AddDevice(testCtx, &DeviceInfo{Name: "test"})
 	assert.NoError(t, err)
 
-	err = store.RemoveDevice(testCtx, "test", testDevInfoCallback)
+	err = store.RemoveDevice(testCtx, "test")
 	assert.NoError(t, err)
 
 	_, err = store.GetDevice(testCtx, "test")

--- a/snapshotter/devmapper/pool_device_test.go
+++ b/snapshotter/devmapper/pool_device_test.go
@@ -128,7 +128,7 @@ func TestPoolDevice(t *testing.T) {
 	output, err = exec.Command("umount", thin1MountPath, snap1MountPath).CombinedOutput()
 	assert.NoErrorf(t, err, "failed to unmount devices: %s", string(output))
 
-	t.Run("RemoveDevice", func(t *testing.T) {
+	t.Run("DeactivateDevice", func(t *testing.T) {
 		testRemoveThinDevice(t, pool)
 	})
 }
@@ -179,11 +179,11 @@ func testRemoveThinDevice(t *testing.T, pool *PoolDevice) {
 	}
 
 	for _, deviceName := range deviceList {
-		err := pool.RemoveDevice(context.Background(), deviceName, false)
+		err := pool.DeactivateDevice(context.Background(), deviceName, false)
 		assert.NoErrorf(t, err, "failed to remove '%s'", deviceName)
 	}
 
-	err := pool.RemoveDevice(context.Background(), "not-existing-device", false)
+	err := pool.DeactivateDevice(context.Background(), "not-existing-device", false)
 	assert.Error(t, err, "should return an error if trying to remove not existing device")
 }
 

--- a/snapshotter/devmapper/pool_device_test.go
+++ b/snapshotter/devmapper/pool_device_test.go
@@ -129,6 +129,10 @@ func TestPoolDevice(t *testing.T) {
 	assert.NoErrorf(t, err, "failed to unmount devices: %s", string(output))
 
 	t.Run("DeactivateDevice", func(t *testing.T) {
+		testDeactivateThinDevice(t, pool)
+	})
+
+	t.Run("RemoveDevice", func(t *testing.T) {
 		testRemoveThinDevice(t, pool)
 	})
 }
@@ -171,9 +175,8 @@ func testCreateSnapshot(t *testing.T, pool *PoolDevice) {
 	assert.NoErrorf(t, err, "failed to create snapshot from '%s' volume", thinDevice1)
 }
 
-func testRemoveThinDevice(t *testing.T, pool *PoolDevice) {
+func testDeactivateThinDevice(t *testing.T, pool *PoolDevice) {
 	deviceList := []string{
-		thinDevice1,
 		thinDevice2,
 		snapDevice1,
 	}
@@ -185,6 +188,11 @@ func testRemoveThinDevice(t *testing.T, pool *PoolDevice) {
 
 	err := pool.DeactivateDevice(context.Background(), "not-existing-device", false)
 	assert.Error(t, err, "should return an error if trying to remove not existing device")
+}
+
+func testRemoveThinDevice(t *testing.T, pool *PoolDevice) {
+	err := pool.RemoveDevice(testCtx, thinDevice1)
+	assert.NoErrorf(t, err, "should delete thin device from pool")
 }
 
 func tempMountPath(t *testing.T) string {

--- a/snapshotter/devmapper/snapshotter.go
+++ b/snapshotter/devmapper/snapshotter.go
@@ -205,7 +205,7 @@ func (s *Snapshotter) removeDevice(ctx context.Context, key string) error {
 	}
 
 	deviceName := s.getDeviceName(snapID)
-	if err := s.pool.DeactivateDevice(ctx, deviceName, true); err != nil {
+	if err := s.pool.RemoveDevice(ctx, deviceName); err != nil {
 		log.G(ctx).WithError(err).Errorf("failed to remove device")
 		return err
 	}

--- a/snapshotter/devmapper/snapshotter.go
+++ b/snapshotter/devmapper/snapshotter.go
@@ -205,7 +205,7 @@ func (s *Snapshotter) removeDevice(ctx context.Context, key string) error {
 	}
 
 	deviceName := s.getDeviceName(snapID)
-	if err := s.pool.RemoveDevice(ctx, deviceName, true); err != nil {
+	if err := s.pool.DeactivateDevice(ctx, deviceName, true); err != nil {
 		log.G(ctx).WithError(err).Errorf("failed to remove device")
 		return err
 	}

--- a/snapshotter/pkg/dmsetup/dmsetup.go
+++ b/snapshotter/pkg/dmsetup/dmsetup.go
@@ -162,7 +162,7 @@ func CreateSnapshot(poolName string, deviceID uint32, baseDeviceID uint32) error
 }
 
 // DeleteDevice sends "delete <deviceID>" message to the given thin-pool
-func DeleteDevice(poolName string, deviceID int) error {
+func DeleteDevice(poolName string, deviceID uint32) error {
 	_, err := dmsetup("message", poolName, "0", fmt.Sprintf("delete %d", deviceID))
 	return err
 }

--- a/snapshotter/pkg/losetup/losetup.go
+++ b/snapshotter/pkg/losetup/losetup.go
@@ -22,7 +22,7 @@ import (
 
 // FindAssociatedLoopDevices returns a list of loop devices attached to a given image
 func FindAssociatedLoopDevices(imagePath string) ([]string, error) {
-	output, err := losetup("--list", "--output", "NAME", "--noheadings", "--associated", imagePath)
+	output, err := losetup("--list", "--output", "NAME", "--associated", imagePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get loop devices: '%s'", output)
 	}
@@ -31,7 +31,13 @@ func FindAssociatedLoopDevices(imagePath string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	return strings.Split(output, "\n"), nil
+	items := strings.Split(output, "\n")
+	if len(items) <= 1 {
+		return []string{}, nil
+	}
+
+	// Skip header with column names
+	return items[1:], nil
 }
 
 // AttachLoopDevice finds first available loop device and associates it with an image.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/firecracker-microvm/firecracker-containerd/issues/61

*Description of changes:*
This PR adds device states instead of transactions and reworks device removal. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
