### PR TITLE
Move proto compiling to a container

### DIFF
--- a/proto/Makefile
+++ b/proto/Makefile
@@ -13,6 +13,9 @@
 
 PROTO_SRC := $(wildcard *.proto)
 PROTO_GEN_SRC := $(PROTO_SRC:.proto=.pb.go)
+DOCKER_IMAGE_TAG?=latest
+UID?=$(shell id -u)
+GID?=$(shell id -g)
 
 $(PROTO_GEN_SRC): $(PROTO_SRC)
 	protoc \
@@ -22,6 +25,12 @@ $(PROTO_GEN_SRC): $(PROTO_SRC)
 proto: $(PROTO_GEN_SRC)
 	PROTOPATH=$(CURDIR) $(MAKE) -C service/fccontrol proto
 	PROTOPATH=$(CURDIR) $(MAKE) -C service/drivemount proto
+
+proto-docker:
+	docker run --rm \
+		-v $(CURDIR):/protobuf \
+		--user $(UID):$(GID) \
+		localhost/proto-builder:${DOCKER_IMAGE_TAG}
 
 clean:
 	- rm -f $(PROTO_GEN_SRC)

--- a/tools/docker/Dockerfile.proto-builder
+++ b/tools/docker/Dockerfile.proto-builder
@@ -13,5 +13,13 @@
 
 FROM golang:1.12-stretch
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install libseccomp-dev pkg-config
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+	libprotobuf-dev \
+	protobuf-compiler \
+	&& go get -u github.com/containerd/ttrpc/cmd/protoc-gen-gogottrpc \
+	&& go get -u github.com/gogo/protobuf/protoc-gen-gogo \
+	&& mkdir /protobuf
+
+WORKDIR /protobuf
+ENTRYPOINT ["/usr/bin/make"]
+CMD ["proto"]


### PR DESCRIPTION
*Description of changes:*
Makes it so that running `make proto` from the root of the project
compiles the protos in a docker container defined in
tools/docker/Docker.proto-builder. This image is build as part of `make
deps`.

This changes the default behavior but the previous behavior is still available by running `make proto` in the proto/ dir.

Signed-off-by: Cody Roseborough <cdr@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
