### PR TITLE
Add haveged to image-builder's rootfs.

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -103,7 +103,8 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
 		iptables \
 		iperf3 \
 		libdevmapper-dev \
-		libseccomp-dev
+		libseccomp-dev \
+		rng-tools # used for rngtest
 
 RUN mkdir -p /var/lib/firecracker-containerd/runtime \
         && curl --silent --show-error --retry 3 --max-time 30 --output default-vmlinux.bin \

--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -55,7 +55,7 @@ ifneq ($(UID),0)
 endif
 	debootstrap \
 		--variant=minbase \
-		--include=udev,systemd,systemd-sysv,procps,libseccomp2 \
+		--include=udev,systemd,systemd-sysv,procps,libseccomp2,haveged \
 		stretch \
 		"$(WORKDIR)" $(DEBMIRROR)
 	rm -rf "$(WORKDIR)/var/cache/apt/archives" \

--- a/tools/image-builder/README.md
+++ b/tools/image-builder/README.md
@@ -74,3 +74,14 @@ the final parameter passed on the kernel command line.
 A complete command line, settable via the `kernel_args` setting in `/etc/containerd/firecracker-runtime.json`, is:
 
     ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init
+
+### Security ###
+
+In order to ensure sufficient entropy is consistently available within 
+the VM, the rootfs is configured to start the 
+[`haveged`](https://manpages.debian.org/buster/haveged/haveged.8.en.html)
+daemon during boot. [More information on its method of operation and other
+details can be found in its FAQ](https://issihosts.com/haveged/faq.html).
+Users of the image created by this utility are encouraged to evaluate 
+`haveged` against their security requirements before running any
+cryptographically-sensitive workloads inside their microVMs and containers.

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/haveged.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/haveged.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/haveged.service

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/haveged.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/haveged.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Entropy Daemon based on the HAVEGE algorithm
+Documentation=man:haveged(8) http://www.issihosts.com/haveged/
+DefaultDependencies=no
+ConditionVirtualization=!container
+After=local-fs.target
+Before=firecracker.target sysinit.target shutdown.target
+
+[Service]
+ExecStart=/usr/sbin/haveged --Foreground --verbose=1 -w 1024
+SuccessExitStatus=143
+SecureBits=noroot-locked
+NoNewPrivileges=yes
+CapabilityBoundingSet=CAP_SYS_ADMIN
+PrivateTmp=yes
+PrivateDevices=yes
+PrivateNetwork=yes
+ProtectSystem=full
+ProtectHome=yes
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
haveged ensures that there is sufficient entropy available to processes running
within the microvm. Without sufficient entropy, it is fairly easy for processes
to get blocked on reading /dev/random or making getrandom() syscalls, including
during boot (which can result in CreateVM calls to fail if the agent process
gets blocked).

haveged was chosen as it enforces no minimum kernel requirements, does not
add CPU requirements (i.e. existence of RDRAND or similar instructions) and is
currently used by Debian for related use cases such as seeding entropy in their
installer.

One other option was "rngd", which has versions that support use of RDRAND.
It was not chosen as RDRAND is not universally trusted or portable. Similarly,
use of the "random.trust_cpu=on" kernel boot parameter was ruled out for now
as it relies on RDRAND and additionally enforces a minimum kernel version of
4.19.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

Addresses #325 

Verified the test by running it w/out starting the haveged daemon, which resulted in the container just getting blocked on /dev/random and the test timing out.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
