### PR TITLE
Use default VM configuration if not specified in request

### DIFF
--- a/firecracker-control/common.go
+++ b/firecracker-control/common.go
@@ -16,6 +16,7 @@ package service
 import (
 	"time"
 
+	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 	"github.com/pkg/errors"
 )
 
@@ -31,4 +32,11 @@ var (
 
 const (
 	firecrackerStartTimeout = 5 * time.Second
+	defaultCPUTemplate      = models.CPUTemplateT2
+	defaultCPUCount         = 1
+	defaultMemSizeMb        = 128
+	defaultKernelArgs       = "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw"
+	defaultFilesPath        = "/var/lib/firecracker-containerd/runtime/"
+	defaultKernelPath       = defaultFilesPath + "default-vmlinux.bin"
+	defaultRootfsPath       = defaultFilesPath + "default-rootfs.img"
 )

--- a/firecracker-control/local_test.go
+++ b/firecracker-control/local_test.go
@@ -76,22 +76,6 @@ func TestLocal_buildVMConfiguration(t *testing.T) {
 	assert.True(t, ni.AllowMMDS)
 }
 
-func TestLocal_buildInvalidConfiguration(t *testing.T) {
-	obj := &local{
-		rootPath:    "/",
-		findVsockFn: func(context.Context) (*os.File, uint32, error) { return nil, 3, nil },
-	}
-
-	request := &proto.CreateVMRequest{}
-
-	_, err := obj.buildVMConfiguration(testCtx, "1", 3, request)
-	assert.EqualError(t, err, "invalid machine configuration")
-
-	request.MachineCfg = &proto.FirecrackerMachineConfiguration{}
-	_, err = obj.buildVMConfiguration(testCtx, "1", 3, request)
-	assert.EqualError(t, err, "root drive can't be empty")
-}
-
 func TestLocal_startMachine(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Signed-off-by: Maksym Pavlenko <makpav@amazon.com>

*Issue #, if available:*
https://github.com/firecracker-microvm/firecracker-containerd/issues/159
*Description of changes:*
- Use default configuration if some parameters weren't specified in create request.
I've reworked helpers to 'map or use defaults' instead of override logic.
- Small namespace fix when publishing stop event

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
