### PR TITLE
update to firecracker-go-sdk v0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/docker/go-events v0.0.0-20170721190031-9461782956ad // indirect
 	github.com/docker/go-units v0.3.3
-	github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190219211450-78fe329f36bd
+	github.com/firecracker-microvm/firecracker-go-sdk v0.15.0
 	github.com/godbus/dbus v0.0.0-20181025153459-66d97aec3384 // indirect
 	github.com/gogo/googleapis v1.1.0 // indirect
 	github.com/gogo/protobuf v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190111234345-e4d80c16
 github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190111234345-e4d80c16bbb3/go.mod h1:UOsA6IaI52MQntB9PrarJFReY1nA9iZg2DI04kxPNMY=
 github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190219211450-78fe329f36bd h1:V3QbB4QSxJqMpezOWJVJ+65+FK8yTYOzz2s/jcOLWWg=
 github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190219211450-78fe329f36bd/go.mod h1:UOsA6IaI52MQntB9PrarJFReY1nA9iZg2DI04kxPNMY=
+github.com/firecracker-microvm/firecracker-go-sdk v0.15.0 h1:KKbgkZFjtrvMfrv2XyxJW+YQAe2cHHsSTFSi6VTRzuE=
+github.com/firecracker-microvm/firecracker-go-sdk v0.15.0/go.mod h1:UOsA6IaI52MQntB9PrarJFReY1nA9iZg2DI04kxPNMY=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb h1:D4uzjWwKYQ5XnAvUbuvHW93esHg7F8N/OYeBBcJoTr0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/firecracker-microvm/firecracker-containerd/issues/121

*Description of changes:*
Updating the SDK is sufficient to work with Firecracker v0.15.0, though the quickstart guide no longer works and the getting started guide also needs to be updated; Firecracker's built-in seccomp enforcement is unhappy with glibc and needs to be built with musl libc.

I can either do the guide updates as part of this same PR or as a separate one; let me know which is preferred.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
