### PR TITLE
Cleanup use of context objects throughout the code.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260 h1:XGyg7oTtD0DoRFh
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/go-runc v0.0.0-20190226155025-7d11b49dc076 h1:biYGul6kwz5/Lh6UxkYQyRKPeYA/ZL5n2pdCAcYUpLA=
 github.com/containerd/go-runc v0.0.0-20190226155025-7d11b49dc076/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
-github.com/containerd/ttrpc v0.0.0-20181001154009-f51df4475b76 h1:vUPO9S35+FvukX2L/1mmPWgdv0y6FEKJzeWzmgVe9IA=
-github.com/containerd/ttrpc v0.0.0-20181001154009-f51df4475b76/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190411181408-699c4e40d1e7 h1:SKDlsIhYxNE1LO0xwuOR+3QWj3zRibVQu5jWIMQmOfU=
 github.com/containerd/ttrpc v0.0.0-20190411181408-699c4e40d1e7/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/typeurl v0.0.0-20181015155603-461401dc8f19 h1:gzdItdct+4eLnZxiZi1YcIXx3uo5QWa/xXKnsldEqY8=

--- a/runtime/service_test.go
+++ b/runtime/service_test.go
@@ -63,7 +63,7 @@ func TestParseCreateTaskOptsParsesFirecrackerConfig(t *testing.T) {
 
 	protoFirecrackerConfig, err := typeurl.MarshalAny(inFirecrackerConfig)
 	require.NoError(t, err, "unable to marshal firecracker config proto message")
-	outFirecrackerConfig, outRuncOpts, err := parseCreateTaskOpts(context.TODO(), protoFirecrackerConfig)
+	outFirecrackerConfig, outRuncOpts, err := parseCreateTaskOpts(protoFirecrackerConfig)
 	require.NoError(t, err, "unable to parse firecracker config from proto message")
 	if outRuncOpts != nil {
 		// assert.Equal is insufficient here as the nil comparison fails for
@@ -82,7 +82,7 @@ func TestParseCreateTaskLeavesNonFirecrackerConfigAlong(t *testing.T) {
 	}
 	protoIn, err := typeurl.MarshalAny(in)
 	require.NoError(t, err, "unable to marshal proto message")
-	outFirecrackerConfig, outOpts, err := parseCreateTaskOpts(context.TODO(), protoIn)
+	outFirecrackerConfig, outOpts, err := parseCreateTaskOpts(protoIn)
 	require.NoError(t, err, "unable to parse firecracker config from proto message")
 	if outFirecrackerConfig != nil {
 		// assert.Equal is insufficient here as the nil comparison fails for


### PR DESCRIPTION
There are a few related changes being made here:
1. Give each ctx object a more specific name that indicates the scope of its
   lifetime (i.e. one that will be canceled after a request or one that shuts
   down the process).
2. Remove ctx when it's not needed for anything but logging; just use a pre-made
   logger object instead
3. Use ctx to cancel requests where previously it was just ignored.

This is all spurred by the recently imported updates to TTRPC that resulted in
service method context objects to be canceled after the request is finished, but
the changes here seem beneficial besides that as its intended to make our use
of context more explicit and consistent.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
