### PR TITLE
runtime: Adding support of setting log levels thru config

### DIFF
--- a/runtime/service.go
+++ b/runtime/service.go
@@ -175,6 +175,11 @@ func NewService(shimCtx context.Context, id string, remotePublisher shim.Publish
 		}
 	}
 
+	if config.Debug {
+		logrus.SetLevel(logrus.DebugLevel)
+		logger.Logger.SetLevel(logrus.DebugLevel)
+	}
+
 	s := &service{
 		taskManager:   vm.NewTaskManager(shimCtx, logger),
 		eventExchange: exchange.NewExchange(),
@@ -582,6 +587,8 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 		LogFifo:      s.shimDir.FirecrackerLogFifoPath(),
 		MetricsFifo:  s.shimDir.FirecrackerMetricsFifoPath(),
 		MachineCfg:   machineConfigurationFromProto(s.config, req.MachineCfg),
+		LogLevel:     s.config.LogLevel,
+		Debug:        s.config.Debug,
 	}
 
 	logger.Debugf("using socket path: %s", cfg.SocketPath)


### PR DESCRIPTION
Prior to this change the config fields of 'Debug' and 'LogLevel' were
not used and did not set the proper debug level during logging.
- [x] Add tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
