### PR TITLE
Disable golang-ci linting on tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  tests: false # disable running linters on tests
+
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
golang-ci causes some issues with some test patterns, like using t.Run
and passing variables from the parent scope which is commonly done with
test vectors in Go.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
