### PR TITLE
Fix containerd binary

### DIFF
--- a/firecracker-control/cmd/containerd/main.go
+++ b/firecracker-control/cmd/containerd/main.go
@@ -46,6 +46,10 @@ import (
 	_ "github.com/containerd/containerd/runtime/v2"
 	_ "github.com/containerd/containerd/runtime/v2/runc/options"
 
+	// Snapshotters
+	_ "github.com/containerd/containerd/snapshots/devmapper"
+	_ "github.com/containerd/containerd/snapshots/overlay"
+
 	// Register fc-control plugin
 	_ "github.com/firecracker-microvm/firecracker-containerd/firecracker-control"
 )


### PR DESCRIPTION
*Description of changes:*
containerd needs at least one snapshotter to be registered.
Otherwise dependent services will fail to register:

```
INFO[2019-09-26T18:20:47.828960162Z] loading plugin "io.containerd.metadata.v1.bolt"...  type=io.containerd.metadata.v1
WARN[2019-09-26T18:20:47.828993788Z] failed to load plugin io.containerd.metadata.v1.bolt  error="no plugins registered for io.containerd.snapshotter.v1: not found"
INFO[2019-09-26T18:20:47.829017391Z] loading plugin "io.containerd.differ.v1.walking"...  type=io.containerd.differ.v1
WARN[2019-09-26T18:20:47.829031956Z] failed to load plugin io.containerd.differ.v1.walking  error="no plugins registered for io.containerd.snapshotter.v1: not found"
INFO[2019-09-26T18:20:47.829046365Z] loading plugin "io.containerd.gc.v1.scheduler"...  type=io.containerd.gc.v1
WARN[2019-09-26T18:20:47.829061020Z] failed to load plugin io.containerd.gc.v1.scheduler  error="no plugins registered for io.containerd.snapshotter.v1: not found"
INFO[2019-09-26T18:20:47.829075577Z] loading plugin "io.containerd.service.v1.containers-service"...  type=io.containerd.service.v1
WARN[2019-09-26T18:20:47.829091062Z] failed to load plugin io.containerd.service.v1.containers-service  error="no plugins registered for io.containerd.snapshotter.v1: not found"
INFO[2019-09-26T18:20:47.829105788Z] loading plugin "io.containerd.service.v1.content-service"...  type=io.containerd.service.v1
WARN[2019-09-26T18:20:47.829118517Z] failed to load plugin io.containerd.service.v1.content-service  error="no plugins registered for io.containerd.snapshotter.v1: not found"
INFO[2019-09-26T18:20:47.829133451Z] loading plugin "io.containerd.service.v1.diff-service"...  type=io.containerd.service.v1
WARN[2019-09-26T18:20:47.829157061Z] failed to load plugin io.containerd.service.v1.diff-service  error="could not load required differ due plugin init error: walking: no plugins registered for io.containerd.snapshotter.v1: not found"
```

Currently:
```
sudo ./firecracker-ctr plugins ls
TYPE                         ID                    PLATFORMS      STATUS
io.containerd.content.v1     content               -              ok
io.containerd.metadata.v1    bolt                  -              error
io.containerd.differ.v1      walking               -              error
io.containerd.gc.v1          scheduler             -              error
io.containerd.service.v1     containers-service    -              error
io.containerd.service.v1     content-service       -              error
io.containerd.service.v1     diff-service          -              error
io.containerd.service.v1     images-service        -              error
io.containerd.service.v1     leases-service        -              error
io.containerd.service.v1     namespaces-service    -              error
io.containerd.service.v1     snapshots-service     -              error
io.containerd.runtime.v1     linux                 linux/amd64    error
io.containerd.runtime.v2     task                  linux/amd64    error
io.containerd.monitor.v1     cgroups               linux/amd64    ok
io.containerd.service.v1     tasks-service         -              error
io.containerd.service.v1     fc-control            -              ok
io.containerd.internal.v1    restart               -              error
io.containerd.grpc.v1        containers            -              error
io.containerd.grpc.v1        content               -              error
io.containerd.grpc.v1        diff                  -              error
io.containerd.grpc.v1        events                -              ok
io.containerd.grpc.v1        healthcheck           -              ok
io.containerd.grpc.v1        images                -              error
io.containerd.grpc.v1        leases                -              error
io.containerd.grpc.v1        namespaces            -              error
io.containerd.internal.v1    opt                   -              ok
io.containerd.grpc.v1        snapshots             -              error
io.containerd.grpc.v1        tasks                 -              error
io.containerd.grpc.v1        version               -              ok
io.containerd.grpc.v1        fc-control-service    -              ok

sudo ./firecracker-ctr ns ls
ctr: unknown service containerd.services.namespaces.v1.Namespaces: not implemented
```

Signed-off-by: Maksym Pavlenko <makpav@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
