### PR TITLE
firecracker-control: linter was complaining about sysCall not being used

### DIFF
--- a/firecracker-control/vsock.go
+++ b/firecracker-control/vsock.go
@@ -56,7 +56,7 @@ func findNextAvailableVsockCID(ctx context.Context) (*os.File, uint32, error) {
 			return nil, 0, ctx.Err()
 		default:
 			cid := contextID
-			_, _, err = syscall.Syscall(
+			_, _, err = sysCall(
 				unix.SYS_IOCTL,
 				file.Fd(),
 				ioctlVsockSetGuestCID,


### PR DESCRIPTION
sysCall was not being used other than in tests. However, since we never actually called the sysCall function, the tests would use syscall.Syscall instead

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
