### PR TITLE
runtime: remove "console" field from documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -223,9 +223,6 @@ configuration file has the following fields:
 * `cpu_template` (required) - The Firecracker CPU emulation template.  Supported
   values are "C3" and "T2".
 * `additional_drives` (unused)
-* `console` (optional) - How the console device should be handled.  Supported
-  values are "" (blank), "stdio", and "xterm".  Setting "xterm" will launch a
-  new xterm instance and requires a running X server.
 * `log_fifo` (optional) - Named pipe where Firecracker logs should be delivered.
 * `log_level` (optional) - Log level for the Firecracker logs
 * `metrics_fifo` (optional) - Named pipe where Firecracker metrics should be
@@ -244,7 +241,6 @@ configuration file has the following fields:
   "root_drive": "/var/lib/firecracker-containerd/runtime/hello-rootfs.ext4",
   "cpu_count": 1,
   "cpu_template": "T2",
-  "console": "stdio",
   "log_fifo": "/tmp/fc-logs.fifo",
   "log_level": "Debug",
   "metrics_fifo": "/tmp/fc-metrics.fifo"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -142,7 +142,6 @@ sudo tee -a /etc/containerd/firecracker-runtime.json <<EOF
   "root_drive": "/var/lib/firecracker-containerd/runtime/hello-rootfs.ext4",
   "cpu_count": 1,
   "cpu_template": "T2",
-  "console": "stdio",
   "log_fifo": "/tmp/fc-logs.fifo",
   "log_level": "Debug",
   "metrics_fifo": "/tmp/fc-metrics.fifo"

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -49,9 +49,6 @@ configuration file has the following fields:
 * `cpu_template` (required) - The Firecracker CPU emulation template.  Supported
   values are "C3" and "T2".
 * `additional_drives` (unused)
-* `console` (optional) - How the console device should be handled.  Supported
-  values are "" (blank), "stdio", and "xterm".  Setting "xterm" will launch a
-  new xterm instance and requires a running X server.
 * `log_fifo` (optional) - Named pipe where Firecracker logs should be delivered.
 * `log_level` (optional) - Log level for the Firecracker logs
 * `metrics_fifo` (optional) - Named pipe where Firecracker metrics should be

--- a/runtime/config.json.example
+++ b/runtime/config.json.example
@@ -8,7 +8,6 @@
   "additional_drives": {
     "./shim.img": "rw"
   },
-  "console": "stdio",
   "log_fifo": "/tmp/fc-logs.fifo",
   "log_level": "Debug",
   "metrics_fifo": "/tmp/fc-metrics.fifo",

--- a/tools/docker/firecracker-runtime.json
+++ b/tools/docker/firecracker-runtime.json
@@ -5,7 +5,6 @@
   "root_drive": "/var/lib/firecracker-containerd/runtime/hello-rootfs.ext4",
   "cpu_count": 1,
   "cpu_template": "T2",
-  "console": "stdio",
   "log_fifo": "/tmp/fc-logs.fifo",
   "log_level": "Debug",
   "metrics_fifo": "/tmp/fc-metrics.fifo"


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/firecracker-microvm/firecracker-containerd/issues/59

*Description of changes:*

The console field was already removed, but stale documentation continued to reference it.  This commit removes the stale documentation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
