### PR TITLE
Remove ID flag from Agent

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"os"
 	"os/signal"
@@ -48,12 +47,10 @@ const (
 
 func main() {
 	var (
-		id    string
 		port  int
 		debug bool
 	)
 
-	flag.StringVar(&id, "id", "", "ContainerID (required)")
 	flag.IntVar(&port, "port", defaultPort, "Vsock port to listen to")
 	flag.BoolVar(&debug, "debug", false, "Turn on debug mode")
 	flag.Parse()
@@ -68,11 +65,6 @@ func main() {
 	shimCtx, shimCancel := context.WithCancel(namespaces.WithNamespace(context.Background(), defaultNamespace))
 	group, shimCtx := errgroup.WithContext(shimCtx)
 
-	// verify arguments, id is required
-	if id == "" {
-		log.G(shimCtx).WithError(errors.New("invalid argument")).Fatal("id not set")
-	}
-
 	// Ensure this process is a subreaper or else containers created via runc will
 	// not be its children.
 	if err := sys.SetSubreaper(enableSubreaper); err != nil {
@@ -83,7 +75,7 @@ func main() {
 	// This can be wrapped to add missing functionality (like
 	// running multiple containers inside one Firecracker VM)
 
-	log.G(shimCtx).WithField("id", id).Info("creating runc shim")
+	log.G(shimCtx).Info("creating task service")
 
 	eventExchange := &event.ExchangeCloser{Exchange: exchange.NewExchange()}
 	taskService := NewTaskService(shimCtx, shimCancel, eventExchange)

--- a/tools/docker/fc-agent.start
+++ b/tools/docker/fc-agent.start
@@ -6,4 +6,4 @@ touch /container/runtime
 
 cd /container
 
-exec /usr/local/bin/agent -id 1 -debug
+exec /usr/local/bin/agent -debug

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
@@ -19,5 +19,5 @@ Requires=local-fs.target
 [Service]
 Type=simple
 WorkingDirectory=/container
-ExecStart=/usr/local/bin/agent -id 1
+ExecStart=/usr/local/bin/agent
 Restart=always


### PR DESCRIPTION
Signed-off-by: Maksym Pavlenko <makpav@amazon.com>

*Description of changes:*
Minor cleanup: `id` command line flag is no longer used, so no reason to require it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
