### PR TITLE
Make integration tests distro-agnostic

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -127,6 +127,8 @@ FROM alpine:3.8 as firecracker-vm-root
 COPY _submodules/runc/runc /usr/local/bin
 COPY --from=firecracker-containerd-build /output/agent /usr/local/bin/
 ADD tools/docker/fc-agent.start /etc/local.d/fc-agent.start
+RUN mkdir -p /var/firecracker-containerd-test/scripts/
+ADD tools/docker/scripts/*  /var/firecracker-containerd-test/scripts/
 RUN apk add openrc \
 	&& ln -s /etc/init.d/local /etc/runlevels/default/local \
 	&& ln -s /etc/init.d/cgroups /etc/runlevels/default/cgroups \

--- a/tools/docker/scripts/lsblk.sh
+++ b/tools/docker/scripts/lsblk.sh
@@ -1,0 +1,32 @@
+#! /bin/sh
+# tiny lsblk(8) equivalent to make integration tests distro-agnostic
+set -eu
+
+echo 'NAME MAJ:MIN RM      SIZE RO | MAGIC'
+
+for name in $(ls /sys/block)
+do
+    # Ignore loop devices
+    case "$name" in
+	loop*)
+	    continue
+	    ;;
+    esac
+
+    # The size entry returns the number of sectors,
+    # not the number of bytes.
+    # https://unix.stackexchange.com/a/301403
+    bytes=$(($(cat /sys/block/$name/size) * 512))
+
+    # Show the first 8 bytes, where our stub device files have own signatures
+    # https://github.com/firecracker-microvm/firecracker-containerd/blob/2578f3df9d899aa48decb39c9f7f23fa41635ede/internal/common.go#L67
+    magic=$(head -c 8 /dev/$name | od -A n -t u1)
+
+    printf "%-4s %-7s %2d %8dB %2d | %s\n" \
+	   "$name" \
+	   $(cat /sys/block/$name/dev) \
+	   $(cat /sys/block/$name/removable) \
+	   "$bytes" \
+	   $(cat /sys/block/$name/ro) \
+	   "$magic"
+done


### PR DESCRIPTION
*Issue #, if available:*

#203

*Description of changes:*

This change introduces our own lsblk(8) equivalent, which makes
the integration test distro-agonostic and be able to run without
util-linux.

Fixes #203.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
