### PR TITLE
Create a small Docker image for running integration tests

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -39,11 +39,12 @@ integ-test:
 		--volume /run/udev/control:/run/udev/control \
 		--volume $(CURDIR)/etc/containerd/firecracker-runtime.json:/etc/containerd/firecracker-runtime.json \
 		--volume $(CURDIR)/logs:/var/log/firecracker-containerd-test \
+		--volume $(CURDIR)/..:/firecracker-containerd \
 		--env FICD_SNAPSHOTTER=$(TEST_SS) \
 		--env FICD_DM_POOL=$(TEST_POOL) \
 		--env EXTRAGOARGS="${EXTRAGOARGS}" \
 		--workdir="/firecracker-containerd/examples" \
-		localhost/firecracker-containerd-integ-test:${DOCKER_IMAGE_TAG} \
+		localhost/firecracker-containerd-integ-test-tiny:${DOCKER_IMAGE_TAG} \
 		"make examples && make testtap && sleep 3 && ./taskworkflow -ip $(TEST_IP)$(TEST_SUBNET) -gw $(TEST_GATEWAY) -ss $(TEST_SS)"
 
 TEST_GATEWAY?=172.16.0.1

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -51,12 +51,15 @@ integ-test:
 			--volume /dev:/dev \
 			--volume /run/udev/control:/run/udev/control \
 			--volume $(CURDIR)/logs:/var/log/firecracker-containerd-test \
+			--volume $(CURDIR)/..:/firecracker-containerd \
 			--env ENABLE_ISOLATED_TESTS=1 \
 			--env FICD_SNAPSHOTTER=$(FICD_SNAPSHOTTER) \
 			--env FICD_DM_POOL=$(FICD_DM_POOL) \
+			--env GOPROXY=direct \
+			--env GOSUMDB=off \
 			--workdir="/firecracker-containerd/runtime" \
 			--init \
-			localhost/firecracker-containerd-integ-test:$(DOCKER_IMAGE_TAG) \
+			localhost/firecracker-containerd-integ-test-tiny:$(DOCKER_IMAGE_TAG) \
 			"go test $(EXTRAGOARGS) -run \"^$(TESTNAME)$$\"" || exit 1; \
 	)
 

--- a/runtime/drive_handler_test.go
+++ b/runtime/drive_handler_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestStubDriveHandler(t *testing.T) {
-	tempPath, err := ioutil.TempDir("./", "TestStubDriveHandler")
+	tempPath, err := ioutil.TempDir("", "TestStubDriveHandler")
 	require.NoError(t, err)
 	defer func() {
 		os.RemoveAll(tempPath)

--- a/runtime/runc_jailer_test.go
+++ b/runtime/runc_jailer_test.go
@@ -33,7 +33,7 @@ import (
 func TestBuildJailedRootHandler_Isolated(t *testing.T) {
 	internal.RequiresIsolation(t)
 	runcConfigPath = "./firecracker-runc-config.json.example"
-	dir, err := ioutil.TempDir("./", "TestBuildJailedRootHandler")
+	dir, err := ioutil.TempDir("", "TestBuildJailedRootHandler")
 	require.NoError(t, err, "failed to create temporary directory")
 
 	defer os.RemoveAll(dir)
@@ -98,7 +98,7 @@ func TestMkdirAllWithPermissions_Isolated(t *testing.T) {
 	// requires isolation so we can change uid/gid of files
 	internal.RequiresIsolation(t)
 
-	tmpdir, err := ioutil.TempDir("./", "TestMkdirAllWithPermissions")
+	tmpdir, err := ioutil.TempDir("", "TestMkdirAllWithPermissions")
 	require.NoError(t, err, "failed to create temporary directory")
 
 	existingPath := filepath.Join(tmpdir, "exists")

--- a/tools/docker/Dockerfile.integ-test
+++ b/tools/docker/Dockerfile.integ-test
@@ -1,0 +1,74 @@
+# Test image that starts up containerd and the naive snapshotter. The default CMD will drop to a bash shell. Overrides
+# to CMD will be provided appended to /bin/bash -c
+FROM golang:1.13-stretch
+ENV PATH="/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/go/bin" \
+	FICD_LOG_DIR="/var/log/firecracker-containerd-test"\
+	DEBIAN_FRONTEND="noninteractive"
+ENV FICD_SNAPSHOTTER="naive" \
+	FICD_SNAPSHOTTER_OUTFILE="${FICD_LOG_DIR}/snapshotter.out" \
+	FICD_CONTAINERD_OUTFILE="${FICD_LOG_DIR}/containerd.out"
+ARG FIRECRACKER_TARGET=x86_64-unknown-linux-musl
+
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+		build-essential \
+		ca-certificates \
+		curl \
+		git \
+		iptables \
+		iperf3 \
+		libdevmapper-dev \
+		libseccomp-dev \
+		rng-tools # used for rngtest
+
+RUN mkdir -p \
+    /var/lib/firecracker-containerd/runtime \
+    /var/run/firecracker-containerd \
+    /opt/cni/bin \
+    /firecracker-containerd \
+    /var/lib/firecracker-containerd/naive \
+    ${FICD_LOG_DIR}
+
+RUN curl --silent --show-error --retry 3 --max-time 30 --output default-vmlinux.bin \
+    "https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin" \
+    && echo "882fa465c43ab7d92e31bd4167da3ad6a82cb9230f9b0016176df597c6014cef default-vmlinux.bin" | sha256sum -c - \
+    && chmod 0444 default-vmlinux.bin \
+    && mv default-vmlinux.bin /var/lib/firecracker-containerd/runtime/default-vmlinux.bin
+
+# Download Go dependencies
+COPY go.mod go.sum /firecracker-containerd
+RUN cd /firecracker-containerd && go mod download
+
+# Copy submodules
+COPY _submodules/firecracker/target/$FIRECRACKER_TARGET/release/firecracker \
+    _submodules/firecracker/target/$FIRECRACKER_TARGET/release/jailer \
+    _submodules/runc/runc \
+    /usr/local/bin
+
+# Copy our binaries
+COPY runtime/containerd-shim-aws-firecracker \
+     snapshotter/cmd/naive/naive_snapshotter \
+     /usr/local/bin
+
+# Copy our binaries but rename them
+COPY firecracker-control/cmd/containerd/firecracker-containerd /usr/local/bin/containerd
+COPY firecracker-control/cmd/containerd/firecracker-ctr /usr/local/bin/ctr
+
+COPY runtime/firecracker-runc-config.json.example /etc/containerd/firecracker-runc-config.json
+COPY tools/image-builder/rootfs.img /var/lib/firecracker-containerd/runtime/default-rootfs.img
+RUN chmod 0444 /var/lib/firecracker-containerd/runtime/default-rootfs.img
+
+# CNI
+COPY build/opt/cni/bin/* /opt/cni/bin
+COPY tools/demo/fcnet.conflist /etc/cni/conf.d/fcnet.conflist
+
+# pull the images the tests need into the content store so we don't need internet
+# access during the tests themselves
+COPY tools/docker/config.toml /etc/containerd/config.toml
+RUN containerd 2>/dev/null & \
+	ctr content fetch docker.io/library/alpine:3.10.1 >/dev/null && \
+	ctr content fetch docker.io/mlabbe/iperf3:3.6-r0 >/dev/null
+
+COPY tools/docker/entrypoint.sh /entrypoint
+
+ENTRYPOINT ["/entrypoint"]
+CMD ["exec /bin/bash"]


### PR DESCRIPTION
*Issue #, if available:*

#313

*Description of changes:*

As described in #313, firecracker-containerd-integ-test is copying the entire source directory to the container in the very early stage, which makes incremental build slower. This PR changes the strategy to

- Build binaries without Docker
- Copy the binaries to a Docker image later
- Only use go.mod and go.sum to download dependencies inside a container

That will make incremental build much faster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
