### PR TITLE
Run "make test" on Travis CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  timeout: 5m
+
 linters:
   disable-all: true
   enable:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,7 @@ install:
   - make deps
 
 script:
+  # "make" must be happening before "make lint" to download dependencies
   - make
   - make lint
+  - make test


### PR DESCRIPTION
"make" doesn't compile *_test.go, but "make test" does.

121afa34449077eef99e533712d2a3cce501612a introduced
ProcessState.ExitCode which is not available in Go 1.11.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
