### PR TITLE
Add TTRPC client helper

### DIFF
--- a/examples/taskworkflow.go
+++ b/examples/taskworkflow.go
@@ -27,12 +27,12 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/pkg/ttrpcutil"
-	"github.com/firecracker-microvm/firecracker-containerd/proto"
-	fccontrol "github.com/firecracker-microvm/firecracker-containerd/proto/service/fccontrol/ttrpc"
-	"github.com/firecracker-microvm/firecracker-containerd/runtime/firecrackeroci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+
+	fcclient "github.com/firecracker-microvm/firecracker-containerd/firecracker-control/client"
+	"github.com/firecracker-microvm/firecracker-containerd/proto"
+	"github.com/firecracker-microvm/firecracker-containerd/runtime/firecrackeroci"
 )
 
 const (
@@ -77,12 +77,12 @@ func taskWorkflow(containerIP string, gateway string, netMask string) (err error
 		return errors.Wrapf(err, "creating container")
 	}
 
-	pluginClient, err := ttrpcutil.NewClient(containerdTTRPCAddress)
+	fcClient, err := fcclient.New(containerdTTRPCAddress)
 	if err != nil {
-		return errors.Wrap(err, "failed to create ttrpc client")
+		return err
 	}
 
-	fcClient := fccontrol.NewFirecrackerClient(pluginClient.Client())
+	defer fcClient.Close()
 
 	vmID := "fc-example"
 	createVMRequest := &proto.CreateVMRequest{VMID: vmID}

--- a/firecracker-control/client/client.go
+++ b/firecracker-control/client/client.go
@@ -1,0 +1,48 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package client
+
+import (
+	"github.com/containerd/containerd/pkg/ttrpcutil"
+	"github.com/pkg/errors"
+
+	fccontrol "github.com/firecracker-microvm/firecracker-containerd/proto/service/fccontrol/ttrpc"
+)
+
+// Client is a helper client for containerd's firecracker-control plugin
+type Client struct {
+	fccontrol.FirecrackerService
+
+	ttrpcClient *ttrpcutil.Client
+}
+
+// New creates a new firecracker-control service client
+func New(ttrpcAddress string) (*Client, error) {
+	ttrpcClient, err := ttrpcutil.NewClient(ttrpcAddress)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create ttrpc client")
+	}
+
+	fcClient := fccontrol.NewFirecrackerClient(ttrpcClient.Client())
+
+	return &Client{
+		FirecrackerService: fcClient,
+		ttrpcClient:        ttrpcClient,
+	}, nil
+}
+
+// Close closes the underlying TTRPC client
+func (c *Client) Close() error {
+	return c.ttrpcClient.Close()
+}


### PR DESCRIPTION
Signed-off-by: Maksym Pavlenko <makpav@amazon.com>

*Description of changes:*
This PR adds a helper TTRPC client for the firecracker service (original discussion  https://github.com/firecracker-microvm/firecracker-containerd/pull/196#discussion_r290807527)
Also now closing a connection after its no longer needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
