### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: go
 
 go:


### PR DESCRIPTION
Signed-off-by: Maksym Pavlenko <makpav@amazon.com>

~Attempt to~ fix Travis by using newer env

Some PRs ([1](https://github.com/firecracker-microvm/firecracker-containerd/pull/156), [2](https://github.com/firecracker-microvm/firecracker-containerd/pull/155)) are failing with
```
# github.com/firecracker-microvm/firecracker-containerd/agent
/home/travis/.gimme/versions/go1.11.7.linux.amd64/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-774945651/000010.o: unrecognized relocation (0x2a) in section `.text'
/usr/bin/ld: final link failed: Bad value
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
