### PR TITLE
log task create options protobuf unmarshalling error.

### DIFF
--- a/runtime/service.go
+++ b/runtime/service.go
@@ -175,6 +175,11 @@ func (s *service) Create(ctx context.Context, request *taskAPI.CreateTaskRequest
 	if request.Options != nil {
 		firecrackerConfig, runcOpts, err = parseCreateTaskOpts(ctx, request.Options)
 		if err != nil {
+			log.G(ctx).WithFields(logrus.Fields{
+				"id":      request.ID,
+				"options": request.Options,
+				"error":   err,
+			}).Error("failed to unmarshal task create request options")
 			return nil, errors.Wrapf(err, "unmarshaling task create request options")
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added an error log when the task create request's options field cannot
be unmarshalled.

*Testing done:* `make clean && make STATIC_AGENT='true' && make examples && make lint` succeeds.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
