### PR TITLE
Make sure the error message regarding stub drives is clear

### DIFF
--- a/runtime/drive_handler.go
+++ b/runtime/drive_handler.go
@@ -127,9 +127,9 @@ func (h *stubDriveHandler) createStubDrive(driveID, path string) error {
 
 // SetDrives will set the given drives and the offset to which the stub drives
 // start.
-func (h *stubDriveHandler) SetDrives(offset int64, d []models.Drive) {
+func (h *stubDriveHandler) SetDrives(d []models.Drive) {
 	h.drives = d
-	h.stubDriveIndex = offset
+	h.stubDriveIndex = 0
 }
 
 // GetDrives returns the associated stub drives

--- a/runtime/drive_handler_test.go
+++ b/runtime/drive_handler_test.go
@@ -40,10 +40,9 @@ func TestStubDriveHandler(t *testing.T) {
 	}()
 
 	logger := log.G(context.Background())
-	handler := newStubDriveHandler(tempPath, logger)
-	paths, err := handler.StubDrivePaths(5)
+	handler, err := newStubDriveHandler(tempPath, logger, 5)
 	assert.NoError(t, err)
-	assert.Equal(t, 5, len(paths))
+	assert.Equal(t, 5, len(handler.GetDrives()))
 
 	infos, err := ioutil.ReadDir(tempPath)
 	assert.NoError(t, err)
@@ -236,9 +235,11 @@ func TestCreateStubDrive(t *testing.T) {
 		c := c // see https://github.com/kyoh86/scopelint/issues/4
 		t.Run(c.Name, func(t *testing.T) {
 			logger := log.G(context.Background())
-			handler := newStubDriveHandler(path, logger)
+			handler, err := newStubDriveHandler(path, logger, 0)
+			assert.NoError(t, err)
+
 			stubDrivePath := filepath.Join(path, c.Name)
-			err := handler.createStubDrive(c.DriveID, stubDrivePath)
+			err = handler.createStubDrive(c.DriveID, stubDrivePath)
 			assert.Equal(t, c.ExpectedError, err != nil, "invalid error: %v", err)
 
 			info, err := os.Stat(stubDrivePath)

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -650,7 +650,7 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create stub drives")
 	}
-	s.stubDriveHandler.SetDrives(0, stubDrives)
+	s.stubDriveHandler.SetDrives(stubDrives)
 
 	var driveBuilder firecracker.DrivesBuilder
 	// Create non-stub drives

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -715,9 +715,11 @@ func (s *service) Create(requestCtx context.Context, request *taskAPI.CreateTask
 	for _, mnt := range request.Rootfs {
 		driveID, err = s.stubDriveHandler.PatchStubDrive(requestCtx, s.machine, mnt.Source)
 		if err != nil {
+			if err == ErrDrivesExhausted {
+				return nil, errors.Wrapf(errdefs.ErrUnavailable, "no remaining stub drives to be used")
+			}
 			return nil, errors.Wrapf(err, "failed to patch stub drive")
 		}
-
 	}
 
 	ociConfigBytes, err := bundleDir.OCIConfig().Bytes()

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -725,6 +725,6 @@ func TestCreateTooManyContainers_Isolated(t *testing.T) {
 
 	// When we reuse a VM explicitly, we cannot start multiple containers unless we pre-allocate stub drives.
 	_, err = c2.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, &stdout, &stderr)))
-	assert.Equal("failed to patch stub drive: There are no remaining drives to be used: unknown", err.Error())
+	assert.Equal("no remaining stub drives to be used: unavailable: unknown", err.Error())
 	require.Error(t, err)
 }

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/process"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/firecracker-microvm/firecracker-containerd/firecracker-control"
@@ -675,4 +676,55 @@ func TestCreateContainerWithSameName_Isolated(t *testing.T) {
 
 	vmID := fmt.Sprintf("same-vm-%d", time.Now().UnixNano())
 	testCreateContainerWithSameName(t, vmID)
+}
+
+func TestCreateTooManyContainers_Isolated(t *testing.T) {
+	internal.RequiresIsolation(t)
+	assert := assert.New(t)
+
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+
+	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	defer client.Close()
+
+	image, err := client.Pull(ctx, guestDockerImage, containerd.WithPullUnpack, containerd.WithPullSnapshotter(naiveSnapshotterName))
+	require.NoError(t, err, "failed to pull image %s, is the the %s snapshotter running?", guestDockerImage, naiveSnapshotterName)
+
+	runEchoHello := containerd.WithNewSpec(oci.WithProcessArgs("echo", "-n", "hello"), firecrackeroci.WithVMID("reuse-same-vm"))
+
+	c1, err := client.NewContainer(ctx,
+		"c1",
+		containerd.WithSnapshotter(naiveSnapshotterName),
+		containerd.WithNewSnapshot("c1", image),
+		runEchoHello,
+	)
+	assert.Equal("hello", startAndWaitTask(ctx, t, c1))
+	require.NoError(t, err, "failed to create a container")
+
+	defer func() {
+		err = c1.Delete(ctx, containerd.WithSnapshotCleanup)
+		require.NoError(t, err, "failed to delete a container")
+	}()
+
+	c2, err := client.NewContainer(ctx,
+		"c2",
+		containerd.WithSnapshotter(naiveSnapshotterName),
+		containerd.WithNewSnapshot("c2", image),
+		runEchoHello,
+	)
+	require.NoError(t, err, "failed to create a container")
+
+	defer func() {
+		err := c2.Delete(ctx, containerd.WithSnapshotCleanup)
+		require.NoError(t, err, "failed to delete a container")
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	// When we reuse a VM explicitly, we cannot start multiple containers unless we pre-allocate stub drives.
+	_, err = c2.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, &stdout, &stderr)))
+	assert.Equal("failed to patch stub drive: There are no remaining drives to be used: unknown", err.Error())
+	require.Error(t, err)
 }

--- a/runtime/service_test.go
+++ b/runtime/service_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/firecracker-microvm/firecracker-containerd/internal"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/vm"
 	"github.com/firecracker-microvm/firecracker-containerd/proto"
 	"github.com/firecracker-microvm/firecracker-go-sdk"
 	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
@@ -216,7 +217,7 @@ func TestBuildVMConfiguration(t *testing.T) {
 			assert.NoError(t, err)
 			defer os.RemoveAll(tempDir)
 
-			svc.stubDriveHandler = newStubDriveHandler(tempDir, svc.logger)
+			svc.shimDir = vm.Dir(tempDir)
 			// For values that remain constant between tests, they are written here
 			tc.expectedCfg.SocketPath = svc.shimDir.FirecrackerSockPath()
 			tc.expectedCfg.VsockDevices = []firecracker.VsockDevice{{Path: "root", CID: svc.machineCID}}
@@ -293,7 +294,7 @@ func TestDebugConfig(t *testing.T) {
 		stubDrivePath := filepath.Join(path, fmt.Sprintf("%d", i))
 		err := os.MkdirAll(stubDrivePath, os.ModePerm)
 		assert.NoError(t, err, "failed to create stub drive path")
-		c.service.stubDriveHandler = newStubDriveHandler(stubDrivePath, c.service.logger)
+		c.service.shimDir = vm.Dir(stubDrivePath)
 		req := proto.CreateVMRequest{}
 
 		cfg, err := c.service.buildVMConfiguration(&req)


### PR DESCRIPTION

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

Related, but doesn't fix #243

*Description of changes:*

While we don't support the use-case right now, the error message
regarding the lack of free stub drives should be clear for customers.

This change also cleans up drive_handler.go.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
