### PR TITLE
Include eventbridge on "make test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-SUBDIRS:=agent runtime snapshotter internal examples firecracker-control/cmd/containerd
+SUBDIRS:=agent runtime snapshotter internal examples firecracker-control/cmd/containerd eventbridge
 TEST_SUBDIRS:=$(addprefix test-,$(SUBDIRS))
 INTEG_TEST_SUBDIRS:=$(addprefix integ-test-,$(SUBDIRS))
 


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

eventbridge/Makefile is mostly empty for common tasks such as "all" or
"integ-test", but "test" runs go test, which should be trigged by
"make test" on the root directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
