### PR TITLE
Makes use of ioutil.TempDir in stub drive tests

### DIFF
--- a/runtime/drive_handler_test.go
+++ b/runtime/drive_handler_test.go
@@ -29,12 +29,12 @@ import (
 	ops "github.com/firecracker-microvm/firecracker-go-sdk/client/operations"
 	"github.com/firecracker-microvm/firecracker-go-sdk/fctesting"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStubDriveHandler(t *testing.T) {
-	const tempPath = "test"
-	err := os.Mkdir(tempPath, os.ModePerm)
-	assert.NoError(t, err)
+	tempPath, err := ioutil.TempDir("./", "TestStubDriveHandler")
+	require.NoError(t, err)
 	defer func() {
 		os.RemoveAll(tempPath)
 	}()


### PR DESCRIPTION
This commit changes to use ioutil.TempDir as opposed to creating a
static directory when running the TestStubDriveHandler.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
