### PR TITLE
dangling whitespace linter isn't friendly with tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - gocritic
     - interfacer # Suggests narrower interface types
     - scopelint # Checks for unpinned variables
+    - gofmt
 
 issues:
   exclude-use-default: false

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ distclean: clean
 
 lint:
 	$(BINPATH)/ltag -t ./.headers -excludes "tools $(SUBMODULES)" -check -v
-	$(BINPATH)/git-validation -run DCO,dangling-whitespace,short-subject -range HEAD~20..HEAD
+	$(BINPATH)/git-validation -run DCO,short-subject -range HEAD~20..HEAD
 	$(BINPATH)/golangci-lint run
 
 deps:


### PR DESCRIPTION
Some tests require spaces at the end of strings for proper string
comparison

The linter, git-validation, checks more than just commit messages, but the actual diff that is going to be merge. And if there are any danglers, it'll error out.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
