### PR TITLE
agent: Adding retry around mounting logic

### DIFF
--- a/agent/error.go
+++ b/agent/error.go
@@ -1,0 +1,25 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"syscall"
+)
+
+// isRetryableMountError will check to see if the error passed in is an
+// syscall.EINVAL
+func isRetryableMountError(err error) bool {
+	errno, ok := err.(syscall.Errno)
+	return ok && errno == syscall.EINVAL
+}

--- a/agent/error_test.go
+++ b/agent/error_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRetryableMountError(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Error    error
+		Expected bool
+	}{
+		{
+			Name:     "nil case",
+			Error:    nil,
+			Expected: false,
+		},
+		{
+			Name:     "syscall.Errno EINVAL case",
+			Error:    syscall.EINVAL,
+			Expected: true,
+		},
+		{
+			Name:     "syscall.Errno ENOENT case",
+			Error:    syscall.ENOENT,
+			Expected: false,
+		},
+		{
+			Name:     "regular error case",
+			Error:    fmt.Errorf("foo bar"),
+			Expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c // see https://github.com/kyoh86/scopelint/issues/4
+		t.Run(c.Name, func(t *testing.T) {
+			assert.Equal(t, c.Expected, isRetryableMountError(c.Error))
+		})
+	}
+}

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -60,9 +60,10 @@ func (d Dir) RootfsPath() string {
 	return filepath.Join(d.RootPath(), internal.BundleRootfsName)
 }
 
-// MountRootfs creates the RootfsPath and mounts the provided sourcePath there.
+// MountRootfs creates the RootfsPath if it does not exist and mounts the
+// provided sourcePath there.
 func (d Dir) MountRootfs(sourcePath string, mountType string, mountOpts []string) error {
-	err := os.Mkdir(d.RootfsPath(), 0700)
+	err := os.MkdirAll(d.RootfsPath(), 0700)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Firecracker requires some time to populate the config space change which
was causing failures in our CI due to calling patch drive followed by
an immediate call of mounting that drive.

https://github.com/firecracker-microvm/firecracker/issues/1159#issuecomment-507984468

Fixes #214

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
