### PR TITLE
Update quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-SUBDIRS:=agent runtime snapshotter examples
+SUBDIRS:=agent runtime snapshotter examples firecracker-control/cmd/containerd
 export INSTALLROOT?=/usr/local
 export STATIC_AGENT
 

--- a/firecracker-control/cmd/containerd/Makefile
+++ b/firecracker-control/cmd/containerd/Makefile
@@ -24,8 +24,8 @@ build: firecracker-containerd
 firecracker-containerd: $(SRC) $(GOMOD) $(GOSUM)
 	go build -v -o firecracker-containerd
 
-install: containerd
-	cp firecracker-containerd /usr/local/bin/
+install: firecracker-containerd
+	install -D -o root -g root -m755 -t $(INSTALLROOT)/bin firecracker-containerd
 
 test: $(SOURCES)
 	go test ./... $(EXTRAGOARGS)

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -68,6 +68,7 @@ func LoadConfig(path string) (*Config, error) {
 		KernelImagePath: defaultKernelPath,
 		RootDrive:       defaultRootfsPath,
 		CPUCount:        defaultCPUCount,
+		CPUTemplate:     string(defaultCPUTemplate),
 	}
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal config from %q", path)

--- a/runtime/config_test.go
+++ b/runtime/config_test.go
@@ -33,6 +33,7 @@ func TestLoadConfigDefaults(t *testing.T) {
 	assert.Equal(t, defaultKernelPath, cfg.KernelImagePath, "expected default kernel path")
 	assert.Equal(t, defaultRootfsPath, cfg.RootDrive, "expected default rootfs path")
 	assert.Equal(t, defaultCPUCount, cfg.CPUCount, "expected default CPU count")
+	assert.Equal(t, string(defaultCPUTemplate), cfg.CPUTemplate, "expected default CPU template")
 }
 
 func TestLoadConfigOverrides(t *testing.T) {
@@ -40,13 +41,15 @@ func TestLoadConfigOverrides(t *testing.T) {
 	overrideKernelPath := "OVERRIDE KERNEL PATH"
 	overrideRootfsPath := "OVERRIDE ROOTFS PATH"
 	overrideCPUCount := 42
+	overrideCPUTemplate := "OVERRIDE CPU TEMPLATE"
 	configContent := fmt.Sprintf(
 		`{
 			"kernel_args":"%s",
 			"kernel_image_path":"%s",
 			"root_drive":"%s",
-			"cpu_count": %d
-		}`, overrideKernelArgs, overrideKernelPath, overrideRootfsPath, overrideCPUCount)
+			"cpu_count": %d,
+            "cpu_template": "%s"
+		}`, overrideKernelArgs, overrideKernelPath, overrideRootfsPath, overrideCPUCount, overrideCPUTemplate)
 	configFile, cleanup := createTempConfig(t, configContent)
 	defer cleanup()
 	cfg, err := LoadConfig(configFile)
@@ -55,7 +58,8 @@ func TestLoadConfigOverrides(t *testing.T) {
 	assert.Equal(t, overrideKernelArgs, cfg.KernelArgs, "expected overridden kernel args")
 	assert.Equal(t, overrideKernelPath, cfg.KernelImagePath, "expected overridden kernel path")
 	assert.Equal(t, overrideRootfsPath, cfg.RootDrive, "expected overridden rootfs path")
-	assert.Equal(t, overrideCPUCount, cfg.CPUCount, "expected overridden cpu count")
+	assert.Equal(t, overrideCPUCount, cfg.CPUCount, "expected overridden CPU count")
+	assert.Equal(t, overrideCPUTemplate, cfg.CPUTemplate, "expected overridden CPU template")
 }
 
 func createTempConfig(t *testing.T, contents string) (string, func()) {

--- a/runtime/helpers.go
+++ b/runtime/helpers.go
@@ -22,10 +22,10 @@ import (
 	"github.com/firecracker-microvm/firecracker-containerd/proto"
 )
 
-func machineConfigurationFromProto(req *proto.FirecrackerMachineConfiguration) models.MachineConfiguration {
+func machineConfigurationFromProto(cfg *Config, req *proto.FirecrackerMachineConfiguration) models.MachineConfiguration {
 	config := models.MachineConfiguration{
-		CPUTemplate: defaultCPUTemplate,
-		VcpuCount:   defaultCPUCount,
+		CPUTemplate: models.CPUTemplate(cfg.CPUTemplate),
+		VcpuCount:   int64(cfg.CPUCount),
 		MemSizeMib:  defaultMemSizeMb,
 	}
 

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -584,7 +584,7 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 		VsockDevices: []firecracker.VsockDevice{{Path: "root", CID: s.machineCID}},
 		LogFifo:      s.shimDir().FirecrackerLogFifoPath(),
 		MetricsFifo:  s.shimDir().FirecrackerMetricsFifoPath(),
-		MachineCfg:   machineConfigurationFromProto(req.MachineCfg),
+		MachineCfg:   machineConfigurationFromProto(s.config, req.MachineCfg),
 	}
 
 	logger.Debugf("using socket path: %s", cfg.SocketPath)
@@ -594,13 +594,13 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 	if val := req.KernelArgs; val != "" {
 		cfg.KernelArgs = val
 	} else {
-		cfg.KernelArgs = defaultKernelArgs
+		cfg.KernelArgs = s.config.KernelArgs
 	}
 
 	if val := req.KernelImagePath; val != "" {
 		cfg.KernelImagePath = val
 	} else {
-		cfg.KernelImagePath = defaultKernelPath
+		cfg.KernelImagePath = s.config.KernelImagePath
 	}
 
 	// Drives configuration
@@ -609,7 +609,7 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 	if root := req.RootDrive; root != nil {
 		driveBuilder = firecracker.NewDrivesBuilder(root.PathOnHost)
 	} else {
-		driveBuilder = firecracker.NewDrivesBuilder(defaultRootfsPath)
+		driveBuilder = firecracker.NewDrivesBuilder(s.config.RootDrive)
 	}
 
 	// TODO: Reserve fake drives here (https://github.com/firecracker-microvm/firecracker-containerd/pull/154)

--- a/tools/docker/firecracker-runtime.json
+++ b/tools/docker/firecracker-runtime.json
@@ -1,8 +1,8 @@
 {
   "firecracker_binary_path": "/usr/local/bin/firecracker",
-  "kernel_image_path": "/var/lib/firecracker-containerd/runtime/hello-vmlinux.bin",
+  "kernel_image_path": "/var/lib/firecracker-containerd/runtime/default-vmlinux.bin",
   "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw",
-  "root_drive": "/var/lib/firecracker-containerd/runtime/hello-rootfs.ext4",
+  "root_drive": "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
   "cpu_count": 1,
   "cpu_template": "T2",
   "log_fifo": "/tmp/fc-logs.fifo",

--- a/tools/image-builder/README.md
+++ b/tools/image-builder/README.md
@@ -44,7 +44,7 @@ build-time dependency is that you can launch Docker container directly
 Alternatively, to build outside a container, you'll need:
 
 * To run the build process as root.
-* `[debootstrap](https://salsa.debian.org/installer-team/debootstrap)`
+* [`debootstrap`](https://salsa.debian.org/installer-team/debootstrap)
   (Install via the package of the same name on Debian and Ubuntu)
 * `mksquashfs`, available in the
    `[squashfs-tools](https://packages.debian.org/stretch/squashfs-tools)

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/container-rootfs.mount
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/container-rootfs.mount
@@ -1,3 +1,15 @@
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
 [Unit]
 Description=Single container root filesystem
 ConditionPathIsDirectory=/container/rootfs

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/container-rootfs.mount
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/container-rootfs.mount
@@ -2,7 +2,6 @@
 Description=Single container root filesystem
 ConditionPathIsDirectory=/container/rootfs
 DefaultDependencies=no
-Before=local-fs.target
 
 [Mount]
 What=/dev/vdb

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
@@ -1,3 +1,15 @@
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
 [Unit]
 Description=Firecracker VM agent
 StartLimitIntervalSec=2

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Firecracker VM agent
 StartLimitIntervalSec=2
-ConditionPathIsMountPoint=/container/rootfs
 After=local-fs.target
 Requires=local-fs.target
 

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target
@@ -1,3 +1,15 @@
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
 [Unit]
 Description=Firecracker containerd VM
 Requires=basic.target


### PR DESCRIPTION
Update our quickstart guide.  Includes some other changes to make the guide work, like:

* Updating the Makefile to build firecracker-containerd
* Restoring some lost support for configuration values in `/etc/containerd/firecracker-runtime.json`
* Removing the "single container rootfs" from the image builder

This is ready for review now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
