### PR TITLE
Test StopVM() with Jailer just in case

### DIFF
--- a/runtime/cni_integ_test.go
+++ b/runtime/cni_integ_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 func TestCNISupport_Isolated(t *testing.T) {
-	prepareIntegTest(t, withJailer())
+	prepareIntegTest(t)
 	testTimeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), testTimeout)
 	defer cancel()

--- a/runtime/integ_test.go
+++ b/runtime/integ_test.go
@@ -40,6 +40,9 @@ var defaultRuntimeConfig = config.Config{
 	LogLevel:              "Debug",
 	Debug:                 true,
 	ShimBaseDir:           shimBaseDir,
+	JailerConfig: config.JailerConfig{
+		RuncBinaryPath: "/usr/local/bin/runc",
+	},
 }
 
 func defaultSnapshotterName() string {
@@ -84,12 +87,6 @@ func writeRuntimeConfig(options ...func(*config.Config)) error {
 	}
 
 	return nil
-}
-
-func withJailer() func(*config.Config) {
-	return func(c *config.Config) {
-		c.JailerConfig.RuncBinaryPath = "/usr/local/bin/runc"
-	}
 }
 
 var testNameToVMIDReplacer = strings.NewReplacer("/", "_")

--- a/runtime/jailer_integ_test.go
+++ b/runtime/jailer_integ_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestJailer_Isolated(t *testing.T) {
-	prepareIntegTest(t, withJailer())
+	prepareIntegTest(t)
 	t.Run("Without Jailer", func(t *testing.T) {
 		testJailer(t, nil)
 	})
@@ -85,7 +85,7 @@ func testJailer(t *testing.T, jailerConfig *proto.JailerConfig) {
 }
 
 func TestJailerCPUSet_Isolated(t *testing.T) {
-	prepareIntegTest(t, withJailer())
+	prepareIntegTest(t)
 
 	t.Run("TestJailerCPUSet_Isolated", func(t *testing.T) {
 		b := cpuset.Builder{}

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -1350,6 +1350,20 @@ func TestStopVM_Isolated(t *testing.T) {
 			},
 		},
 
+		{
+			name: "Jailer",
+			createVMRequest: proto.CreateVMRequest{
+				JailerConfig: &proto.JailerConfig{
+					UID: 300000,
+					GID: 300000,
+				},
+			},
+			stopFunc: func(ctx context.Context, fcClient fccontrol.FirecrackerService, vmID string) {
+				_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: vmID})
+				require.Equal(status.Code(err), codes.OK)
+			},
+		},
+
 		// Firecracker is too fast to test a case where we hit the timeout on a StopVMRequest.
 		// The rootfs below explicitly sleeps 60 seconds after shutting down the agent to simulate the case.
 		{

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -225,7 +225,7 @@ func createTapDevice(ctx context.Context, tapName string) error {
 }
 
 func TestMultipleVMs_Isolated(t *testing.T) {
-	prepareIntegTest(t, withJailer())
+	prepareIntegTest(t)
 
 	netns, err := ns.GetCurrentNS()
 	require.NoError(t, err, "failed to get a namespace")


### PR DESCRIPTION
While the functionality is working, I'd like to have more tests with jailer-enabled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
