### PR TITLE
Skip unneeded chown when copying fc-agent.start.

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -175,7 +175,7 @@ RUN --mount=type=cache,from=build-base,source=/home/builder/go/pkg/mod,target=/h
 FROM alpine:3.8 as firecracker-vm-root
 COPY --from=runc-build /output/runc /usr/local/bin/
 COPY --from=firecracker-containerd-build /output/agent /usr/local/bin/
-ADD --chown=builder tools/docker/fc-agent.start /etc/local.d/fc-agent.start
+ADD tools/docker/fc-agent.start /etc/local.d/fc-agent.start
 RUN apk add openrc \
 	&& ln -s /etc/init.d/local /etc/runlevels/default/local \
 	&& ln -s /etc/init.d/cgroups /etc/runlevels/default/cgroups \


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <sipsma@amazon.com>

There appears to have been an update pushed to either docker or buildkit that results in this line (which previously just did nothing) to fail. The `--chown` is not needed in the first place though so this change just removes it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
