### PR TITLE
Add an image-builder component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 bin/
+*stamp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "runc"]
+	path = _submodules/runc
+	url = https://github.com/opencontainers/runc

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ DOCKER_IMAGE_TAG?=latest
 
 GOPATH:=$(shell go env GOPATH)
 BINPATH:=$(abspath ./bin)
+SUBMODULES=_submodules
 
 all: $(SUBDIRS)
 
@@ -33,7 +34,7 @@ clean:
 	- rm -rf $(BINPATH)/
 
 lint:
-	$(BINPATH)/ltag -t ./.headers -check -v
+	$(BINPATH)/ltag -t ./.headers -excludes $(SUBMODULES) -check -v
 	$(BINPATH)/git-validation -run DCO,dangling-whitespace,short-subject -range HEAD~20..HEAD
 	$(BINPATH)/golangci-lint run
 

--- a/tools/docker/Dockerfile.runc-builder
+++ b/tools/docker/Dockerfile.runc-builder
@@ -1,0 +1,4 @@
+FROM golang:1.12-stretch
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install libseccomp-dev pkg-config

--- a/tools/image-builder/.gitignore
+++ b/tools/image-builder/.gitignore
@@ -1,0 +1,4 @@
+files_ephemeral
+*.img
+rootfs
+*stamp

--- a/tools/image-builder/Dockerfile.debian-image
+++ b/tools/image-builder/Dockerfile.debian-image
@@ -1,0 +1,23 @@
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM debian:stretch-slim
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      --no-install-recommends \
+      make squashfs-tools debootstrap
+
+VOLUME ["/src"]
+WORKDIR "/src"
+ENTRYPOINT ["make"]

--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -1,0 +1,97 @@
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+UID        := $(shell id -u)
+WORKDIR    := rootfs
+WORKDIRLOC := $(shell readlink -f $(WORKDIR))
+IMAGE_DIRS := /dev /bin /etc /etc/init.d /tmp /var /run /proc /sys /container/rootfs /agent /rom /overlay
+DIRS       := $(foreach dir,$(IMAGE_DIRS),"$(WORKDIR)$(dir)")
+DEBMIRROR  ?= http://deb.debian.org/debian
+
+# When referenced in a _stamp target's recipe,
+# e.g. files_debootstrap_stamp, this function uses tar to copy the
+# contents of the base directory (e.g. files_debootstrap) to the image
+# root. In order for the file locations to be correctly represented in
+# the image root, the directory structure of the source directory
+# should match that of the root image, e.g. if files_debootstrap
+# contains usr/local/bin/foo, then 'foo' will be installed in
+# /usr/local/bin/ in the root filesystem.
+define install_dir =
+if [ -d $(subst _stamp,,$@) ]; then \
+  cd $(subst _stamp,,$@) && tar cf - . | (cd "$(WORKDIRLOC)" && tar xvf -);\
+fi
+# Reset the timestamp on $(WORKDIR), which may have been modified by the
+# creation of files in it:
+touch --reference=debootstrap_stamp --no-create "$(WORKDIR)"
+endef
+
+all: rootfs.img
+
+$(WORKDIR):
+	mkdir $(WORKDIR)
+
+image_files=$(shell find files_* -mindepth 1 -type f -print)
+files_%_stamp: debootstrap_stamp $(image_files)
+	$(install_dir)
+	touch $@
+
+debootstrap: debootstrap_stamp
+
+debootstrap_stamp: $(WORKDIR)
+ifneq ($(UID),0)
+	$(error $(@) needs to run as root, not $(UID))
+endif
+	debootstrap \
+		--variant=minbase \
+		--include=udev,systemd,systemd-sysv,procps,libseccomp2 \
+		stretch \
+		"$(WORKDIR)" $(DEBMIRROR)
+	rm -rf "$(WORKDIR)/var/cache/apt/archives" \
+	       "$(WORKDIR)/usr/share/doc" \
+	       "$(WORKDIR)/var/lib/apt/lists"
+	mkdir -p $(DIRS)
+	touch $@
+
+rootfs.img: files_common_stamp files_debootstrap_stamp files_ephemeral_stamp
+	mksquashfs "$(WORKDIR)" rootfs.img -noappend
+
+builder: builder_stamp
+
+builder_stamp:
+	docker build -t fc-image-builder -f Dockerfile.debian-image .
+	touch $@
+
+# For any given target, append "-in-docker" to it to run the build
+# recipe in a container, e.g. instead of:
+# $ make rootfs.img
+# you can use
+# $ make rootfs.img-in-docker
+%-in-docker: builder_stamp
+	docker run --rm \
+		--security-opt=apparmor=unconfined \
+		-it --volume $(CURDIR):/src \
+		--cap-add=sys_admin \
+		--cap-add=sys_chroot \
+		--env=DEBMIRROR \
+		fc-image-builder:latest $(subst -in-docker,,$@)
+
+clean:
+	-rm -f *stamp
+	-rm -rf $(WORKDIR)
+	-rm -f rootfs.img
+
+distclean: clean-in-docker
+	rm -rf files_ephemeral
+	docker rmi fc-image-builder:latest
+
+.PHONY: debootstrap clean distclean builder %-in-docker

--- a/tools/image-builder/README.md
+++ b/tools/image-builder/README.md
@@ -1,0 +1,53 @@
+# Create Firecracker VM images for use with firecracker-containerd #
+
+## Debian root image ##
+
+### Overview ###
+
+The image builder component of firecracker-containerd will build a
+microVM image including the necessary components to support container
+management inside the microVM. In particular, the
+firecracker-containerd runtime agent and runc binary will be installed
+in the image.
+
+The image is generated as a read-only squashfs image. A read/write
+overlay layer is supported via the /sbin/overlay-init program, which
+should be used as init (e.g. by passing `init=/sbin/overlay-init` as a
+kernel boot parameter). By default, overlay-init allocates a tmpfs
+filesystem for use as the upper layer, but a block device can be
+provided via the `overlay_root` kernel parameter,
+e.g. `overlay_root=vdc`. This device should already contain a
+(possibly empty) ext4 filesystem. By using a block device, it is
+possible to preserve the filesystem state beyond the termination of
+the VM, and potentially re-use it for subsequent VM execution.
+
+The image currently expects `vdb` to be the block device containing
+the container root filesystem, and this device is mounted on
+`/container/rootfs`.
+
+If the `vsock_srv` program from the
+[clownix](https://github.com/clownix/cloonix_vsock) github repository
+is present in `ephemeral_files/bin/` when the image is built, it will
+be embedded in the image and run at boot, allowing easy shell access
+to the VM. This can be convenient for debugging, but it is not
+embedded by default for security and licensing reasons.
+
+### Generation ###
+
+There are two alternatives for providing the build environment. You
+can perform the image build in Docker, in which case the only
+build-time dependency is that you can launch Docker container directly
+(i.e. without `sudo`, etc). To build an image in this configuration, use:
+
+`$ make rootfs.img-in-docker`
+
+Alternatively, to build outside a container, you'll need:
+
+* To run the build process as root.
+* `[debootstrap](https://salsa.debian.org/installer-team/debootstrap)`
+  (Install via the package of the same name on Debian and Ubuntu)
+* `mksquashfs`, available in the
+   `[squashfs-tools](https://packages.debian.org/stretch/squashfs-tools)
+   package on Debian and Ubuntu.
+
+Then execute `make rootfs.img`

--- a/tools/image-builder/files_debootstrap/etc/hostname
+++ b/tools/image-builder/files_debootstrap/etc/hostname
@@ -1,0 +1,1 @@
+microvm

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/apt-daily-upgrade.timer
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/apt-daily-upgrade.timer
@@ -1,0 +1,1 @@
+/dev/null

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/apt-daily.timer
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/apt-daily.timer
@@ -1,0 +1,1 @@
+/dev/null

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/container-rootfs.mount
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/container-rootfs.mount
@@ -1,0 +1,9 @@
+[Unit]
+Description=Single container root filesystem
+ConditionPathIsDirectory=/container/rootfs
+DefaultDependencies=no
+Before=local-fs.target
+
+[Mount]
+What=/dev/vdb
+Where=/container/rootfs

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Firecracker VM agent
+StartLimitIntervalSec=2
+ConditionPathIsMountPoint=/container/rootfs
+After=local-fs.target
+Requires=local-fs.target
+
+[Service]
+Type=simple
+WorkingDirectory=/container
+ExecStart=/usr/local/bin/agent -id 1
+Restart=always

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=Firecracker containerd VM
+Requires=basic.target
+Conflicts=rescue.service rescue.target
+After=basic.target rescue.service rescue.target
+AllowIsolate=yes

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/container-rootfs.mount
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/container-rootfs.mount
@@ -1,0 +1,1 @@
+/etc/systemd/system/container-rootfs.mount

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/firecracker-agent.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/firecracker-agent.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/firecracker-agent.service

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/getty.target
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/getty.target
@@ -1,0 +1,1 @@
+/lib/systemd/system/getty.target

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/vsock-cli.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/vsock-cli.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/vsock-cli.service

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/getty-static.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/getty-static.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/rom-dev.mount
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/rom-dev.mount
@@ -1,0 +1,1 @@
+/dev/null

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/rom-overlay.mount
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/rom-overlay.mount
@@ -1,0 +1,1 @@
+/dev/null

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/rom.mount
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/rom.mount
@@ -1,0 +1,1 @@
+/dev/null

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/systemd-timesyncd.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/systemd-timesyncd.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/vsock-cli.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/vsock-cli.service
@@ -1,0 +1,28 @@
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# If the vsock_srv program from
+# https://github.com/clownix/cloonix_vsock is present, let's run it as
+# a service. It's useful for debug and test, but we don't want it
+# installed by default.
+
+[Unit]
+Description=vsock login service
+ConditionFileIsExecutable=/bin/vsock_srv
+StartLimitIntervalSec=2
+
+[Service]
+Type=forking
+ExecStart=/bin/vsock_srv 9999
+GuessMainPID=yes
+Restart=always

--- a/tools/image-builder/files_debootstrap/sbin/overlay-init
+++ b/tools/image-builder/files_debootstrap/sbin/overlay-init
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -x
+
+# Parameters:
+# 1. rw_root -- path where the read/write root is mounted
+# 2. work_dir -- path to the overlay workdir (must be on same filesystem as rw_root)
+# Overlay will be set up on /mnt, original root on /mnt/rom
+pivot() {
+    local rw_root work_dir
+    rw_root="$1"
+    work_dir="$2"
+    /bin/mount \
+	-o noatime,lowerdir=/,upperdir=${rw_root},workdir=${work_dir} \
+	-t overlay "overlayfs:${rw_root}" /mnt
+    pivot_root /mnt /mnt/rom
+}
+
+# Overlay is configured under /overlay
+# Global variable $overlay_root is expected to be set to either:
+# "ram", which configures a tmpfs as the rw overlay layer (this is
+# the default, if the variable is unset)
+# - or -
+# A block device name, relative to /dev, in which case it is assumed
+# to contain an ext4 filesystem suitable for use as a rw overlay
+# layer. e.g. "vdb"
+do_overlay() {
+    local overlay_dir="/overlay"
+    if [ "$overlay_root" = ram ] ||
+           [ -z "$overlay_root" ]; then
+        /bin/mount -t tmpfs -o noatime,mode=0755 tmpfs /overlay
+    else
+        /bin/mount -t ext4 "/dev/$overlay_root" /overlay
+    fi
+    mkdir -p /overlay/root /overlay/work
+    pivot /overlay/root /overlay/work
+}
+
+# If we're given an overlay, ensure that it really exists. Panic if not.
+if [ -n "$overlay_root" ] &&
+       [ "$overlay_root" != ram ] &&
+       [ ! -b "/dev/$overlay_root" ]; then
+    echo -n "FATAL: "
+    echo "Overlay root given as $overlay_root but /dev/$overlay_root does not exist"
+    exit 1
+fi
+
+do_overlay
+
+# invoke the actual system init program and procede with the boot
+# process.
+exec /sbin/init $@


### PR DESCRIPTION
*Issue #75, #33*

*Description of changes:*

This PR adds automation for creating MicroVM root fillesystem images. The images are created as *squashfs* files and configured to support read-only attachment with a read/write overlay layer on top. RunC and the firecracker-containerd agent are embedded in the image, and the agent is started by default. Per our current convention, the snapshotter-created container rootfs image is assumed to be on `vdb` and is mounted at `/container`.

If you have docker installed and configured in such a way as to allow you to run containers without root access, you can build an image with `make image` from the top level directory. The resulting image will be available as `image-builder/rootfs.img` See [README.md](image-builder/README.md) for more details.

In order to use the resulting image with firecracker-containerd, you should pass the following kernel parameters at MicroVM launch: `systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init`

There are a couple of optimizations missing at this time. In particular, because the target responsible for building the agent is a `PHONY` target, the dependent `image` target can run when not strictly necessary.
