### PR TITLE
Add "client" package for container orchestrators

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,21 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package client
+
+import "github.com/firecracker-microvm/firecracker-containerd/internal/bundle"
+
+// RootFSPathInVM returns the path to the rootfs of the container inside a microVM.
+func RootFSPathInVM(taskID string) string {
+	return bundle.VMBundleDir(taskID).RootfsPath()
+}


### PR DESCRIPTION
Some container orchestrators need to how firecracker-containerd uses
microVMs, especially the layout of key directories.

The client package is designed to expose the layout, without exposing
the implementation details too much.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
