### PR TITLE
Update to go1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 language: go
 
 go:
+  - 1.13.x
   - 1.12.x
   - 1.11.x
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/docker/go-events v0.0.0-20170721190031-9461782956ad // indirect
 	github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 // indirect
 	github.com/docker/go-units v0.3.3
-	github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20191030150325-dbf9a1e05f090
+	github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20191029213755-dbf9a1e05f09
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/godbus/dbus v0.0.0-20181025153459-66d97aec3384 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible
@@ -53,3 +53,5 @@ require (
 
 // Workaround for github.com/containerd/containerd issue #3031
 replace github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
+
+go 1.11

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 h1:X0fj836zx99zF
 github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20191030150325-dbf9a1e05f090 h1:xxS6hBxzXh/EEahnfwXBLxIIDtDAfLJrA5OmsQQ/lNI=
-github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20191030150325-dbf9a1e05f090/go.mod h1:tVXziw7GjioCKVjI5/agymYxUaqJM6q7cp9e6kwjo8Q=
+github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20191029213755-dbf9a1e05f09 h1:JDfRpK+V2J1Es+Xm6aMJjCqvA4xv1kuWnJfeSopyDwo=
+github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20191029213755-dbf9a1e05f09/go.mod h1:tVXziw7GjioCKVjI5/agymYxUaqJM6q7cp9e6kwjo8Q=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb h1:D4uzjWwKYQ5XnAvUbuvHW93esHg7F8N/OYeBBcJoTr0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -17,7 +17,7 @@
 # COMMON IMAGES
 #
 #########################################
-FROM golang:1.12-stretch as base
+FROM golang:1.13-stretch as base
 # Set up a non-root user for running builds and some tests in later stages
 # Buildkit caches don't support anything like a "--chown" flag yet, so we need to ensure builder will have access to them
 RUN useradd --create-home --uid 1001 builder \

--- a/tools/docker/Dockerfile.proto-builder
+++ b/tools/docker/Dockerfile.proto-builder
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.12-stretch
+FROM golang:1.13-stretch
 
 RUN apt-get update && apt-get install --yes --no-install-recommends \
 	libprotobuf-dev \

--- a/tools/docker/Dockerfile.runc-builder
+++ b/tools/docker/Dockerfile.runc-builder
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.12-stretch
+FROM golang:1.13-stretch
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install libseccomp-dev pkg-config


### PR DESCRIPTION
- Add go1.13 as a build target for travis.
- Set the go version in go.mod at 1.11.
- Update a line in go.mod that wasn't compliant with the more stringent
validation in 1.13.
- Update Dockerfiles to use 1.13.


See [here](https://tip.golang.org/doc/go1.13#version-validation) for information on the version validation. The error I was seeing was:

```go: github.com/firecracker-microvm/firecracker-go-sdk@v0.17.1-0.20191030150325-dbf9a1e05f090: invalid pseudo-version: revision is longer than canonical (dbf9a1e05f09)```

This seems to be happening b/c the git prefix was 1 char to long (13 instead of 12).


Signed-off-by: Cody Roseborough <cdr@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
