### PR TITLE
Adds cleanup step for CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,3 +86,11 @@ steps:
     command: 'make -C examples integ-test'
     concurrency: 1
     concurrency_group: 'loop-device test'
+
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":wastebasket: cleanup"
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+    command: 'make clean'


### PR DESCRIPTION
image-builder may fail cleanup if a job has been cancelled. To fix this
we will manually run make clean at the end of every CI job.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
