### PR TITLE
Add send2vsock to send systemd journal from a guest to the host

### DIFF
--- a/send2vsock/Makefile
+++ b/send2vsock/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+EXTRAGOARGS?=
+
+SOURCES:=$(shell find . -name '*.go')
+
+all: send2vsock
+
+send2vsock: $(SOURCES)
+	go build $(EXTRAGOARGS) -o $@
+
+test:
+	go test ./... $(EXTRAGOARGS)
+
+clean:
+	-rm -f send2vsock
+
+distclean: clean
+
+# Install is a noop here, for now.
+install:
+
+.PHONY: clean distclean all install test integ-test
+

--- a/send2vsock/main.go
+++ b/send2vsock/main.go
@@ -1,0 +1,51 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/mdlayher/vsock"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "Usage: send2vsock CID PORT\n")
+		os.Exit(1)
+	}
+
+	cid, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid CID: %+v\n", err)
+		os.Exit(1)
+	}
+
+	port, err := strconv.Atoi(os.Args[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid port: %+v\n", err)
+		os.Exit(1)
+	}
+
+	conn, err := vsock.Dial(uint32(cid), uint32(port))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to connect to the vsock: %+v\n", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	io.Copy(conn, os.Stdin)
+}


### PR DESCRIPTION
Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

#276

*Description of changes:*

This PR is still work-in-progress. Early feedback is welcome!

Basically I want to run `journalctl -f | send2vsock` as a systemd unit. systemd can forward logs to syslogd, but supporting a remote syslogd location is not supported and using a mini daemon is recommended instead (see https://github.com/systemd/systemd/issues/7170).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
