### PR TITLE
runtime: pass logger to firecracker libraries

### DIFF
--- a/runtime/service.go
+++ b/runtime/service.go
@@ -935,6 +935,7 @@ func (s *service) startVM(ctx context.Context,
 		Build(ctx)
 	machineOpts := []firecracker.Opt{
 		firecracker.WithProcessRunner(cmd),
+		firecracker.WithLogger(log.G(ctx)),
 	}
 
 	vmmCtx, vmmCancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This ensures that we capture logs from the firecracker-go-sdk libraries at the
expected verbosity level and to the expected output location.

Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
