### PR TITLE
Extending timeout for snapshotter tests

### DIFF
--- a/snapshotter/Makefile
+++ b/snapshotter/Makefile
@@ -41,7 +41,7 @@ test-docker-all: $(SOURCES) $(GOMOD) $(GOSUM)
 		--env EXTRAGOARGS="${EXTRAGOARGS}" \
 		--workdir="/firecracker-containerd/snapshotter" \
 		localhost/firecracker-containerd-unittest:${DOCKER_IMAGE_TAG} \
-		"make test"
+		'EXTRAGOARGS="-timeout 15m" make test'
 
 test-docker-unit: $(SOURCES) $(GOMOD) $(GOSUM)
 	docker run --rm \
@@ -49,7 +49,7 @@ test-docker-unit: $(SOURCES) $(GOMOD) $(GOSUM)
 		--env DISABLE_ROOT_TESTS="true" \
 		--workdir="/firecracker-containerd/snapshotter" \
 		localhost/firecracker-containerd-unittest-nonroot:${DOCKER_IMAGE_TAG} \
-		"make test"
+		'EXTRAGOARGS="-timeout 15m" make test'
 
 
 clean:


### PR DESCRIPTION
Extends snapshotter tests timeout. I ran several tests today on this on my CI box, but none of my builds were failing and were succeeding within 5 minutes. However, I did encounter some timing issues yesterday and was able to resolve them by simply extending the timeout which mostly succeeded within 15 minutes but had one instance where a single test took 23 minutes...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
