### PR TITLE
Add note about DM_DISABLE_UDEV to README.

### DIFF
--- a/snapshotter/README.md
+++ b/snapshotter/README.md
@@ -1,3 +1,12 @@
+## Requirements
+
+### Running
+Due to its dependency on `dmsetup`, executing the snapshotter process in an environment where a udev
+daemon is not accessible (such as a container) may result in unexpected behavior. In this case, try executing the
+snapshotter with the `DM_DISABLE_UDEV=1` environment variable, which tells `dmsetup` to ignore udev and manage devices
+itself. See [lvm(8)](http://man7.org/linux/man-pages/man8/lvm.8.html) and
+[dmsetup(8)](http://man7.org/linux/man-pages/man8/dmsetup.8.html) for more information.
+
 ## How to run snapshotters benchmark
 
 - `firecracker-containerd` project contains CloudFormation template to run an EC2 instance suitable for benchmarking.


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <sipsma@amazon.com>

When working on running our tests in a container, I encountered a bunch of strange race-conditions related to device node creation during the snapshotter tests. This turned out to be due to the udev daemon not being accessible inside the container even though I was bind-mounting /dev from the host to the container.

Another possible fix to this issue would be to change our snapshotter code to use the `--verifyudev` flag for all dmsetup operations. However, it turns out there is an environment variable `DM_DISABLE_UDEV` (documented on the lvm(8) man-page only, not dmsetup(8) man-page for some reason), that appears to be a catch-all for making dmsetup and other tools under the lvm umbrella behave well in an environment where udev is not accessible.

Given the flexibility of environment variables relative to hardcoding flags in our code, just documenting this behavior feels like the best fix, so this PR is just a README update.

I tested this by running the tests in a docker container (`docker run --rm -it --privileged -v /local/container-tmp:/tmp firecracker-containerd`) where I started the snapshotter inside with `DM_DISABLE_UDEV=1` and saw the tests pass consistently:
```
ok      github.com/firecracker-microvm/firecracker-containerd/snapshotter       0.008s [no tests to run]
ok      github.com/firecracker-microvm/firecracker-containerd/snapshotter/cmd/devmapper 0.008s
?       github.com/firecracker-microvm/firecracker-containerd/snapshotter/cmd/naive     [no test files]
ok      github.com/firecracker-microvm/firecracker-containerd/snapshotter/devmapper     72.819s
ok      github.com/firecracker-microvm/firecracker-containerd/snapshotter/naive 300.045s
ok      github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/dmsetup   33.658s
ok      github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/losetup   36.016s
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
