### PR TITLE
Don't patch non-stub drives

### DIFF
--- a/runtime/service.go
+++ b/runtime/service.go
@@ -665,6 +665,7 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 	}
 
 	// a micro VM must know all drives
+	// nolint: gocritic
 	cfg.Drives = append(stubDrives, driveBuilder.Build()...)
 
 	// Setup network interfaces

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -594,7 +594,7 @@ func (s *service) createStubDrives(stubDriveCount int) ([]models.Drive, error) {
 		return nil, errors.Wrap(err, "failed to retrieve stub drive paths")
 	}
 
-	stubDrives := make([]models.Drive, 0)
+	stubDrives := make([]models.Drive, 0, stubDriveCount)
 	for i, path := range paths {
 		stubDrives = append(stubDrives, models.Drive{
 			DriveID:      firecracker.String(fmt.Sprintf("stub%d", i)),


### PR DESCRIPTION
*Issue #, if available:*

Related to, but may need more changes to actually fix #230

*Description of changes:*

Currently the drive handler knows non-stub drives (root drive). Because of that PatchStubDrive() replace non-stub drives, once all stub drives are patched.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
