### PR TITLE
Fix root tests to be ran as isolated tests

### DIFF
--- a/snapshotter/Makefile
+++ b/snapshotter/Makefile
@@ -20,6 +20,11 @@ SOURCES:=$(shell find . -name '*.go')
 GOMOD := $(shell go env GOMOD)
 GOSUM := $(GOMOD:.mod=.sum)
 DOCKER_IMAGE_TAG?=latest
+INTEG_TEST_SUFFIX := _Isolated
+INTEG_TESTNAMES=$(shell docker run --rm \
+		--workdir="/firecracker-containerd/snapshotter" \
+		localhost/firecracker-containerd-test:$(DOCKER_IMAGE_TAG) \
+		"go test -list . | sed '$$d' | grep $(INTEG_TEST_SUFFIX)")
 
 all: $(SUBDIRS)
 
@@ -30,18 +35,22 @@ install: $(SUBDIRS)
 	for d in $(SUBDIRS); do $(MAKE) -C $$d install; done
 
 test:
-	DISABLE_ROOT_TESTS=true go test ./... $(EXTRAGOARGS)
+	go test ./... $(EXTRAGOARGS)
 
 integ-test:
-	docker run --rm -it \
-		--privileged \
-		--ipc=host \
-		--volume /dev:/dev \
-		--volume /sys:/sys \
-		--volume /run/udev/control:/run/udev/control \
-		--workdir="/firecracker-containerd/snapshotter" \
-		localhost/firecracker-containerd-test:${DOCKER_IMAGE_TAG} \
-		"go test ./... $(EXTRAGOARGS)"
+	$(foreach TESTNAME,$(INTEG_TESTNAMES),\
+		docker run --rm -it \
+			--privileged \
+			--ipc=host \
+			--network=none \
+			--volume /dev:/dev \
+			--volume /run/udev/control:/run/udev/control \
+			--env ENABLE_ISOLATED_TESTS=1 \
+			--workdir="/firecracker-containerd/snapshotter" \
+			--init \
+			localhost/firecracker-containerd-naive-integ-test:$(DOCKER_IMAGE_TAG) \
+			"go test $(EXTRAGOARGS) -run \"^$(TESTNAME)$$\"" || exit 1; \
+	)
 
 clean:
 	for d in $(SUBDIRS); do $(MAKE) -C $$d clean; done

--- a/snapshotter/devmapper/pool_device_test.go
+++ b/snapshotter/devmapper/pool_device_test.go
@@ -53,8 +53,8 @@ const (
 // - Change v1 file to v2 on 'thin-1'
 // - Mount 'snap-1' and make sure test file is v1
 // - Unmount volumes and remove all devices
-func TestPoolDevice(t *testing.T) {
-	internal.RequiresRoot(t)
+func TestPoolDevice_Isolated(t *testing.T) {
+	internal.RequiresIsolation(t)
 	logrus.SetLevel(logrus.DebugLevel)
 	ctx := context.Background()
 

--- a/snapshotter/devmapper/snapshotter_test.go
+++ b/snapshotter/devmapper/snapshotter_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/pkg/losetup"
 )
 
-func TestSnapshotterSuite(t *testing.T) {
-	internal.RequiresRoot(t)
+func TestSnapshotterSuite_Isolated(t *testing.T) {
+	internal.RequiresIsolation(t)
 	logrus.SetLevel(logrus.DebugLevel)
 
 	snapshotterFn := func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {

--- a/snapshotter/naive/naive_test.go
+++ b/snapshotter/naive/naive_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/firecracker-microvm/firecracker-containerd/internal"
 )
 
-func TestCreateImage(t *testing.T) {
-	internal.RequiresRoot(t)
+func TestCreateImage_Isolated(t *testing.T) {
+	internal.RequiresIsolation(t)
 	snap := Snapshotter{}
 
 	tempDir, err := ioutil.TempDir("", "fc-snapshotter")
@@ -66,7 +66,7 @@ func createSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter,
 	return snap, snap.Close, nil
 }
 
-func TestSnapshotterSuite(t *testing.T) {
-	internal.RequiresRoot(t)
+func TestSnapshotterSuite_Isolated(t *testing.T) {
+	internal.RequiresIsolation(t)
 	testsuite.SnapshotterSuite(t, "Snapshotter", createSnapshotter)
 }

--- a/snapshotter/pkg/dmsetup/dmsetup_test.go
+++ b/snapshotter/pkg/dmsetup/dmsetup_test.go
@@ -35,8 +35,8 @@ const (
 	snapshotID     = 2
 )
 
-func TestDMSetup(t *testing.T) {
-	internal.RequiresRoot(t)
+func TestDMSetup_Isolated(t *testing.T) {
+	internal.RequiresIsolation(t)
 	tempDir, err := ioutil.TempDir("", "dmsetup-tests-")
 	require.NoErrorf(t, err, "failed to make temp dir for tests")
 

--- a/snapshotter/pkg/losetup/losetup_test.go
+++ b/snapshotter/pkg/losetup/losetup_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLosetup(t *testing.T) {
-	internal.RequiresRoot(t)
+func TestLosetup_Isolated(t *testing.T) {
+	internal.RequiresIsolation(t)
 	var (
 		imagePath   = createSparseImage(t)
 		loopDevice1 string


### PR DESCRIPTION
Prior to this fix the snapshotter root tests were not being run. This
change changes the root tests to be isolated tests and which allows them
to be ran in our CI pipeline.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
