### PR TITLE
Snapshotter test improvements

### DIFF
--- a/internal/testutils.go
+++ b/internal/testutils.go
@@ -1,0 +1,44 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package internal
+
+import (
+	"os"
+	"testing"
+)
+
+const rootDisableEnvName = "DISABLE_ROOT_TESTS"
+
+var rootDisabled bool
+
+func init() {
+	if v := os.Getenv(rootDisableEnvName); len(v) != 0 {
+		rootDisabled = true
+	}
+}
+
+// RequiresRoot will ensure that tests that require root access are actually
+// root. In addition, this will skip root tests if the DISABLE_ROOT_TESTS is
+// set to true
+func RequiresRoot(t testing.TB) {
+	if rootDisabled {
+		t.Skip("skipping test that requires root")
+	}
+
+	if e, a := 0, os.Getuid(); e != a {
+		t.Fatalf("This test must be run as root. To disable tests that "+
+			"require root, run the tests with the %s environment variable set.",
+			rootDisableEnvName)
+	}
+}

--- a/snapshotter/Makefile
+++ b/snapshotter/Makefile
@@ -11,7 +11,11 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# Set this to pass additional commandline flags to the go compiler, e.g. "make test EXTRAGOARGS=-v"
+EXTRAGOARGS:=
+
 SUBDIRS:=cmd/devmapper cmd/naive
+SOURCES:=$(shell find . -name '*.go')
 
 all: $(SUBDIRS)
 
@@ -20,6 +24,9 @@ $(SUBDIRS):
 
 install: $(SUBDIRS)
 	for d in $(SUBDIRS); do $(MAKE) -C $$d install; done
+
+test: $(SOURCES)
+	go test ./... $(EXTRAGOARGS)
 
 clean:
 	for d in $(SUBDIRS); do $(MAKE) -C $$d clean; done

--- a/snapshotter/devmapper/pool_device_test.go
+++ b/snapshotter/devmapper/pool_device_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/docker/go-units"
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,6 +51,7 @@ const (
 // - Mount 'snap-1' and make sure test file is v1
 // - Unmount volumes and remove all devices
 func TestPoolDevice(t *testing.T) {
+	internal.RequiresRoot(t)
 	logrus.SetLevel(logrus.DebugLevel)
 	ctx := context.Background()
 

--- a/snapshotter/devmapper/snapshotter_test.go
+++ b/snapshotter/devmapper/snapshotter_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/testsuite"
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,7 @@ import (
 )
 
 func TestSnapshotterSuite(t *testing.T) {
+	internal.RequiresRoot(t)
 	logrus.SetLevel(logrus.DebugLevel)
 
 	testsuite.SnapshotterSuite(t, "devmapper", func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {

--- a/snapshotter/naive/naive_test.go
+++ b/snapshotter/naive/naive_test.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/testsuite"
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
 )
 
 func TestCreateImage(t *testing.T) {
+	internal.RequiresRoot(t)
 	snap := Snapshotter{}
 
 	tempDir, err := ioutil.TempDir("", "fc-snapshotter")
@@ -64,5 +66,6 @@ func createSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter,
 }
 
 func TestSnapshotterSuite(t *testing.T) {
+	internal.RequiresRoot(t)
 	testsuite.SnapshotterSuite(t, "Snapshotter", createSnapshotter)
 }

--- a/snapshotter/pkg/dmsetup/dmsetup_test.go
+++ b/snapshotter/pkg/dmsetup/dmsetup_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/docker/go-units"
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -35,6 +36,7 @@ const (
 )
 
 func TestDMSetup(t *testing.T) {
+	internal.RequiresRoot(t)
 	tempDir, err := ioutil.TempDir("", "dmsetup-tests-")
 	require.NoErrorf(t, err, "failed to make temp dir for tests")
 

--- a/snapshotter/pkg/losetup/losetup_test.go
+++ b/snapshotter/pkg/losetup/losetup_test.go
@@ -19,11 +19,13 @@ import (
 	"testing"
 
 	"github.com/docker/go-units"
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLosetup(t *testing.T) {
+	internal.RequiresRoot(t)
 	var (
 		imagePath   = createSparseImage(t)
 		loopDevice1 string


### PR DESCRIPTION
*Description of changes:*
* Additional `go test` arguments can be specified with the `EXTRAGOARGS` make variable
* Tests which require root fail-fast instead of panicking, or can be skipped by setting the `DISABLE_ROOT_TESTS` environment variable.

<details>
<summary>fast-fail</summary>

```
$ make test EXTRAGOARGS='-v -count=1'
go test ./... -v -count=1
?   	github.com/firecracker-microvm/firecracker-containerd/snapshotter	[no test files]
?   	github.com/firecracker-microvm/firecracker-containerd/snapshotter/cmd/devmapper	[no test files]
?   	github.com/firecracker-microvm/firecracker-containerd/snapshotter/cmd/naive	[no test files]
=== RUN   TestLoadConfig
--- PASS: TestLoadConfig (0.00s)
=== RUN   TestLoadConfigInvalidPath
--- PASS: TestLoadConfigInvalidPath (0.00s)
=== RUN   TestParseInvalidData
--- PASS: TestParseInvalidData (0.00s)
=== RUN   TestFieldValidation
--- PASS: TestFieldValidation (0.00s)
=== RUN   TestPoolMetadata_AddDevice
--- PASS: TestPoolMetadata_AddDevice (0.02s)
=== RUN   TestPoolMetadata_AddDeviceRollback
--- PASS: TestPoolMetadata_AddDeviceRollback (0.01s)
=== RUN   TestPoolMetadata_AddDeviceDuplicate
--- PASS: TestPoolMetadata_AddDeviceDuplicate (0.01s)
=== RUN   TestPoolMetadata_ReuseDeviceID
--- PASS: TestPoolMetadata_ReuseDeviceID (0.02s)
=== RUN   TestPoolMetadata_RemoveDevice
--- PASS: TestPoolMetadata_RemoveDevice (0.01s)
=== RUN   TestPoolMetadata_UpdateDevice
--- PASS: TestPoolMetadata_UpdateDevice (0.01s)
=== RUN   TestPoolMetadata_GetDeviceNames
--- PASS: TestPoolMetadata_GetDeviceNames (0.01s)
=== RUN   TestPoolDevice
--- FAIL: TestPoolDevice (0.00s)
    testutils.go:40: This test must be run as root. To disable tests that require root, run the tests with the DISABLE_ROOT_TESTS environment variable set.
=== RUN   TestSnapshotterSuite
--- FAIL: TestSnapshotterSuite (0.00s)
    testutils.go:40: This test must be run as root. To disable tests that require root, run the tests with the DISABLE_ROOT_TESTS environment variable set.
FAIL
FAIL	github.com/firecracker-microvm/firecracker-containerd/snapshotter/devmapper	0.098s
=== RUN   TestCreateImage
--- FAIL: TestCreateImage (0.00s)
    testutils.go:40: This test must be run as root. To disable tests that require root, run the tests with the DISABLE_ROOT_TESTS environment variable set.
=== RUN   TestSnapshotterSuite
--- FAIL: TestSnapshotterSuite (0.00s)
    testutils.go:40: This test must be run as root. To disable tests that require root, run the tests with the DISABLE_ROOT_TESTS environment variable set.
FAIL
FAIL	github.com/firecracker-microvm/firecracker-containerd/snapshotter/naive	0.002s
=== RUN   TestDMSetup
--- FAIL: TestDMSetup (0.00s)
    testutils.go:40: This test must be run as root. To disable tests that require root, run the tests with the DISABLE_ROOT_TESTS environment variable set.
FAIL
FAIL	github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/dmsetup	0.008s
=== RUN   TestLosetup
--- FAIL: TestLosetup (0.00s)
    testutils.go:40: This test must be run as root. To disable tests that require root, run the tests with the DISABLE_ROOT_TESTS environment variable set.
FAIL
FAIL	github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/losetup	0.003s
Makefile:29: recipe for target 'test' failed
make: *** [test] Error 1
```
</details>

<details>
<summary>skipping</summary>

```
$ DISABLE_ROOT_TESTS=1 make test EXTRAGOARGS='-v -count=1'
go test ./... -v -count=1
?   	github.com/firecracker-microvm/firecracker-containerd/snapshotter	[no test files]
?   	github.com/firecracker-microvm/firecracker-containerd/snapshotter/cmd/devmapper	[no test files]
?   	github.com/firecracker-microvm/firecracker-containerd/snapshotter/cmd/naive	[no test files]
=== RUN   TestLoadConfig
--- PASS: TestLoadConfig (0.00s)
=== RUN   TestLoadConfigInvalidPath
--- PASS: TestLoadConfigInvalidPath (0.00s)
=== RUN   TestParseInvalidData
--- PASS: TestParseInvalidData (0.00s)
=== RUN   TestFieldValidation
--- PASS: TestFieldValidation (0.00s)
=== RUN   TestPoolMetadata_AddDevice
--- PASS: TestPoolMetadata_AddDevice (0.01s)
=== RUN   TestPoolMetadata_AddDeviceRollback
--- PASS: TestPoolMetadata_AddDeviceRollback (0.01s)
=== RUN   TestPoolMetadata_AddDeviceDuplicate
--- PASS: TestPoolMetadata_AddDeviceDuplicate (0.01s)
=== RUN   TestPoolMetadata_ReuseDeviceID
--- PASS: TestPoolMetadata_ReuseDeviceID (0.01s)
=== RUN   TestPoolMetadata_RemoveDevice
--- PASS: TestPoolMetadata_RemoveDevice (0.01s)
=== RUN   TestPoolMetadata_UpdateDevice
--- PASS: TestPoolMetadata_UpdateDevice (0.01s)
=== RUN   TestPoolMetadata_GetDeviceNames
--- PASS: TestPoolMetadata_GetDeviceNames (0.01s)
=== RUN   TestPoolDevice
--- SKIP: TestPoolDevice (0.00s)
    testutils.go:36: skipping test that requires root
=== RUN   TestSnapshotterSuite
--- SKIP: TestSnapshotterSuite (0.00s)
    testutils.go:36: skipping test that requires root
PASS
ok  	github.com/firecracker-microvm/firecracker-containerd/snapshotter/devmapper	0.085s
=== RUN   TestCreateImage
--- SKIP: TestCreateImage (0.00s)
    testutils.go:36: skipping test that requires root
=== RUN   TestSnapshotterSuite
--- SKIP: TestSnapshotterSuite (0.00s)
    testutils.go:36: skipping test that requires root
PASS
ok  	github.com/firecracker-microvm/firecracker-containerd/snapshotter/naive	0.002s
=== RUN   TestDMSetup
--- SKIP: TestDMSetup (0.00s)
    testutils.go:36: skipping test that requires root
PASS
ok  	github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/dmsetup	0.007s
=== RUN   TestLosetup
--- SKIP: TestLosetup (0.00s)
    testutils.go:36: skipping test that requires root
PASS
ok  	github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/losetup	0.012s
```

</details>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
