### PR TITLE
lint: limit git-validation to 20 commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ deps:
 
 lint:
 	ltag -t ./.headers -check -v
-	git-validation -run DCO,dangling-whitespace,short-subject -range dd78e4f0182dfff8ef33e5eb7dc925d5f6e84301..HEAD
+	git-validation -run DCO,dangling-whitespace,short-subject -range HEAD~20..HEAD
 	golangci-lint run
 
 install:


### PR DESCRIPTION
Travis (which runs this target) performs a shallow clone of the git repository at 50 commits.  Previously, a static commit SHA was specified, which has now become more than 50 commits in the past. This commit changes the git-validation line such that we only validate the most recent 20 commits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
