### PR TITLE
Disable setting the shim as a subreaper.

### DIFF
--- a/runtime/main.go
+++ b/runtime/main.go
@@ -35,5 +35,6 @@ func init() {
 func main() {
 	shim.Run(shimID, NewService, func(cfg *shim.Config) {
 		cfg.NoSetupLogger = true
+		cfg.NoSubreaper = true
 	})
 }


### PR DESCRIPTION
Setting the shim process as a subreaper appears to enable race conditions
when using the Go stdlib "os/exec" library to start child processes, resulting
in occasional "wait: no child processes" errors when subprocesses are run. There
are similar reports online of these race conditions, though I have not found
any open issues with golang at this time.

The issue is very inconsistent. I first encountered it randomly when manually
testing with `ctr` on an instance, where it seemed to happen about half the time
(specifically being triggered when the shim spawned CNI plugin child processes
via the Firecracker Go SDK). I managed to see it again in an automated test
case, but only once. However, when making this change to disable setting the
shim as a subreaper, I no longer ever got the "wait: no child processes" error
from the manual ctr commands where I could reproduce it more consistently, so I
have some degree of confidence that it fixes the issue at this time.

It seems safe to disable this as it only makes sense for the shim to be a
subreaper if it also actually runs a reaper loop (where it calls Wait with -1,
or handles SIGCHLD signals), but our shim doesn't do that, so even if it
inherited a child process from a descendant, it would not actually wait on it.
There also doesn't seem to be any reason for us to add a reaper loop; child
processes can just be reparented to init (or the next subreaper), which can
handle waiting on them without any harm.

The likely reason containerd sets this to true by default is that a caller of
runc actually would want to be a subreaper (due to the fact that the final
container process created by runc is several descendants below the caller).
However, we do not invoke runc from the shim, only from the VM agent (where we
actually do run a reaper loop).

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
