### PR TITLE
Cancel integration tests that take more than 10 minutes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,6 +52,7 @@ steps:
     command:
       - cp "/local/artifacts/$BUILDKITE_BUILD_NUMBER/rootfs.img" tools/image-builder/rootfs.img
       - make test-in-docker
+    timeout_in_minutes: 10
 
   - label: ":rotating_light: :hammer: snapshotter *root* tests"
     agents:
@@ -60,6 +61,7 @@ steps:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
       EXTRAGOARGS: "-v -count=1"
     command: 'make -C snapshotter integ-test'
+    timeout_in_minutes: 10
     concurrency: 1
     concurrency_group: 'loop-device test'
 
@@ -73,6 +75,7 @@ steps:
       - "runtime/logs/*"
     command:
       - make -C runtime integ-test FICD_SNAPSHOTTER=devmapper FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_runtime
+    timeout_in_minutes: 10
 
   - label: ":rotating_light: :exclamation: example tests (naive)"
     agents:
@@ -83,6 +86,7 @@ steps:
     artifact_paths:
       - "examples/logs/*"
     command: 'make -C examples integ-test'
+    timeout_in_minutes: 10
     concurrency: 1
     concurrency_group: 'loop-device test'
 
@@ -96,3 +100,4 @@ steps:
       - "examples/logs/*"
     command:
       - make -C examples integ-test TEST_SS=devmapper TEST_POOL=build_${BUILDKITE_BUILD_NUMBER}_example
+    timeout_in_minutes: 10


### PR DESCRIPTION
Integration tests seem having some issues, and took hours sometimes.
While we should fix the root cause, this change makes the issues less
severe.

Here are some bad builds we had recently:

 * https://buildkite.com/firecracker-microvm/firecracker-containerd/builds/1123
 * https://buildkite.com/firecracker-microvm/firecracker-containerd/builds/1122
 * https://buildkite.com/firecracker-microvm/firecracker-containerd/builds/1121
 * https://buildkite.com/firecracker-microvm/firecracker-containerd/builds/1166

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
