### PR TITLE
Cleanup around Shutdown() and StopVM() 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/docker/go-events v0.0.0-20170721190031-9461782956ad // indirect
 	github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 // indirect
 	github.com/docker/go-units v0.3.3
-	github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20191029213755-dbf9a1e05f09
+	github.com/firecracker-microvm/firecracker-go-sdk v0.19.0
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/godbus/dbus v0.0.0-20181025153459-66d97aec3384 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 h1:X0fj836zx99zF
 github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20191029213755-dbf9a1e05f09 h1:JDfRpK+V2J1Es+Xm6aMJjCqvA4xv1kuWnJfeSopyDwo=
-github.com/firecracker-microvm/firecracker-go-sdk v0.17.1-0.20191029213755-dbf9a1e05f09/go.mod h1:tVXziw7GjioCKVjI5/agymYxUaqJM6q7cp9e6kwjo8Q=
+github.com/firecracker-microvm/firecracker-go-sdk v0.19.0 h1:Fgb3WhB4q3J5e+ksMBtjVwBTvbDtPAkx7eQulb2BOq8=
+github.com/firecracker-microvm/firecracker-go-sdk v0.19.0/go.mod h1:kW0gxvPpPvMukUxxTO9DrpSlScrtrTDGY3VgjAj/Qwc=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb h1:D4uzjWwKYQ5XnAvUbuvHW93esHg7F8N/OYeBBcJoTr0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -1185,11 +1185,6 @@ func (s *service) Shutdown(requestCtx context.Context, req *taskAPI.ShutdownRequ
 		shutdownErr = multierror.Append(shutdownErr, errors.Wrap(err, "failed to gracefully stop VM"))
 	}
 
-	err = os.RemoveAll(s.shimDir.RootPath())
-	if err != nil {
-		shutdownErr = multierror.Append(shutdownErr, errors.Wrapf(err, "failed to remove VM dir %q during shutdown", s.shimDir.RootPath()))
-	}
-
 	if shutdownErr != nil {
 		s.logger.WithError(shutdownErr).Error()
 		return nil, shutdownErr

--- a/tools/image-builder/Dockerfile.debian-image
+++ b/tools/image-builder/Dockerfile.debian-image
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \

--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -56,7 +56,7 @@ endif
 	debootstrap \
 		--variant=minbase \
 		--include=udev,systemd,systemd-sysv,procps,libseccomp2,haveged \
-		stretch \
+		buster \
 		"$(WORKDIR)" $(DEBMIRROR)
 	rm -rf "$(WORKDIR)/var/cache/apt/archives" \
 	       "$(WORKDIR)/usr/share/doc" \

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker-agent.service
@@ -15,9 +15,9 @@ Description=Firecracker VM agent
 StartLimitIntervalSec=2
 After=local-fs.target
 Requires=local-fs.target
+SuccessAction=reboot
 
 [Service]
 Type=simple
 WorkingDirectory=/container
 ExecStart=/usr/local/bin/agent
-Restart=always

--- a/tools/image-builder/files_debootstrap/sbin/overlay-init
+++ b/tools/image-builder/files_debootstrap/sbin/overlay-init
@@ -59,4 +59,4 @@ do_overlay
 
 # invoke the actual system init program and procede with the boot
 # process.
-exec /sbin/init $@
+exec /usr/sbin/init $@


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

- On rootfs side, we `reboot(2)` after the successful completion of VM agent. That allow us to not killing Firecracker
- On firecracker-contol, `os.RemoveAll()` is added to simplify shim. Since firecracker-control is responsible for creating a shim directory, corresponding removal should be happening on there as well.
- On runtime, `Shutdown()` is now waiting the completion of the VMM process and not killing Firecracker if possible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
