### PR TITLE
runtime: defaults for kernel and rootfs paths

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -212,13 +212,16 @@ configuration file has the following fields:
   `firecracker` located in its working directory.  A fully-qualified path to the
   `firecracker` binary is recommended, as the working directory typically
   changes every execution when run by containerd.
-* `kernel_image_path` (required) - A path where the kernel image file is
-  located.  A fully-qualified path is recommended.
+* `kernel_image_path` (optional) - A path where the kernel image file is
+  located.  A fully-qualified path is recommended.  If left undefined, the
+  runtime looks for a file named
+  `/var/lib/firecracker-containerd/runtime/default-vmlinux.bin`.
 * `kernel_args` (optional) - Arguments for the kernel command line.  If left
   undefined, the runtime specifies "console=ttyS0 noapic reboot=k panic=1
   pci=off nomodules rw".
-* `root_drive` (required) - A path where the root drive image file is located. A
-  fully-qualified path is recommended.
+* `root_drive` (optional) - A path where the root drive image file is located. A
+  fully-qualified path is recommended.  If left undefined, the runtime looks for
+  a file named `/var/lib/firecracker-containerd/runtime/default-rootfs.img`.
 * `cpu_count` (required) - The number of vCPUs to make available to a microVM.
 * `cpu_template` (required) - The Firecracker CPU emulation template.  Supported
   values are "C3" and "T2".

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -133,13 +133,12 @@ cd ~
 
 # Configure the aws.firecracker runtime
 sudo mkdir -p /var/lib/firecracker-containerd/runtime
-sudo cp hello-rootfs.ext4 hello-vmlinux.bin /var/lib/firecracker-containerd/runtime
+sudo cp hello-rootfs.ext4 /var/lib/firecracker-containerd/runtime/default-rootfs.img
+sudo cp hello-vmlinux.bin /var/lib/firecracker-containerd/runtime/default-vmlinux.bin
 sudo mkdir -p /etc/containerd
 sudo tee -a /etc/containerd/firecracker-runtime.json <<EOF
 {
   "firecracker_binary_path": "/usr/local/bin/firecracker",
-  "kernel_image_path": "/var/lib/firecracker-containerd/runtime/hello-vmlinux.bin",
-  "root_drive": "/var/lib/firecracker-containerd/runtime/hello-rootfs.ext4",
   "cpu_count": 1,
   "cpu_template": "T2",
   "log_fifo": "/tmp/fc-logs.fifo",

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -38,13 +38,16 @@ configuration file has the following fields:
   `firecracker` located in its working directory.  A fully-qualified path to the
   `firecracker` binary is recommended, as the working directory typically
   changes every execution when run by containerd.
-* `kernel_image_path` (required) - A path where the kernel image file is
-  located.  A fully-qualified path is recommended.
+* `kernel_image_path` (optional) - A path where the kernel image file is
+  located.  A fully-qualified path is recommended.  If left undefined, the
+  runtime looks for a file named
+  `/var/lib/firecracker-containerd/runtime/default-vmlinux.bin`.
 * `kernel_args` (optional) - Arguments for the kernel command line.  If left
   undefined, the runtime specifies "console=ttyS0 noapic reboot=k panic=1
   pci=off nomodules rw".
-* `root_drive` (required) - A path where the root drive image file is located. A
-  fully-qualified path is recommended.
+* `root_drive` (optional) - A path where the root drive image file is located. A
+  fully-qualified path is recommended.  If left undefined, the runtime looks for
+  a file named `/var/lib/firecracker-containerd/runtime/default-rootfs.img`.
 * `cpu_count` (required) - The number of vCPUs to make available to a microVM.
 * `cpu_template` (required) - The Firecracker CPU emulation template.  Supported
   values are "C3" and "T2".

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -26,6 +26,9 @@ const (
 	defaultConfigPath = "/etc/containerd/firecracker-runtime.json"
 	defaultSocketPath = "./firecracker.sock"
 	defaultKernelArgs = "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw"
+	defaultFilesPath  = "/var/lib/firecracker-containerd/runtime/"
+	defaultKernelPath = defaultFilesPath + "default-vmlinux.bin"
+	defaultRootfsPath = defaultFilesPath + "default-rootfs.img"
 )
 
 // Config represents runtime configuration parameters
@@ -60,7 +63,9 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	cfg := &Config{
-		KernelArgs: defaultKernelArgs,
+		KernelArgs:      defaultKernelArgs,
+		KernelImagePath: defaultKernelPath,
+		RootDrive:       defaultRootfsPath,
 	}
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal config from %q", path)

--- a/runtime/config_test.go
+++ b/runtime/config_test.go
@@ -27,24 +27,31 @@ func TestLoadConfigDefaults(t *testing.T) {
 	configFile, cleanup := createTempConfig(t, configContent)
 	defer cleanup()
 	cfg, err := LoadConfig(configFile)
-	if err != nil {
-		t.Error(err, "failed to load config")
-	}
+	assert.NoError(t, err, "failed to load config")
 
-	assert.Equal(t, cfg.KernelArgs, defaultKernelArgs, "expected default kernel args")
+	assert.Equal(t, defaultKernelArgs, cfg.KernelArgs, "expected default kernel args")
+	assert.Equal(t, defaultKernelPath, cfg.KernelImagePath, "expected default kernel path")
+	assert.Equal(t, defaultRootfsPath, cfg.RootDrive, "expected default rootfs path")
 }
 
 func TestLoadConfigOverrides(t *testing.T) {
 	overrideKernelArgs := "OVERRIDE KERNEL ARGS"
-	configContent := fmt.Sprintf(`{"kernel_args":"%s"}`, overrideKernelArgs)
+	overrideKernelPath := "OVERRIDE KERNEL PATH"
+	overrideRootfsPath := "OVERRIDE ROOTFS PATH"
+	configContent := fmt.Sprintf(
+		`{
+			"kernel_args":"%s",
+			"kernel_image_path":"%s",
+			"root_drive":"%s"
+		}`, overrideKernelArgs, overrideKernelPath, overrideRootfsPath)
 	configFile, cleanup := createTempConfig(t, configContent)
 	defer cleanup()
 	cfg, err := LoadConfig(configFile)
-	if err != nil {
-		t.Error(err, "failed to load config")
-	}
+	assert.NoError(t, err, "failed to load config")
 
-	assert.Equal(t, cfg.KernelArgs, overrideKernelArgs, "expected overridden kernel args")
+	assert.Equal(t, overrideKernelArgs, cfg.KernelArgs, "expected overridden kernel args")
+	assert.Equal(t, overrideKernelPath, cfg.KernelImagePath, "expected overridden kernel path")
+	assert.Equal(t, overrideRootfsPath, cfg.RootDrive, "expected overridden rootfs path")
 }
 
 func createTempConfig(t *testing.T, contents string) (string, func()) {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/firecracker-microvm/firecracker-containerd/issues/59

*Description of changes:*

Sets some default file paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
