### PR TITLE
runtime: hard-code Firecracker API socket path

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -212,10 +212,6 @@ configuration file has the following fields:
   `firecracker` located in its working directory.  A fully-qualified path to the
   `firecracker` binary is recommended, as the working directory typically
   changes every execution when run by containerd.
-* `socket_path` (required) - A path where a socket file should be created for
-  communicating with the Firecracker API.  A relative path like
-  `./firecracker.sock` is recommended so that the socket is created in the
-  temporary working directory allocated by containerd.
 * `kernel_image_path` (required) - A path where the kernel image file is
   located.  A fully-qualified path is recommended.
 * `kernel_args` (required) - Arguments for the kernel command line.
@@ -241,7 +237,6 @@ configuration file has the following fields:
 ```json
 {
   "firecracker_binary_path": "/usr/local/bin/firecracker",
-  "socket_path": "./firecracker.sock",
   "kernel_image_path": "/var/lib/firecracker-containerd/runtime/hello-vmlinux.bin",
   "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw",
   "root_drive": "/var/lib/firecracker-containerd/runtime/hello-rootfs.ext4",

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -138,7 +138,6 @@ sudo mkdir -p /etc/containerd
 sudo tee -a /etc/containerd/firecracker-runtime.json <<EOF
 {
   "firecracker_binary_path": "/usr/local/bin/firecracker",
-  "socket_path": "./firecracker.sock",
   "kernel_image_path": "/var/lib/firecracker-containerd/runtime/hello-vmlinux.bin",
   "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw",
   "root_drive": "/var/lib/firecracker-containerd/runtime/hello-rootfs.ext4",

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -38,10 +38,6 @@ configuration file has the following fields:
   `firecracker` located in its working directory.  A fully-qualified path to the
   `firecracker` binary is recommended, as the working directory typically
   changes every execution when run by containerd.
-* `socket_path` (required) - A path where a socket file should be created for
-  communicating with the Firecracker API.  A relative path like
-  `./firecracker.sock` is recommended so that the socket is created in the
-  temporary working directory allocated by containerd.
 * `kernel_image_path` (required) - A path where the kernel image file is
   located.  A fully-qualified path is recommended.
 * `kernel_args` (required) - Arguments for the kernel command line.

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -24,12 +24,12 @@ import (
 const (
 	configPathEnvName = "FIRECRACKER_CONTAINERD_RUNTIME_CONFIG_PATH"
 	defaultConfigPath = "/etc/containerd/firecracker-runtime.json"
+	defaultSocketPath = "./firecracker.sock"
 )
 
 // Config represents runtime configuration parameters
 type Config struct {
 	FirecrackerBinaryPath string            `json:"firecracker_binary_path"`
-	SocketPath            string            `json:"socket_path"`
 	KernelImagePath       string            `json:"kernel_image_path"`
 	KernelArgs            string            `json:"kernel_args"`
 	RootDrive             string            `json:"root_drive"`

--- a/runtime/config.json.example
+++ b/runtime/config.json.example
@@ -1,6 +1,5 @@
 {
   "firecracker_binary_path": "./firecracker",
-  "socket_path": "./firecracker.sock",
   "kernel_image_path": "vmlinux",
   "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw",
   "root_drive": "./vsock.img",

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -637,7 +637,7 @@ func (s *service) startVM(ctx context.Context,
 	}
 
 	cfg := firecracker.Config{
-		SocketPath:      s.config.SocketPath,
+		SocketPath:      defaultSocketPath,
 		VsockDevices:    []firecracker.VsockDevice{{Path: "root", CID: cid}},
 		KernelImagePath: s.config.KernelImagePath,
 		KernelArgs:      s.config.KernelArgs,
@@ -673,7 +673,7 @@ func (s *service) startVM(ctx context.Context,
 	cfg.Drives = driveBuilder.Build()
 	cmd := firecracker.VMCommandBuilder{}.
 		WithBin(s.config.FirecrackerBinaryPath).
-		WithSocketPath(s.config.SocketPath).
+		WithSocketPath(defaultSocketPath).
 		Build(ctx)
 	machineOpts := []firecracker.Opt{
 		firecracker.WithProcessRunner(cmd),


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/firecracker-microvm/firecracker-containerd/issues/59

*Description of changes:*
The Firecracker API socket is important for the runtime, as it uses the socket to communicate with Firecracker.  Allowing the runtime to fully control the API socket (including its path) removes a potential failure condition from misconfiguration.

The API socket is hard-coded to exist within the current working directory.  Part of the contract that containerd exposes for runtimes is that they are started with the current working directory changed to be that of the OCI bundle.  Using an API socket in the OCI bundle makes its location well-known and predictable to the runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
