### PR TITLE
Pass the logger to a new stubDriveHandler correctly

### DIFF
--- a/runtime/drive_handler.go
+++ b/runtime/drive_handler.go
@@ -54,6 +54,7 @@ type stubDriveHandler struct {
 func newStubDriveHandler(path string, logger *logrus.Entry) stubDriveHandler {
 	return stubDriveHandler{
 		RootPath: path,
+		logger:   logger,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

None

*Description of changes:*

newStubDriveHandler is not passing the logger, while it is taking.

(wouldn't it be caught by static analysis?)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
