### PR TITLE
Use bridge networking in the demo-network configuration

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -321,18 +321,28 @@ pre-created tap devices and with tap devices created automatically by
 [CNI](https://github.com/containernetworking/cni) plugins.
 
 ### CNI Setup
-CNI-configured networks offer the quickest way to get VMs up and running with 
-connectivity to external networks. Setting one up requires a few extra steps in 
-addition to the above Setup steps.
+
+CNI-configured networks offer the quickest way to get VMs up and running with
+connectivity between MicroVMs and to external networks. Setting one up requires
+a few extra steps in addition to the above Setup steps.
+
+Production deployments should be sure to choose a network configuration suitale
+to the specifics of the environment and workloads being hosting, with particular
+attention being given to network isolation between tasks.
 
 To install the required CNI dependencies, run the following make target from the 
 previously cloned firecracker-containerd repository:
+
 ```bash
 $ sudo make demo-network
 ```
 
 You can check the Makefile to see exactly what is installed and where, but for a
 quick summary:
+* [`bridge` CNI plugin](https://github.com/containernetworking/plugins/tree/master/plugins/main/bridge)
+  - Creates a [veth](http://man7.org/linux/man-pages/man4/veth.4.html) pair with
+  one end in a private network namespace and the other end attached to a bridge
+  device in the host's network namespace.
 * [`ptp` CNI plugin](https://github.com/containernetworking/plugins/tree/master/plugins/main/ptp)
   - Creates a [veth](http://man7.org/linux/man-pages/man4/veth.4.html) pair with
   one end in a private network namespace and the other end in the host's network

--- a/tools/demo/fc-br0.interface
+++ b/tools/demo/fc-br0.interface
@@ -1,0 +1,11 @@
+# This interfaces(5) configuration file is intended to work with the
+# ifupdown interface management framework provided by Debian 10.  It
+# may require modification to work elsewhere.
+auto fc-br0
+iface fc-br0 inet static
+      address 192.168.1.1
+      network 192.168.1.0
+      netmask 255.255.255.0
+      broadcast 192.168.1.255
+      gateway 192.168.1.1
+      bridge_ports none

--- a/tools/demo/fcnet.conflist
+++ b/tools/demo/fcnet.conflist
@@ -3,8 +3,12 @@
   "name": "fcnet",
   "plugins": [
     {
-      "type": "ptp",
+      "type": "bridge",
+      "bridge": "fc-br0",
+      "isDefaultGateway": true,
+      "forceAddress": false,
       "ipMasq": true,
+      "hairpinMode": true,
       "mtu": 1500,
       "ipam": {
         "type": "host-local",


### PR DESCRIPTION
Previously our CNI-based demo network used the ptp CNI plugin to configure
point-to-point connectivity between the container VMs and the host.  This
change uses the bridge plugin instead, which facilitates direct communication
between container VMs via the bridge interface.  The justification for this is
that inter-container connectivity can be useful from a deployment point of
view, but also makes for a more interesting demo.

Production deployments should, of course, configure their networking based on
local requirements, which includes taking task isolation into account as
appropriate.

Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
