### PR TITLE
Returns codes.DeadlineExceeded when we forcebily kill a VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,10 @@ DEFAULT_RUNC_JAILER_CONFIG_INSTALLPATH?=/etc/containerd/firecracker-runc-config.
 $(DEFAULT_RUNC_JAILER_CONFIG_INSTALLPATH): $(ETC_CONTAINERD) runtime/firecracker-runc-config.json.example
 	install -D -o root -g root -m400 runtime/firecracker-runc-config.json.example $@
 
+ROOTFS_SLOW_REBOOT_INSTALLPATH=$(FIRECRACKER_CONTAINERD_RUNTIME_DIR)/rootfs-slow-reboot.img
+$(ROOTFS_SLOW_REBOOT_INSTALLPATH): tools/image-builder/rootfs-slow-reboot.img $(FIRECRACKER_CONTAINERD_RUNTIME_DIR)
+	install -D -o root -g root -m400 $< $@
+
 .PHONY: default-vmlinux
 default-vmlinux: $(DEFAULT_VMLINUX_NAME)
 
@@ -195,6 +199,8 @@ install-default-rootfs: $(DEFAULT_ROOTFS_INSTALLPATH)
 .PHONY: install-default-runc-jailer-config
 install-default-runc-jailer-config: $(DEFAULT_RUNC_JAILER_CONFIG_INSTALLPATH)
 
+.PHONY: install-test-rootfs
+install-test-rootfs: $(ROOTFS_SLOW_REBOOT_INSTALLPATH)
 
 ##########################
 # CNI Network

--- a/agent/main.go
+++ b/agent/main.go
@@ -108,7 +108,12 @@ func main() {
 	}
 
 	group.Go(func() error {
-		return server.Serve(shimCtx, listener)
+		err := server.Serve(shimCtx, listener)
+		if err == ttrpc.ErrServerClosed {
+			// Calling server.Shutdown() from another goroutine will cause ErrServerClosed, which is fine.
+			return nil
+		}
+		return err
 	})
 
 	group.Go(func() error {

--- a/firecracker-control/local.go
+++ b/firecracker-control/local.go
@@ -218,7 +218,6 @@ func (s *local) StopVM(requestCtx context.Context, req *proto.StopVMRequest) (*e
 
 	resp, err := client.StopVM(requestCtx, req)
 	if err != nil {
-		err = errors.Wrap(err, "shim client failed to stop VM")
 		s.logger.WithError(err).Error()
 		return nil, err
 	}

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -1186,6 +1186,7 @@ func (s *service) shutdown(requestCtx, shutdownCtx context.Context, req *taskAPI
 		}
 		s.logger.WithError(shutdownErr).Error("the VM returns unknown error")
 	case <-shutdownCtx.Done():
+		shutdownErr = status.Errorf(codes.DeadlineExceeded, "the VM %q will be killed forcebily", req.ID)
 		s.logger.Error("the VM hasn't been stopped before the context's deadline")
 	}
 

--- a/tools/docker/Dockerfile.integ-test
+++ b/tools/docker/Dockerfile.integ-test
@@ -51,6 +51,7 @@ RUN --mount=type=bind,target=/src make -C /src \
   install-default-rootfs \
   install-default-runc-jailer-config \
   install-test-cni-bins \
+  install-test-rootfs \
   demo-network
 
 COPY tools/docker/entrypoint.sh /entrypoint

--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 UID        := $(shell id -u)
-WORKDIR    := rootfs
+WORKDIR    := tmp/rootfs
 WORKDIRLOC := $(shell readlink -f $(WORKDIR))
 IMAGE_DIRS := /dev /bin /etc /etc/init.d /tmp /var /run /proc /sys /container/rootfs /agent /rom /overlay
 DIRS       := $(foreach dir,$(IMAGE_DIRS),"$(WORKDIR)$(dir)")
@@ -37,7 +37,7 @@ fi
 touch --reference=debootstrap_stamp --no-create "$(WORKDIR)"
 endef
 
-all: rootfs.img
+all: rootfs.img rootfs-slow-reboot.img
 
 $(WORKDIR):
 	mkdir $(WORKDIR)
@@ -67,6 +67,13 @@ endif
 rootfs.img: files_common_stamp files_debootstrap_stamp files_ephemeral_stamp
 	mksquashfs "$(WORKDIR)" rootfs.img -noappend
 
+# Intentionally break the rootfs to simulate the case where StopVM is taking longer than the minimal timeout
+rootfs-slow-reboot.img: files_common_stamp files_debootstrap_stamp files_ephemeral_stamp
+	rm -fr tmp/$@
+	cp -a "$(WORKDIR)" tmp/$@
+	echo 'ExecStop=/bin/sleep 60' >> tmp/$@/etc/systemd/system/firecracker-agent.service
+	mksquashfs tmp/$@ $@ -noappend
+
 builder: builder_stamp
 
 builder_stamp:
@@ -81,7 +88,9 @@ builder_stamp:
 %-in-docker: builder_stamp
 	docker run --rm \
 		--security-opt=apparmor=unconfined \
-		-it --volume $(CURDIR):/src \
+		-it \
+		--volume $(CURDIR):/src \
+		--volume /src/tmp \
 		--cap-add=sys_admin \
 		--cap-add=sys_chroot \
 		--env=DEBMIRROR \
@@ -89,13 +98,10 @@ builder_stamp:
 
 clean:
 	-rm -f *stamp
-	if [ -d $(WORKDIR) ] || [ -e rootfs.img ]; then \
-	  if [ $(UID) -eq 0 ]; then \
-	    rm -rf $(WORKDIR) \
-	    rm -f rootfs.img ;\
-	   else \
-	     $(MAKE) clean-in-docker ;\
-	   fi ; \
+	if [ $(UID) -eq 0 ]; then \
+	  rm -f rootfs.img rootfs-slow-reboot.img ;\
+	else \
+	  $(MAKE) clean-in-docker ;\
 	fi
 
 distclean: clean


### PR DESCRIPTION
*Issue #, if available:*

 #247 

*Description of changes:*

There are three commits in this PR
* Add a rootfs to simulate the situation: Not so sure this is the best way though.
* Remove errors.Wrap from firecracker-control: Shim is more aware about errors and fc-control should be act as a transparent proxy. We should remove all of errrors.Wrap from this layer and let shim decide errors.
* Actually fix the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
