### PR TITLE
Update getting started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -236,3 +236,20 @@ $ sudo ctr --address /run/firecracker-containerd/containerd.sock \
   run --snapshotter firecracker-naive --runtime aws.firecracker --tty \
   docker.io/library/busybox:latest busybox-test
 ```
+
+Alternatively you can specify `--runtime` and `--snapshotter` just once when creating a new namespace using containerd's default labels:
+
+```bash
+$ sudo ctr --address /run/firecracker-containerd/containerd.sock \
+  namespaces create fc
+
+$ sudo ctr --address /run/firecracker-containerd/containerd.sock \
+  namespaces label fc \
+  containerd.io/defaults/runtime=aws.firecracker \
+  containerd.io/defaults/snapshotter=firecracker-naive
+
+$ sudo ctr --address /run/firecracker-containerd/containerd.sock \
+  -n fc \
+  run --tty \
+  docker.io/library/busybox:latest busybox-test
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/containerd/cgroups v0.0.0-20181105182409-82cb49fc1779 // indirect
 	github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50 // indirect
-	github.com/containerd/containerd v1.2.1-0.20190626153021-bb9616ba206c
+	github.com/containerd/containerd v1.2.1-0.20190711201753-f2b6c31d0fa7
 	github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac
 	github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260
 	github.com/containerd/go-runc v0.0.0-20190226155025-7d11b49dc076 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/containerd/cgroups v0.0.0-20181105182409-82cb49fc1779 h1:j1IsLW6/hNZP
 github.com/containerd/cgroups v0.0.0-20181105182409-82cb49fc1779/go.mod h1:X9rLEHIqSf/wfK8NsPqxJmeZgW4pcfzdXITDrUSJ6uI=
 github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50 h1:WMpHmC6AxwWb9hMqhudkqG7A/p14KiMnl6d3r1iUMjU=
 github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
-github.com/containerd/containerd v1.2.1-0.20190626153021-bb9616ba206c h1:m/ToFT22QUZDGCSrSwiayu75/NDnTWIeHGNY770sLiU=
-github.com/containerd/containerd v1.2.1-0.20190626153021-bb9616ba206c/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.2.1-0.20190711201753-f2b6c31d0fa7 h1:oIh8usyIH8KVp/+g15ki0h9wizhWZraz5l5AKu9wGqM=
+github.com/containerd/containerd v1.2.1-0.20190711201753-f2b6c31d0fa7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac h1:PThQaO4yCvJzJBUW1XoFQxLotWRhvX2fgljJX8yrhFI=
 github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260 h1:XGyg7oTtD0DoRFhbpV6x1WfV0flKC4UxXU7ab1zC08U=


### PR DESCRIPTION
Signed-off-by: Maksym Pavlenko <makpav@amazon.com>

*Description of changes:*
This PR updates getting started guide with info about containerd's default labels.
It allows to specify `--runtime` and `--snapshotter` flags just once when creating a namespace (or add labels to an existing one), and then just use `ctr` without these params.

ref: https://github.com/containerd/containerd/pull/3403

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
