### PR TITLE
Sync quickstart and getting-started docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,7 +66,7 @@ optional `vsock` feature using the `--features vsock` flag.
 > seccomp, you must adjust your seccomp profile for these changes.
 
 ```bash
-git checkout v0.16.0 # latest released tag
+git checkout v0.17.0 # latest released tag
 cargo build --release --features vsock # --target x86_64-unknown-linux-gnu
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -105,6 +105,7 @@ Once you have built the runtime, be sure to place the following binaries on your
 * `snapshotter/cmd/devmapper/devmapper_snapshotter`
 * `snapshotter/cmd/naive/naive_snapshotter`
 * `firecracker-control/cmd/containerd/firecracker-containerd`
+* `firecracker-control/cmd/containerd/firecracker-ctr`
 
 You can use the `make install` target to install the files to `/usr/local/bin`,
 or specify a different `INSTALLROOT` if you prefer another location.
@@ -151,6 +152,12 @@ state = "/run/firecracker-containerd"
 [debug]
   level = "debug"
 ```
+
+Also note the `firecracker-ctr` binary installed alongside the `firecracker-containerd`
+binary. `ctr` is containerd's standard cli client; `firecracker-ctr` is a build of `ctr`
+from the same version of containerd as `firecracker-containerd`, which ensures the two
+binaries are in sync with one another. While other builds of `ctr` may work with
+`firecracker-containerd`, use of `firecracker-ctr` will ensure compatibility.
 
 ### Configure containerd runtime plugin
 
@@ -224,7 +231,7 @@ $ sudo PATH=$PATH /usr/local/bin/firecracker-containerd \
 Pull an image
 
 ```bash
-$ sudo ctr --address /run/firecracker-containerd/containerd.sock images \
+$ sudo firecracker-ctr --address /run/firecracker-containerd/containerd.sock images \
   pull --snapshotter firecracker-naive \
   docker.io/library/busybox:latest
 ```
@@ -232,7 +239,7 @@ $ sudo ctr --address /run/firecracker-containerd/containerd.sock images \
 And start a container!
 
 ```bash
-$ sudo ctr --address /run/firecracker-containerd/containerd.sock \
+$ sudo firecracker-ctr --address /run/firecracker-containerd/containerd.sock \
   run --snapshotter firecracker-naive --runtime aws.firecracker --tty \
   docker.io/library/busybox:latest busybox-test
 ```
@@ -240,15 +247,15 @@ $ sudo ctr --address /run/firecracker-containerd/containerd.sock \
 Alternatively you can specify `--runtime` and `--snapshotter` just once when creating a new namespace using containerd's default labels:
 
 ```bash
-$ sudo ctr --address /run/firecracker-containerd/containerd.sock \
+$ sudo firecracker-ctr --address /run/firecracker-containerd/containerd.sock \
   namespaces create fc
 
-$ sudo ctr --address /run/firecracker-containerd/containerd.sock \
+$ sudo firecracker-ctr --address /run/firecracker-containerd/containerd.sock \
   namespaces label fc \
   containerd.io/defaults/runtime=aws.firecracker \
   containerd.io/defaults/snapshotter=firecracker-naive
 
-$ sudo ctr --address /run/firecracker-containerd/containerd.sock \
+$ sudo firecracker-ctr --address /run/firecracker-containerd/containerd.sock \
   -n fc \
   run --tty \
   docker.io/library/busybox:latest busybox-test

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -156,11 +156,11 @@ sudo firecracker-containerd --config /etc/firecracker-containerd/config.toml
 6. Open a new terminal, pull an image, and run a container!
 
 ```bash
-sudo ctr --address /run/firecracker-containerd/containerd.sock \
+sudo firecracker-ctr --address /run/firecracker-containerd/containerd.sock \
      image pull \
      --snapshotter firecracker-naive \
      docker.io/library/debian:latest
-sudo ctr --address /run/firecracker-containerd/containerd.sock \
+sudo firecracker-ctr --address /run/firecracker-containerd/containerd.sock \
      run \
      --snapshotter firecracker-naive \
      --runtime aws.firecracker \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,10 +46,10 @@ curl https://sh.rustup.rs -sSf | sh -s -- --verbose -y --default-toolchain 1.32.
 source $HOME/.cargo/env
 rustup target add x86_64-unknown-linux-musl
 
-# Check out Firecracker and build it from the v0.15.2 tag
+# Check out Firecracker and build it from the v0.17.0 tag
 git clone https://github.com/firecracker-microvm/firecracker.git
 cd firecracker
-git checkout v0.15.2
+git checkout v0.17.0
 cargo build --release --features vsock --target x86_64-unknown-linux-musl
 sudo cp target/x86_64-unknown-linux-musl/release/{firecracker,jailer} /usr/local/bin
 

--- a/firecracker-control/cmd/containerd/Makefile
+++ b/firecracker-control/cmd/containerd/Makefile
@@ -20,17 +20,24 @@ GOSUM := $(GOMOD:.mod=.sum)
 
 all: build
 
-build: firecracker-containerd
+build: firecracker-containerd firecracker-ctr
+
 firecracker-containerd: $(SRC) $(GOMOD) $(GOSUM)
 	go build -v -o firecracker-containerd
 
-install: firecracker-containerd
+firecracker-ctr: $(GOMOD) $(GOSUM)
+	GOBIN=$(CURDIR) go install -tags=no_cri github.com/containerd/containerd/cmd/ctr
+	mv ctr firecracker-ctr
+
+install: firecracker-containerd firecracker-ctr
 	install -D -o root -g root -m755 -t $(INSTALLROOT)/bin firecracker-containerd
+	install -D -o root -g root -m755 -t $(INSTALLROOT)/bin firecracker-ctr
 
 test: $(SOURCES)
 	go test ./... $(EXTRAGOARGS)
 
 clean:
 	- rm -f firecracker-containerd
+	- rm -f firecracker-ctr
 
 .PHONY: all build install test clean

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -61,6 +61,5 @@ configuration file has the following fields:
 * `debug` (optional) - Enable debug-level logging from the runtime.
 
 ## Usage
-
-Can invoke by downloading an image and doing 
-`ctr run --runtime aws.firecracker <image-name> <id>`
+See our [Getting Started Guide](../docs/getting-started.md) for details on how to use 
+the aws.firecracker runtime.

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -110,9 +110,8 @@ RUN --mount=type=cache,from=build-base,source=/home/builder/go/pkg/mod,target=/h
 RUN --mount=type=cache,from=build-base,source=/home/builder/go/pkg/mod,target=/home/builder/go/pkg/mod \
   cd firecracker-containerd/firecracker-control/cmd/containerd/ \
   && make \
-  && cp \
-  firecracker-containerd \
-  /output/containerd
+  && cp firecracker-containerd /output/containerd \
+  && cp firecracker-ctr /output/ctr
 
 
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -164,12 +164,7 @@ ENV PATH="/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/loca
 	FICD_LOG_DIR="/var/log/firecracker-containerd-test"
 ENV FICD_SNAPSHOTTER_OUTFILE="${FICD_LOG_DIR}/snapshotter.out" \
 	FICD_CONTAINERD_OUTFILE="${FICD_LOG_DIR}/containerd.out"
-RUN mkdir -p /etc/apt/sources.list.d \
-	&& echo "deb http://ftp.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/stretch-backports.list \
-	&& apt-get update \
-	&& apt-get --target-release stretch-backports install --yes --no-install-recommends \
-		golang-go \
-	&& apt-get install --yes --no-install-recommends \
+RUN apt-get update && apt-get install --yes --no-install-recommends \
 		build-essential \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
The commits here:
* Build a `firecracker-ctr` binary from the same version of our `firecracker-containerd` binary to ensure the two are at compatible versions. The docs are updated to specify use of `firecracker-ctr` over plain `ctr`.
* Specify in the docs that Firecracker needs to be built from the 0.17.0 tag, which we recently updated to use.

As discussed elsewhere, I originally attempted to build the `firecracker-ctr` binary by adding `containerd` as a submodule and put a replace directive in our go.mod file pointing to the submodule. This actually worked but was extremely ugly as use of the replace directive requires that the replacement directory have a go.mod file, which in turn requires us to run `go mod init` in our containerd submodule, which itself had other side effects, etc. The solution instead is to just use `go install` to install the `ctr` binary using the version in our `go.mod` file and rename it to `firecracker-ctr`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
