### PR TITLE
Disable setting the shim as a subreaper and a reaper.

### DIFF
--- a/runtime/main.go
+++ b/runtime/main.go
@@ -35,5 +35,12 @@ func init() {
 func main() {
 	shim.Run(shimID, NewService, func(cfg *shim.Config) {
 		cfg.NoSetupLogger = true
+
+		// Just let child processes get reparented to init
+		// (or the nearest subreaper). Enabling reaping
+		// creates races with `os.Exec` commands that expect
+		// to be able to wait on their child processes.
+		cfg.NoSubreaper = true
+		cfg.NoReaper = true
 	})
 }


### PR DESCRIPTION
By default, containerd shim code results in our shim process being a subreaper
and running a reaper loop that waits on any children when SIGCHLD signals are
delivered. This does not work for us because we have code that uses "os/exec" to
spawn child processes (in the go sdk specifically). When "os/exec" waits on
child processes, it is in a race with the reaper loop, causing occasional
"wait: no child processes" errors when running commands.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

Fixes #285 

Unfortunately, there aren't really any good ways to test this that aren't incredibly contrived. The only way I could get the error to occur consistently was changing the code to spawn tons of child processes, which we obviously don't want to do in actual merged code. I manually tested this change with that temporary change though and confirmed I could no longer reproduce the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
