### PR TITLE
Build cni-bins in docker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ all-in-docker:
 		--env STATIC_AGENT=on \
 		--workdir /src \
 		$(FIRECRACKER_CONTAINERD_BUILDER_IMAGE) \
-		$(MAKE) all test-cni-bins
+		$(MAKE) all cni-bins test-cni-bins
 
 proto:
 	DOCKER_BUILDKIT=1 docker build \

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/firecracker-microvm/firecracker-containerd
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
-	github.com/checkpoint-restore/go-criu v0.0.0-20190109184317-bdb7599cd87b // indirect
 	github.com/containerd/cgroups v0.0.0-20181105182409-82cb49fc1779 // indirect
 	github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50 // indirect
 	github.com/containerd/containerd v1.3.1
@@ -15,7 +14,6 @@ require (
 	github.com/containernetworking/cni v0.7.2-0.20190807151350-8c6c47d1c7fc
 	github.com/containernetworking/plugins v0.8.2
 	github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142 // indirect
-	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-events v0.0.0-20170721190031-9461782956ad // indirect
 	github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 // indirect
@@ -32,12 +30,10 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/mdlayher/vsock v0.0.0-20190329173812-a92c53d5dcab
 	github.com/miekg/dns v1.1.16
-	github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v1.0.0-rc9
 	github.com/opencontainers/runtime-spec v0.1.2-0.20181106065543-31e0d16c1cb7
-	github.com/opencontainers/selinux v1.3.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2 // indirect
 	github.com/shirou/gopsutil v2.18.12+incompatible


### PR DESCRIPTION
This is beneficial in that it removes another hard dependency on the host's
version of go. It also might prevent an issue I saw this morning in buildkite
where builds that previously passed started failing when compiling a third-party
dependency during the call to "cni-bins". The build was using the host's GOPATH
(not the docker volume gocache) and go version and I was only able to fix it by
manually logging into the host and clearing out the GOPATH directory.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
