### PR TITLE
 Fail runtime integ-test if any single test fails. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ $(TEST_SUBDIRS):
 
 integ-test: $(INTEG_TEST_SUBDIRS)
 
-$(INTEG_TEST_SUBDIRS): docker-images
+$(INTEG_TEST_SUBDIRS): test-images
 	$(MAKE) -C $(patsubst integ-test-%,%,$@) integ-test
 
 runc-builder: runc-builder-stamp

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -53,7 +53,7 @@ integ-test:
 			--env ENABLE_ISOLATED_TESTS=1 \
 			--workdir="/firecracker-containerd/runtime" \
 			localhost/firecracker-containerd-naive-integ-test:$(DOCKER_IMAGE_TAG) \
-			"go test $(EXTRAGOARGS) -run \"^$(TESTNAME)$$\""; \
+			"go test $(EXTRAGOARGS) -run \"^$(TESTNAME)$$\"" || exit 1; \
 	)
 
 clean:


### PR DESCRIPTION
Before this, the runtime integ-test target would only be marked as failed if
the last test failed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I also included a separate commit here fixing a typo from #227 where the top-level integ-test target used the wrong dependency name.