### PR TITLE
runtime: Fix integration test by calling wait before start

### DIFF
--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -402,11 +402,11 @@ func TestStubBlockDevices_Isolated(t *testing.T) {
 		cio.NewCreator(cio.WithStreams(nil, bufio.NewWriter(&stdout), bufio.NewWriter(&stderr))))
 	require.NoError(t, err, "failed to create task for container %s", containerName)
 
-	err = newTask.Start(ctx)
-	require.NoError(t, err, "failed to start task for container %s", containerName)
-
 	exitCh, err := newTask.Wait(ctx)
 	require.NoError(t, err, "failed to wait on task for container %s", containerName)
+
+	err = newTask.Start(ctx)
+	require.NoError(t, err, "failed to start task for container %s", containerName)
 
 	const containerID = 0
 


### PR DESCRIPTION
Previous integration tests would call wait before start on a new task,
but the stub integ test did start and then wait, which may have
completed by the time wait was called. This would result in an error on
wait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
