### PR TITLE
Add firewall plugin to demo-network configuration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,10 @@ HOSTLOCAL_BIN?=$(CNI_BIN_ROOT)/host-local
 $(HOSTLOCAL_BIN): $(CNI_BIN_ROOT)
 	GOBIN=$(CNI_BIN_ROOT) GO111MODULE=off go get -u github.com/containernetworking/plugins/plugins/ipam/host-local
 
+FIREWALL_BIN?=$(CNI_BIN_ROOT)/firewall
+$(FIREWALL_BIN): $(CNI_BIN_ROOT)
+	GOBIN=$(CNI_BIN_ROOT) GO111MODULE=off go get -u github.com/containernetworking/plugins/plugins/meta/firewall
+
 TC_REDIRECT_TAP_BIN?=$(CNI_BIN_ROOT)/tc-redirect-tap
 $(TC_REDIRECT_TAP_BIN): $(CNI_BIN_ROOT)
 	GOBIN=$(CNI_BIN_ROOT) go install github.com/firecracker-microvm/firecracker-go-sdk/cni/cmd/tc-redirect-tap
@@ -157,7 +161,7 @@ $(FCNET_CONFIG):
 	cp tools/demo/fcnet.conflist $(FCNET_CONFIG)
 
 .PHONY: demo-network
-demo-network: $(PTP_BIN) $(HOSTLOCAL_BIN) $(TC_REDIRECT_TAP_BIN) $(FCNET_CONFIG)
+demo-network: $(PTP_BIN) $(HOSTLOCAL_BIN) $(FIREWALL_BIN) $(TC_REDIRECT_TAP_BIN) $(FCNET_CONFIG)
 
 ##########################
 # Firecracker submodule

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,15 +38,11 @@ You need to have the following things in order to use firecracker-containerd:
   
   </details>
 * git
-* The Firecracker binary with the optional `vsock` feature enabled.  This
-  feature requires building from source; instructions for doing so are in the
-  [Firecracker getting started guide](https://github.com/firecracker-microvm/firecracker/blob/master/docs/getting-started.md#building-from-source)
 * A root filesystem image (you can use the one
   [described here](https://github.com/firecracker-microvm/firecracker/blob/master/docs/getting-started.md#running-firecracker)
   as `hello-rootfs.ext4`). 
 * A recent installation of [Docker CE](https://docker.com).
 * Go 1.11 or later, which you can download from [here](https://golang.org/dl/).
-* Rust 1.32 (and Cargo), which you can download from [here](https://rustup.rs/).
 
 ## Setup
 

--- a/tools/demo/fcnet.conflist
+++ b/tools/demo/fcnet.conflist
@@ -1,5 +1,5 @@
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "fcnet",
   "plugins": [
     {
@@ -11,6 +11,9 @@
         "subnet": "192.168.1.0/24",
         "resolvConf": "/etc/resolv.conf"
       }
+    },
+    {
+      "type": "firewall"
     },
     {
       "type": "tc-redirect-tap"


### PR DESCRIPTION
Fixes #265 

Also included a separate small commit to remove some outdated instructions in the getting-started guide that I noticed while working on this.

Tested by running the quickstart guide on a new `m5d.metal` w/ Debian Stretch and verifying I by default got internet access from firecracker-containerd containers even when the host had pre-existing Docker iptables rules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
