### PR TITLE
firecracker-control: ignore firecracker-ctr binary

### DIFF
--- a/firecracker-control/cmd/containerd/.gitignore
+++ b/firecracker-control/cmd/containerd/.gitignore
@@ -1,1 +1,2 @@
 firecracker-containerd
+firecracker-ctr


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
