### PR TITLE
Upgrade to Firecracker v0.18.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,11 @@ demo-network: $(PTP_BIN) $(HOSTLOCAL_BIN) $(TC_REDIRECT_TAP_BIN) $(FCNET_CONFIG)
 .PHONY: firecracker
 firecracker: $(FIRECRACKER_BIN) $(JAILER_BIN)
 
+.PHONY: install-firecracker
+install-firecracker: firecracker
+	install -D -o root -g root -m755 -t $(INSTALLROOT)/bin $(FIRECRACKER_BIN)
+	install -D -o root -g root -m755 -t $(INSTALLROOT)/bin $(JAILER_BIN)
+
 $(FIRECRACKER_DIR)/Cargo.toml:
 	git submodule update --init --recursive $(FIRECRACKER_DIR)
 
@@ -182,7 +187,7 @@ $(FIRECRACKER_BIN) $(JAILER_BIN): $(FIRECRACKER_DIR)/Cargo.toml tools/firecracke
 		-e HOME=/tmp \
 		--workdir /src \
 		localhost/$(FIRECRACKER_BUILDER_NAME):$(DOCKER_IMAGE_TAG) \
-		cargo build --release --features vsock --target $(FIRECRACKER_TARGET)
+		cargo build --release --target $(FIRECRACKER_TARGET)
 
 .PHONY: firecracker-clean
 firecracker-clean:

--- a/agent/main.go
+++ b/agent/main.go
@@ -26,7 +26,6 @@ import (
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
 	"github.com/containerd/containerd/sys/reaper"
 	"github.com/containerd/ttrpc"
-	"github.com/mdlayher/vsock"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -34,6 +33,7 @@ import (
 
 	"github.com/firecracker-microvm/firecracker-containerd/eventbridge"
 	"github.com/firecracker-microvm/firecracker-containerd/internal/event"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/vm"
 )
 
 const (
@@ -93,8 +93,8 @@ func main() {
 
 	// Run ttrpc over vsock
 
-	log.G(shimCtx).WithField("port", port).Info("listening to vsock")
-	listener, err := vsock.Listen(uint32(port))
+	vsockLogger := log.G(shimCtx).WithField("port", port)
+	listener, err := vm.VSockListener(shimCtx, vsockLogger, uint32(port))
 	if err != nil {
 		log.G(shimCtx).WithError(err).Fatalf("failed to listen to vsock on port %d", port)
 	}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,27 +50,6 @@ You need to have the following things in order to use firecracker-containerd:
 
 ## Setup
 
-### Build Firecracker with `vsock` support
-
-Clone the repository to your computer in a directory of your choice:
-
-```bash
-git clone https://github.com/firecracker-microvm/firecracker.git
-```
-Change into the new directory, and build with Cargo.  Make sure to enable the
-optional `vsock` feature using the `--features vsock` flag.
-
-> Note: Firecracker normally builds a statically-linked binary with musl libc.
-> On Amazon Linux 2, you must specify `--target x86_64-unknown-linux-gnu`
-> because musl libc is not available.  Switching to this target changes the set
-> of syscalls invoked by Firecracker.  If you intend to jail Firecracker using
-> seccomp, you must adjust your seccomp profile for these changes.
-
-```bash
-git checkout v0.17.0 # latest released tag
-cargo build --release --features vsock # --target x86_64-unknown-linux-gnu
-```
-
 ### Download appropriate kernel
 
 You can use the following kernel:
@@ -90,7 +69,7 @@ Clone this repository to your computer in a directory of your choice.
 We recommend choosing a directory outside of `$GOPATH` or `~/go`.
 
 ```bash
-git clone https://github.com/firecracker-microvm/firecracker-containerd
+git clone --recurse-submodules https://github.com/firecracker-microvm/firecracker-containerd
 make all
 ```
 
@@ -109,6 +88,21 @@ Once you have built the runtime, be sure to place the following binaries on your
 * `firecracker-control/cmd/containerd/firecracker-ctr`
 
 You can use the `make install` target to install the files to `/usr/local/bin`,
+or specify a different `INSTALLROOT` if you prefer another location.
+
+### Build Firecracker
+
+From the repository cloned in the previous step, run
+```bash
+make firecracker
+```
+
+Once you have built firecracker, be sure to place the following binaries on your
+`$PATH`:
+* `_submodules/firecracker/target/x86_64-unknown-linux-musl/release/firecracker`
+* `_submodules/firecracker/target/x86_64-unknown-linux-musl/release/jailer`
+
+You can use the `make install-firecracker` target to install the files to `/usr/local/bin`,
 or specify a different `INSTALLROOT` if you prefer another location.
 
 ### Build a root filesystem

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,20 +41,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get \
   git \
   curl \
   e2fsprogs \
-  musl-tools \
   util-linux
-
-# Install Rust
-curl https://sh.rustup.rs -sSf | sh -s -- --verbose -y --default-toolchain 1.32.0
-source $HOME/.cargo/env
-rustup target add x86_64-unknown-linux-musl
-
-# Check out Firecracker and build it from the v0.17.0 tag
-git clone https://github.com/firecracker-microvm/firecracker.git
-cd firecracker
-git checkout v0.17.0
-cargo build --release --features vsock --target x86_64-unknown-linux-musl
-sudo cp target/x86_64-unknown-linux-musl/release/{firecracker,jailer} /usr/local/bin
 
 cd ~
 
@@ -87,9 +74,8 @@ cd ~
 git clone https://github.com/firecracker-microvm/firecracker-containerd.git
 cd firecracker-containerd
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y dmsetup
-sg docker -c 'make all image'
-sudo make install
-sudo make demo-network
+sg docker -c 'make all image firecracker'
+sudo make install install-firecracker demo-network
 
 cd ~
 
@@ -142,9 +128,6 @@ sudo tee /etc/containerd/firecracker-runtime.json <<EOF
   }]
 }
 EOF
-
-# Enable vhost-vsock
-sudo modprobe vhost-vsock
 ```
 
 4. Open a new terminal and start the `naive_snapshotter` program in the

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -40,7 +40,7 @@ integ-test:
 		--env EXTRAGOARGS="${EXTRAGOARGS}" \
 		--workdir="/firecracker-containerd/examples" \
 		localhost/firecracker-containerd-naive-integ-test:${DOCKER_IMAGE_TAG} \
-		"make examples && make testtap && ./taskworkflow -ip $(TEST_IP)$(TEST_SUBNET) -gw $(TEST_GATEWAY)"
+		"make examples && make testtap && sleep 3 && ./taskworkflow -ip $(TEST_IP)$(TEST_SUBNET) -gw $(TEST_GATEWAY)"
 
 TEST_GATEWAY?=172.16.0.1
 TEST_IP?=172.16.0.2

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/docker/go-events v0.0.0-20170721190031-9461782956ad // indirect
 	github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 // indirect
 	github.com/docker/go-units v0.3.3
-	github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20190912001513-a4afb10dd9d7
+	github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20190920221449-6afccc1d121f
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/godbus/dbus v0.0.0-20181025153459-66d97aec3384 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 h1:X0fj836zx99zF
 github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20190912001513-a4afb10dd9d7 h1:9suT/hW4u++sJdgHLU1duoiRuRHwrGf/RKSKG2prsJY=
-github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20190912001513-a4afb10dd9d7/go.mod h1:tVXziw7GjioCKVjI5/agymYxUaqJM6q7cp9e6kwjo8Q=
+github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20190920221449-6afccc1d121f h1:G81Ey0lQDWCqwdIRq6aLN5RyYbnSDx2O7FKFl433shc=
+github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20190920221449-6afccc1d121f/go.mod h1:tVXziw7GjioCKVjI5/agymYxUaqJM6q7cp9e6kwjo8Q=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb h1:D4uzjWwKYQ5XnAvUbuvHW93esHg7F8N/OYeBBcJoTr0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=

--- a/internal/common.go
+++ b/internal/common.go
@@ -31,6 +31,9 @@ const (
 
 	// FirecrackerSockName is the name of the Firecracker VMM API socket
 	FirecrackerSockName = "firecracker.sock"
+	// FirecrackerVSockName is the name of the Firecracker VSock unix path used for communication
+	// between the runtime and the agent
+	FirecrackerVSockName = "firecracker.vsock"
 	// FirecrackerLogFifoName is the name of the Firecracker VMM log FIFO
 	FirecrackerLogFifoName = "fc-logs.fifo"
 	// FirecrackerMetricsFifoName is the name of the Firecracker VMM metrics FIFO

--- a/internal/vm/dir.go
+++ b/internal/vm/dir.go
@@ -83,6 +83,12 @@ func (d Dir) FirecrackerSockPath() string {
 	return filepath.Join(d.RootPath(), internal.FirecrackerSockName)
 }
 
+// FirecrackerVSockPath returns the path to the vsock unix socket that the runtime uses
+// to communicate with the VM agent.
+func (d Dir) FirecrackerVSockPath() string {
+	return filepath.Join(d.RootPath(), internal.FirecrackerVSockName)
+}
+
 // FirecrackerLogFifoPath returns the path to the FIFO at which the firecracker VMM writes
 // its logs
 func (d Dir) FirecrackerLogFifoPath() string {

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -551,7 +551,7 @@ func TestStubBlockDevices_Isolated(t *testing.T) {
 
 		const expectedOutput = `
 NAME MAJ:MIN RM      SIZE RO | MAGIC
-vda  254:0    0 53633024B  0 |  104 115 113 115 128  28   0   0
+vda  254:0    0 53641216B  0 |  104 115 113 115 128  28   0   0
 vdb  254:16   0        0B  0 | 
 vdc  254:32   0      512B  0 |  214 244 216 245 215 177 177 177
 vdd  254:48   0      512B  0 |  214 244 216 245 215 177 177 177

--- a/tools/docker/Dockerfile.firecracker-builder
+++ b/tools/docker/Dockerfile.firecracker-builder
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM rust:1.32-stretch
+FROM rust:1.35-stretch
 
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get install --yes --no-install-recommends \


### PR DESCRIPTION
This consists of:
* Upgrading to the new Go SDK version.
* Using the new vsock interface with unix-domain socket backend on the host.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

Closes #259 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
