### PR TITLE
Fixing CI to run sequentially

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,8 @@ steps:
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
     command: 'sudo losetup -D'
+    concurrency: 1
+    concurrency_group: 'loop-device test'
 
   - wait
 
@@ -54,6 +56,8 @@ steps:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
       EXTRAGOARGS: "-v -count=1"
     command: 'cd snapshotter && make test-docker-all'
+    concurrency: 1
+    concurrency_group: 'loop-device test'
 
   - label: ":running_shirt_with_sash: runtime unit tests"
     agents:
@@ -72,6 +76,8 @@ steps:
     artifact_paths:
       - "runtime/logs/*"
     command: 'cd runtime && make test-docker-isolated'
+    concurrency: 1
+    concurrency_group: 'loop-device test'
 
   - label: ":fencer: agent unit tests"
     agents:


### PR DESCRIPTION
This actually makes some steps be required to be sequential. The steps
that were used to be ran sequentially was determined by whether or not
they used the naive snapshotter

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
