### PR TITLE
runtime: default CPU count is 1

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -222,7 +222,8 @@ configuration file has the following fields:
 * `root_drive` (optional) - A path where the root drive image file is located. A
   fully-qualified path is recommended.  If left undefined, the runtime looks for
   a file named `/var/lib/firecracker-containerd/runtime/default-rootfs.img`.
-* `cpu_count` (required) - The number of vCPUs to make available to a microVM.
+* `cpu_count` (optional) - The number of vCPUs to make available to a microVM.
+  If left undefined, the default is 1.
 * `cpu_template` (required) - The Firecracker CPU emulation template.  Supported
   values are "C3" and "T2".
 * `additional_drives` (unused)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -139,7 +139,6 @@ sudo mkdir -p /etc/containerd
 sudo tee -a /etc/containerd/firecracker-runtime.json <<EOF
 {
   "firecracker_binary_path": "/usr/local/bin/firecracker",
-  "cpu_count": 1,
   "cpu_template": "T2",
   "log_fifo": "/tmp/fc-logs.fifo",
   "log_level": "Debug",

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -48,7 +48,8 @@ configuration file has the following fields:
 * `root_drive` (optional) - A path where the root drive image file is located. A
   fully-qualified path is recommended.  If left undefined, the runtime looks for
   a file named `/var/lib/firecracker-containerd/runtime/default-rootfs.img`.
-* `cpu_count` (required) - The number of vCPUs to make available to a microVM.
+* `cpu_count` (optional) - The number of vCPUs to make available to a microVM.
+  If left undefined, the default is 1.
 * `cpu_template` (required) - The Firecracker CPU emulation template.  Supported
   values are "C3" and "T2".
 * `additional_drives` (unused)

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -29,6 +29,7 @@ const (
 	defaultFilesPath  = "/var/lib/firecracker-containerd/runtime/"
 	defaultKernelPath = defaultFilesPath + "default-vmlinux.bin"
 	defaultRootfsPath = defaultFilesPath + "default-rootfs.img"
+	defaultCPUCount   = 1
 )
 
 // Config represents runtime configuration parameters
@@ -66,6 +67,7 @@ func LoadConfig(path string) (*Config, error) {
 		KernelArgs:      defaultKernelArgs,
 		KernelImagePath: defaultKernelPath,
 		RootDrive:       defaultRootfsPath,
+		CPUCount:        defaultCPUCount,
 	}
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal config from %q", path)

--- a/runtime/config_test.go
+++ b/runtime/config_test.go
@@ -32,18 +32,21 @@ func TestLoadConfigDefaults(t *testing.T) {
 	assert.Equal(t, defaultKernelArgs, cfg.KernelArgs, "expected default kernel args")
 	assert.Equal(t, defaultKernelPath, cfg.KernelImagePath, "expected default kernel path")
 	assert.Equal(t, defaultRootfsPath, cfg.RootDrive, "expected default rootfs path")
+	assert.Equal(t, defaultCPUCount, cfg.CPUCount, "expected default CPU count")
 }
 
 func TestLoadConfigOverrides(t *testing.T) {
 	overrideKernelArgs := "OVERRIDE KERNEL ARGS"
 	overrideKernelPath := "OVERRIDE KERNEL PATH"
 	overrideRootfsPath := "OVERRIDE ROOTFS PATH"
+	overrideCPUCount := 42
 	configContent := fmt.Sprintf(
 		`{
 			"kernel_args":"%s",
 			"kernel_image_path":"%s",
-			"root_drive":"%s"
-		}`, overrideKernelArgs, overrideKernelPath, overrideRootfsPath)
+			"root_drive":"%s",
+			"cpu_count": %d
+		}`, overrideKernelArgs, overrideKernelPath, overrideRootfsPath, overrideCPUCount)
 	configFile, cleanup := createTempConfig(t, configContent)
 	defer cleanup()
 	cfg, err := LoadConfig(configFile)
@@ -52,6 +55,7 @@ func TestLoadConfigOverrides(t *testing.T) {
 	assert.Equal(t, overrideKernelArgs, cfg.KernelArgs, "expected overridden kernel args")
 	assert.Equal(t, overrideKernelPath, cfg.KernelImagePath, "expected overridden kernel path")
 	assert.Equal(t, overrideRootfsPath, cfg.RootDrive, "expected overridden rootfs path")
+	assert.Equal(t, overrideCPUCount, cfg.CPUCount, "expected overridden cpu count")
 }
 
 func createTempConfig(t *testing.T, contents string) (string, func()) {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/firecracker-microvm/firecracker-containerd/issues/59

*Description of changes:*

Specify default CPU count as 1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
