### PR TITLE
Use docker's --init as is

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -52,6 +52,7 @@ integ-test:
 			--volume $(CURDIR)/logs:/var/log/firecracker-containerd-test \
 			--env ENABLE_ISOLATED_TESTS=1 \
 			--workdir="/firecracker-containerd/runtime" \
+			--init \
 			localhost/firecracker-containerd-naive-integ-test:$(DOCKER_IMAGE_TAG) \
 			"go test $(EXTRAGOARGS) -run \"^$(TESTNAME)$$\"" || exit 1; \
 	)

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -205,22 +205,11 @@ ENTRYPOINT ["/bin/bash", "-c"]
 # Test image that starts up containerd and the naive snapshotter. The default CMD will drop to a bash shell. Overrides
 # to CMD will be provided appended to /bin/bash -c
 FROM firecracker-containerd-test as firecracker-containerd-naive-integ-test
-# Install tini init to handle zombies created by our double-forked shims.
-# Unfortunately, we need to do this rather than only use docker's "--init" flag because docker
-# currently puts its default init binary at /dev/init, but we need to bind-mount /dev from
-# the host in order for the snapshotter to work.
-# This should no longer be an issue after github.com/moby/moby #37665 is released.
-RUN curl --silent --show-error --retry 3 --max-time 30 --location --output tini \
-  "https://github.com/krallin/tini/releases/download/v0.18.0/tini" \
-  && echo "12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855 tini" | sha256sum -c - \
-  && mv tini /sbin/tini \
-  && chmod +x /sbin/tini
-
 COPY tools/docker/naive-snapshotter/config.toml /etc/containerd/config.toml
 COPY tools/docker/naive-snapshotter/entrypoint.sh /entrypoint
 RUN mkdir -p /var/lib/firecracker-containerd/naive
 
-ENTRYPOINT ["/sbin/tini", "--", "/entrypoint"]
+ENTRYPOINT ["/entrypoint"]
 CMD ["exec /bin/bash"]
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Docker no longer uses /dev/init as init. So, we can use --init instead
of installing our own tini binary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
