### PR TITLE
Upgrade to v2 runc service in VM Agent.

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -78,7 +78,10 @@ func main() {
 	log.G(shimCtx).Info("creating task service")
 
 	eventExchange := &event.ExchangeCloser{Exchange: exchange.NewExchange()}
-	taskService := NewTaskService(shimCtx, shimCancel, eventExchange)
+	taskService, err := NewTaskService(shimCtx, shimCancel, eventExchange)
+	if err != nil {
+		log.G(shimCtx).WithError(err).Fatal("failed to create task service")
+	}
 
 	server, err := ttrpc.NewServer()
 	if err != nil {

--- a/internal/vm/task_test.go
+++ b/internal/vm/task_test.go
@@ -55,7 +55,6 @@ type mockTaskService struct {
 func defaultMockTaskArgs(id string) addTaskArgs {
 	return addTaskArgs{
 		id:        fmt.Sprintf("container-%s", id),
-		ts:        &mockTaskService{},
 		bundleDir: mockBundleDir,
 		extraData: mockExtraData,
 		fifoSet:   mockFIFOSet,
@@ -64,26 +63,24 @@ func defaultMockTaskArgs(id string) addTaskArgs {
 
 type addTaskArgs struct {
 	id        string
-	ts        task.TaskService
 	bundleDir bundle.Dir
 	extraData *proto.ExtraData
 	fifoSet   *cio.FIFOSet
 }
 
 func addTaskFromArgs(tm TaskManager, args addTaskArgs) (*Task, error) {
-	return tm.AddTask(args.id, args.ts, args.bundleDir, args.extraData, args.fifoSet, context.Background().Done(), func() {})
+	return tm.AddTask(args.id, args.bundleDir, args.extraData, args.fifoSet, context.Background().Done(), func() {})
 }
 
 func TestTaskManager_AddRemoveTask(t *testing.T) {
 	logger, _ := test.NewNullLogger()
-	tm := NewTaskManager(logger.WithField("test", t.Name()))
+	tm := NewTaskManager(logger.WithField("test", t.Name()), &mockTaskService{})
 
 	taskAArgs := defaultMockTaskArgs("A")
 	taskBArgs := defaultMockTaskArgs("B")
 	taskCArgs := defaultMockTaskArgs("C")
 
 	assertExpectedTask := func(args addTaskArgs, createdTask *Task) {
-		require.Equal(t, args.ts, createdTask.TaskService, "AddTask sets expected task service")
 		require.Equal(t, args.id, createdTask.ID, "AddTask sets expected container ID")
 		require.Equal(t, args.extraData, createdTask.extraData, "AddTask sets expected container ID")
 		require.Equal(t, args.bundleDir, createdTask.bundleDir, "AddTask sets expected container ID")
@@ -180,7 +177,7 @@ func TestTaskManager_StartStdioProxy_VSockToFIFO(t *testing.T) {
 
 func testStdioProxy(t *testing.T, inputDirection IODirection) {
 	logger, _ := test.NewNullLogger()
-	tm := NewTaskManager(logger.WithField("test", t.Name()))
+	tm := NewTaskManager(logger.WithField("test", t.Name()), &mockTaskService{})
 
 	taskArgs := defaultMockTaskArgs("A")
 


### PR DESCRIPTION
The new runc service implementation supports managing multiple tasks in a single
service. This upgrade thus allows us to use a single task service instantiation
instead of 1-per-task, which in turn helps simplify our internal task manager
implementation.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

**NOTE:** This change stands on its own, but the primary motivation for doing it now is that it ends up simplifying a lot of the code for exec support, which I'm in the process of finalizing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
