### PR TITLE
Add log folder cleanup

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -58,5 +58,6 @@ integ-test:
 
 clean:
 	- rm -f containerd-shim-aws-firecracker
+	- rm -rf logs
 
 .PHONY: all runtime clean install test integ-test


### PR DESCRIPTION
When running isolated tests a logs folder is created but is not properly
cleaned up. This fix alleviates that by removing the folder

Signed-off-by: xibz <impactbchang@gmail.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
