### PR TITLE
Delete files as root before git clone

### DIFF
--- a/.buildkite/hooks/pre-checkout
+++ b/.buildkite/hooks/pre-checkout
@@ -1,0 +1,4 @@
+#! /bin/sh
+# -ffxdq is BuildKite's default clean flags.
+# https://buildkite.com/docs/agent/v3/configuration
+sudo git clean -ffxdq


### PR DESCRIPTION
We sometimes messed up file permissions and created files that are
owned by root. Those files cannot be deleted from BuildKite Agent,
since the agent is running as non-root.

Adding this hook will clean the files.

https://buildkite.com/docs/agent/v3/configuration
https://buildkite.com/docs/agent/v3/hooks
https://buildkite.com/firecracker-microvm/firecracker-containerd/builds/1240#82400f89-cab5-43b2-9eb5-43115f778dfc

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
