### PR TITLE
Fix shutdown logic.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,7 +86,7 @@ steps:
       - "runtime/logs/*"
     command:
       - make -C runtime integ-test FICD_SNAPSHOTTER=devmapper FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_runtime
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
 
   - label: ":rotating_light: :exclamation: example tests (devmapper)"
     agents:

--- a/examples/etc/containerd/firecracker-runtime.json
+++ b/examples/etc/containerd/firecracker-runtime.json
@@ -6,6 +6,7 @@
   "cpu_count": 1,
   "cpu_template": "T2",
   "log_level": "Debug",
+  "debug": true,
   "jailer": {
     "runc_binary_path": "/usr/local/bin/runc"
   }


### PR DESCRIPTION
There's a few related cleanups here:
1. Fix an issue where the timeout used for Shutdown calls (as opposed to StopVM
   calls) was too long due to multiplying by time.Second twice.
2. Don't rely on the error type being exec.ExitError to determine if StopVMM
   needs to be called. This didn't work because the Go SDK wraps error types
   returned by machine.Wait(). The new logic eliminates the need for this check.
3. Expose monitorVMExit's knowledge of when the VM exits via a field, which
   allows shutdown to just read that field instead of making its own separate
   Wait call. This dedupes some logs and simplifies the shutdown function a bit.

Overall, the code related to shutdown is still pretty convoluted. The
complication is mostly due to the fact that we are given multiple contexts by
containerd shim code (shimCtx and requestCtx), which creates complicated
dependencies between those contexts and the lifecycle of the VM, our ttrpc
servers+connection and the shim process itself. This change doesn't really
help that situation, it's just focused on fixing some of the logical errors in
the shutdown procedure.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

Ref: #358 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
