### PR TITLE
Snapshotter improvements

### DIFF
--- a/snapshotter/cmd/devmapper/main.go
+++ b/snapshotter/cmd/devmapper/main.go
@@ -110,20 +110,8 @@ func applyStorageOpt(ctx context.Context, key, value string, config *devmapper.C
 
 		config.BaseImageSize = value
 		config.BaseImageSizeBytes = uint64(size)
-	case "dm.metadatadev":
-		config.MetadataDevice = value
-	case "dm.datadev":
-		config.DataDevice = value
 	case "dm.thinpooldev":
 		config.PoolName = strings.TrimPrefix(value, dmsetup.DevMapperDir)
-	case "dm.blocksize":
-		size, err := units.RAMInBytes(value)
-		if err != nil {
-			return err
-		}
-
-		config.DataBlockSize = value
-		config.DataBlockSizeSectors = uint32(size / dmsetup.SectorSize)
 	case "dm.fs":
 		// TODO: Support alternative file systems (https://github.com/firecracker-microvm/firecracker-containerd/issues/44)
 		if value != "ext4" {

--- a/snapshotter/cmd/devmapper/main_test.go
+++ b/snapshotter/cmd/devmapper/main_test.go
@@ -43,9 +43,5 @@ func TestApplyStorageOpt(t *testing.T) {
 
 	assert.Equal(t, "10gb", config.BaseImageSize)
 	assert.EqualValues(t, 10*1024*1024*1024, config.BaseImageSizeBytes)
-	assert.Equal(t, "/meta_dev", config.MetadataDevice)
-	assert.Equal(t, "/data_dev", config.DataDevice)
 	assert.Equal(t, "/pool_dev", config.PoolName)
-	assert.Equal(t, "100mb", config.DataBlockSize)
-	assert.EqualValues(t, 100*1024*1024/512, config.DataBlockSizeSectors)
 }

--- a/snapshotter/devmapper/config.go
+++ b/snapshotter/devmapper/config.go
@@ -22,19 +22,6 @@ import (
 	"github.com/docker/go-units"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-
-	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/dmsetup"
-)
-
-const (
-	// See https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt for details
-	dataBlockMinSize = 128
-	dataBlockMaxSize = 2097152
-)
-
-var (
-	errInvalidBlockSize      = errors.Errorf("block size should be between %d and %d", dataBlockMinSize, dataBlockMaxSize)
-	errInvalidBlockAlignment = errors.Errorf("block size should be multiple of %d sectors", dataBlockMinSize)
 )
 
 // Config represents device mapper configuration loaded from file.
@@ -45,19 +32,6 @@ type Config struct {
 
 	// Name for 'thin-pool' device to be used by snapshotter (without /dev/mapper/ prefix)
 	PoolName string `json:"pool_name"`
-
-	// Path to data volume to be used by thin-pool
-	DataDevice string `json:"data_device"`
-
-	// Path to metadata volume to be used by thin-pool
-	MetadataDevice string `json:"meta_device"`
-
-	// The size of allocation chunks in data file.
-	// Must be between 128 sectors (64KB) and 2097152 sectors (1GB) and a multiple of 128 sectors (64KB)
-	// Block size can't be changed after pool created.
-	// See https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
-	DataBlockSize        string `json:"data_block_size"`
-	DataBlockSizeSectors uint32 `json:"-"`
 
 	// Defines how much space to allocate when creating base image for container
 	BaseImageSize      string `json:"base_image_size"`
@@ -96,23 +70,13 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 func (c *Config) parse() error {
-	var result *multierror.Error
-
-	if c.DataBlockSize != "" {
-		if blockSize, err := units.RAMInBytes(c.DataBlockSize); err != nil {
-			result = multierror.Append(result, errors.Wrapf(err, "failed to parse data block size: %q", c.DataBlockSize))
-		} else {
-			c.DataBlockSizeSectors = uint32(blockSize / dmsetup.SectorSize)
-		}
+	baseImageSize, err := units.RAMInBytes(c.BaseImageSize)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse base image size: '%s'", c.BaseImageSize)
 	}
 
-	if baseImageSize, err := units.RAMInBytes(c.BaseImageSize); err != nil {
-		result = multierror.Append(result, errors.Wrapf(err, "failed to parse base image size: %q", c.BaseImageSize))
-	} else {
-		c.BaseImageSizeBytes = uint64(baseImageSize)
-	}
-
-	return result.ErrorOrNil()
+	c.BaseImageSizeBytes = uint64(baseImageSize)
+	return nil
 }
 
 // Validate makes sure configuration fields are valid
@@ -129,33 +93,6 @@ func (c *Config) Validate() error {
 
 	if c.BaseImageSize == "" {
 		result = multierror.Append(result, fmt.Errorf("base_image_size is required"))
-	}
-
-	// The following fields are required only if we want to create or reload pool.
-	// Otherwise existing pool with 'PoolName' (prepared in advance) can be used by snapshotter.
-	if c.DataDevice != "" || c.MetadataDevice != "" || c.DataBlockSize != "" || c.DataBlockSizeSectors != 0 {
-		strChecks := []struct {
-			field string
-			name  string
-		}{
-			{c.DataDevice, "data_device"},
-			{c.MetadataDevice, "meta_device"},
-			{c.DataBlockSize, "data_block_size"},
-		}
-
-		for _, check := range strChecks {
-			if check.field == "" {
-				result = multierror.Append(result, errors.Errorf("%s is empty", check.name))
-			}
-		}
-
-		if c.DataBlockSizeSectors < dataBlockMinSize || c.DataBlockSizeSectors > dataBlockMaxSize {
-			result = multierror.Append(result, errInvalidBlockSize)
-		}
-
-		if c.DataBlockSizeSectors%dataBlockMinSize != 0 {
-			result = multierror.Append(result, errInvalidBlockAlignment)
-		}
 	}
 
 	return result.ErrorOrNil()

--- a/snapshotter/devmapper/pool_device.go
+++ b/snapshotter/devmapper/pool_device.go
@@ -15,7 +15,6 @@ package devmapper
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/containerd/containerd/log"
@@ -50,58 +49,16 @@ func NewPoolDevice(ctx context.Context, config *Config) (*PoolDevice, error) {
 		return nil, err
 	}
 
-	if err := openPool(ctx, config); err != nil {
-		return nil, err
+	// Make sure pool exists and available
+	poolPath := dmsetup.GetFullDevicePath(config.PoolName)
+	if _, err := dmsetup.Info(poolPath); err != nil {
+		return nil, errors.Wrapf(err, "failed to query pool %q", poolPath)
 	}
 
 	return &PoolDevice{
 		poolName: config.PoolName,
 		metadata: poolMetaStore,
 	}, nil
-}
-
-func openPool(ctx context.Context, config *Config) error {
-	if err := config.Validate(); err != nil {
-		return err
-	}
-
-	var (
-		poolPath   = dmsetup.GetFullDevicePath(config.PoolName)
-		poolExists = false
-	)
-
-	if _, err := os.Stat(poolPath); err != nil && !os.IsNotExist(err) {
-		return errors.Wrapf(err, "failed to stat for %q", poolPath)
-	} else if err == nil {
-		poolExists = true
-	}
-
-	// Create new pool if not exists
-	if !poolExists {
-		log.G(ctx).Debug("creating new pool device")
-		if err := dmsetup.CreatePool(config.PoolName, config.DataDevice, config.MetadataDevice, config.DataBlockSizeSectors); err != nil {
-			return errors.Wrapf(err, "failed to create thin-pool with name %q", config.PoolName)
-		}
-
-		return nil
-	}
-
-	// Pool exists, check if it needs to be reloaded
-	if config.DataDevice != "" && config.MetadataDevice != "" {
-		log.G(ctx).Debugf("reloading existing pool %q", poolPath)
-		if err := dmsetup.ReloadPool(config.PoolName, config.DataDevice, config.MetadataDevice, config.DataBlockSizeSectors); err != nil {
-			return errors.Wrapf(err, "failed to reload pool %q", config.PoolName)
-		}
-
-		return nil
-	}
-
-	// If data and meta devices are not provided, use existing pool. Query info to make sure it's OK.
-	if _, err := dmsetup.Info(poolPath); err != nil {
-		return errors.Wrapf(err, "failed to query info for existing pool %q", poolPath)
-	}
-
-	return nil
 }
 
 // transition invokes 'updateStateFn' callback to perform devmapper operation and reflects device state changes/errors in meta store.

--- a/snapshotter/devmapper/pool_device_test.go
+++ b/snapshotter/devmapper/pool_device_test.go
@@ -15,11 +15,13 @@ package devmapper
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
@@ -61,6 +63,10 @@ func TestPoolDevice(t *testing.T) {
 	_, loopDataDevice := createLoopbackDevice(t, tempDir)
 	_, loopMetaDevice := createLoopbackDevice(t, tempDir)
 
+	poolName := fmt.Sprintf("test-pool-device-%d", time.Now().Nanosecond())
+	err = dmsetup.CreatePool(poolName, loopDataDevice, loopMetaDevice, 64*1024/dmsetup.SectorSize)
+	require.NoErrorf(t, err, "failed to create pool %q", poolName)
+
 	defer func() {
 		// Detach loop devices and remove images
 		err := losetup.DetachLoopDevice(loopDataDevice, loopMetaDevice)
@@ -71,14 +77,10 @@ func TestPoolDevice(t *testing.T) {
 	}()
 
 	config := &Config{
-		PoolName:             "test-pool-device-1",
-		RootPath:             tempDir,
-		DataDevice:           loopDataDevice,
-		MetadataDevice:       loopMetaDevice,
-		DataBlockSize:        "65536",
-		DataBlockSizeSectors: 128,
-		BaseImageSize:        "16mb",
-		BaseImageSizeBytes:   16 * 1024 * 1024,
+		PoolName:           poolName,
+		RootPath:           tempDir,
+		BaseImageSize:      "16mb",
+		BaseImageSizeBytes: 16 * 1024 * 1024,
 	}
 
 	pool, err := NewPoolDevice(ctx, config)

--- a/snapshotter/devmapper/pool_device_test.go
+++ b/snapshotter/devmapper/pool_device_test.go
@@ -187,12 +187,13 @@ func testDeactivateThinDevice(t *testing.T, pool *PoolDevice) {
 	}
 
 	for _, deviceName := range deviceList {
+		assert.True(t, pool.IsActivated(deviceName))
+
 		err := pool.DeactivateDevice(context.Background(), deviceName, false)
 		assert.NoErrorf(t, err, "failed to remove '%s'", deviceName)
-	}
 
-	err := pool.DeactivateDevice(context.Background(), "not-existing-device", false)
-	assert.Error(t, err, "should return an error if trying to remove not existing device")
+		assert.False(t, pool.IsActivated(deviceName))
+	}
 }
 
 func testRemoveThinDevice(t *testing.T, pool *PoolDevice) {

--- a/snapshotter/devmapper/pool_device_test.go
+++ b/snapshotter/devmapper/pool_device_test.go
@@ -22,11 +22,11 @@ import (
 	"testing"
 
 	"github.com/docker/go-units"
-	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/dmsetup"
 	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/losetup"
 )

--- a/snapshotter/devmapper/snapshotter.go
+++ b/snapshotter/devmapper/snapshotter.go
@@ -275,7 +275,9 @@ func (s *Snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		}
 
 		if err := s.mkfs(ctx, deviceName); err != nil {
-			return nil, err
+			// Rollback thin device creation if mkfs failed
+			return nil, multierror.Append(err,
+				s.pool.RemoveDevice(ctx, deviceName))
 		}
 	} else {
 		parentDeviceName := s.getDeviceName(snap.ParentIDs[0])

--- a/snapshotter/devmapper/snapshotter_test.go
+++ b/snapshotter/devmapper/snapshotter_test.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/testsuite"
-	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/dmsetup"
 	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/losetup"
 )

--- a/snapshotter/devmapper/snapshotter_test.go
+++ b/snapshotter/devmapper/snapshotter_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/testsuite"
+	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/firecracker-microvm/firecracker-containerd/internal"
@@ -54,22 +54,24 @@ func TestSnapshotterSuite(t *testing.T) {
 			return nil, nil, err
 		}
 
-		// Remove device mapper pool after test completes
+		// Remove device mapper pool and detach loop devices after test completes
 		removePool := func() error {
-			return snap.pool.RemovePool(ctx)
+			var result *multierror.Error
+
+			if err := snap.pool.RemovePool(ctx); err != nil {
+				result = multierror.Append(result, err)
+			}
+
+			if err := losetup.DetachLoopDevice(loopDataDevice, loopMetaDevice); err != nil {
+				result = multierror.Append(result, err)
+			}
+
+			return result.ErrorOrNil()
 		}
 
 		// Pool cleanup should be called before closing metadata store (as we need to retrieve device names)
 		snap.cleanupFn = append([]closeFunc{removePool}, snap.cleanupFn...)
 
-		return snap, func() error {
-			err := snap.Close()
-			assert.NoErrorf(t, err, "failed to close snapshotter")
-
-			err = losetup.DetachLoopDevice(loopDataDevice, loopMetaDevice)
-			assert.NoErrorf(t, err, "failed to detach loop devices")
-
-			return err
-		}, nil
+		return snap, snap.Close, nil
 	})
 }

--- a/snapshotter/devmapper/snapshotter_test.go
+++ b/snapshotter/devmapper/snapshotter_test.go
@@ -56,15 +56,9 @@ func TestSnapshotterSuite(t *testing.T) {
 
 		// Remove device mapper pool and detach loop devices after test completes
 		removePool := func() error {
-			var result *multierror.Error
-
-			if err := snap.pool.RemovePool(ctx); err != nil {
-				result = multierror.Append(result, err)
-			}
-
-			if err := losetup.DetachLoopDevice(loopDataDevice, loopMetaDevice); err != nil {
-				result = multierror.Append(result, err)
-			}
+			result := multierror.Append(
+				snap.pool.RemovePool(ctx),
+				losetup.DetachLoopDevice(loopDataDevice, loopMetaDevice))
 
 			return result.ErrorOrNil()
 		}


### PR DESCRIPTION
*Description of changes:*
Address a few issues I got in `containerd` [PR](https://github.com/containerd/containerd/pull/3022) review:
- Resume base thin-device when snapshot creation failed
- Better check whether thin-device is active (all thin devices gets deactivated on reboot, so we can't rely on metadata)
- Snapshotter no longer creates or reloads thin-pool, just opens it or fails.
- Rollback thin device on error (#107)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

/cc @sipsma
