### PR TITLE
Specify unix socket paths as relative paths.

### DIFF
--- a/firecracker-control/local.go
+++ b/firecracker-control/local.go
@@ -280,6 +280,12 @@ func (s *local) newShim(ns, vmID, containerdAddress string, shimSocket *net.Unix
 		return nil, err
 	}
 
+	// note: The working dir of the shim has an effect on the length of the path
+	// needed to specify various unix sockets that the shim uses to communicate
+	// with the firecracker VMM and guest agent within. The length of that path
+	// has a relatively low limit (usually 108 chars), so modifying the working
+	// dir should be done with caution. See internal/vm/dir.go for the path
+	// definitions.
 	cmd.Dir = shimDir.RootPath()
 
 	shimSocketFile, err := shimSocket.File()

--- a/internal/vm/dir_test.go
+++ b/internal/vm/dir_test.go
@@ -40,9 +40,9 @@ func TestShimDir(t *testing.T) {
 		{name: "id with ?", ns: "test", id: "?", outErr: `invalid vm id: identifier "?" must match`},
 		{name: "id with *", ns: "test", id: "*", outErr: `invalid vm id: identifier "*" must match`},
 		{name: "id with ,", ns: "test", id: ",", outErr: `invalid vm id: identifier "," must match`},
-		{name: "valid", ns: "ns", id: "1", outDir: "/var/run/firecracker-containerd/ns/1"},
-		{name: "valid with dashes", ns: "test-123", id: "123-456", outDir: "/var/run/firecracker-containerd/test-123/123-456"},
-		{name: "valid with dots", ns: "test.123", id: "123.456", outDir: "/var/run/firecracker-containerd/test.123/123.456"},
+		{name: "valid", ns: "ns", id: "1", outDir: "/run/firecracker-containerd/ns/1"},
+		{name: "valid with dashes", ns: "test-123", id: "123-456", outDir: "/run/firecracker-containerd/test-123/123-456"},
+		{name: "valid with dots", ns: "test.123", id: "123.456", outDir: "/run/firecracker-containerd/test.123/123.456"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This limits their length which prevents us from exceeding the max socket
length limit imposed by Linux.

Closes #264

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
