### PR TITLE
Add pre-exit hook to cleanup after job

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+
+make -C "$BUILDKITE_BUILD_CHECKOUT_PATH" clean

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,11 +86,3 @@ steps:
     command: 'make -C examples integ-test'
     concurrency: 1
     concurrency_group: 'loop-device test'
-
-  - wait: ~
-    continue_on_failure: true
-
-  - label: ":wastebasket: cleanup"
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
-    command: 'make clean'


### PR DESCRIPTION
This commit removes the cleanup step from the pipeline.yml file and
instead adds a hook that allows for cleanup to always occur even in the
event of a cancel.

The `pipeline.yml` cleanup only occurs if you let the whole job finish, which is not what we want.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
