### PR TITLE
Only use runtime config w/ default network ifaces in one test.

### DIFF
--- a/runtime/cni_integ_test.go
+++ b/runtime/cni_integ_test.go
@@ -135,6 +135,7 @@ func TestCNISupport_Isolated(t *testing.T) {
 
 func TestAutomaticCNISupport_Isolated(t *testing.T) {
 	internal.RequiresIsolation(t)
+	useDefaultNetworkInterfaceRuntimeConfig(t)
 
 	testTimeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), testTimeout)
@@ -353,6 +354,16 @@ func writeCNIConf(path, chainedPluginName, networkName, nameserver string) error
     }
   ]
 }`, networkName, nameserver, chainedPluginName)), 0644)
+}
+
+func useDefaultNetworkInterfaceRuntimeConfig(t *testing.T) {
+	t.Helper()
+
+	err := os.RemoveAll(runtimeConfigPath)
+	require.NoError(t, err, "failed to remove existing firecracker containerd runtime config file")
+
+	err = os.Symlink(defaultNetworkInterfaceRuntimeConfigPath, runtimeConfigPath)
+	require.NoError(t, err, "failed to symlink default network interface runtime config")
 }
 
 func runCommand(ctx context.Context, t *testing.T, name string, args ...string) {

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -63,6 +63,9 @@ const (
 	defaultVMRootfsPath = "/var/lib/firecracker-containerd/runtime/default-rootfs.img"
 	defaultVMNetDevName = "eth0"
 	varRunDir           = "/run/firecracker-containerd"
+
+	runtimeConfigPath                        = "/etc/containerd/firecracker-runtime.json"
+	defaultNetworkInterfaceRuntimeConfigPath = "/etc/containerd/firecracker-runtime-defaultnetwork.json"
 )
 
 // Images are presumed by the isolated tests to have already been pulled

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -165,6 +165,7 @@ RUN make -C /firecracker-containerd/internal test-bridged-tap && \
 	chmod a+x /firecracker-containerd/internal/test-bridged-tap
 
 COPY tools/docker/firecracker-runtime.json /etc/containerd/firecracker-runtime.json
+COPY tools/docker/firecracker-runtime-defaultnetwork.json /etc/containerd/firecracker-runtime-defaultnetwork.json
 COPY tools/docker/naive-snapshotter/entrypoint.sh /entrypoint
 
 ENTRYPOINT ["/entrypoint"]

--- a/tools/docker/firecracker-runtime-defaultnetwork.json
+++ b/tools/docker/firecracker-runtime-defaultnetwork.json
@@ -7,5 +7,13 @@
   "cpu_template": "T2",
   "log_fifo": "/tmp/fc-logs.fifo",
   "log_level": "Debug",
-  "metrics_fifo": "/tmp/fc-metrics.fifo"
+  "metrics_fifo": "/tmp/fc-metrics.fifo",
+  "default_network_interfaces": [
+    {
+      "CNIConfig": {
+        "NetworkName": "fcnet",
+        "InterfaceName": "veth0"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
TestAutomaticCNISupport is the only test which requires a runtime config
that has a list of default network interfaces. This change results in
that test being the only one to use such a runtime config, which allows
other tests to optionally not use any network interfaces if required.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

In general, I think a better model will be for tests to just each generate this runtime config themselves instead of using a set of static ones copied into the docker image (using some helper methods). I [created an issue](https://github.com/firecracker-microvm/firecracker-containerd/issues/291) for implementing this, but the change in this PR will unblock in the short-term some needed test updates in the jailer PR.