### PR TITLE
Add version information for in-VM agent, shim, firecracker-conta…

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -17,14 +17,15 @@ GOMOD := $(shell go env GOMOD)
 GOSUM := $(GOMOD:.mod=.sum)
 SOURCES:=$(shell find . -name '*.go')
 DOCKER_IMAGE_TAG?=latest
+REVISION := $(shell git rev-parse HEAD)
 
 all: agent
 
 agent: *.go $(GOMOD) $(GOSUM)
 ifneq ($(STATIC_AGENT),)
-	CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "-s" $(EXTRAGOARGS) -o agent
+	CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "-s -X main.revision=$(REVISION)" $(EXTRAGOARGS) -o agent
 else
-	go build $(EXTRAGOARGS) -o agent
+	go build $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)" -o agent
 endif
 
 test:

--- a/agent/main.go
+++ b/agent/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -47,18 +48,29 @@ const (
 	enableSubreaper = 1
 )
 
+var (
+	revision string
+)
+
 func main() {
 	var (
-		port  int
-		debug bool
+		port    int
+		debug   bool
+		version bool
 	)
 
 	flag.IntVar(&port, "port", defaultPort, "Vsock port to listen to")
 	flag.BoolVar(&debug, "debug", false, "Turn on debug mode")
+	flag.BoolVar(&version, "version", false, "Show the version")
 	flag.Parse()
 
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	if version {
+		showVersion()
+		return
 	}
 
 	signals := make(chan os.Signal, 32)
@@ -154,4 +166,10 @@ func main() {
 		log.G(shimCtx).WithError(err).Error("shim error")
 		panic(err)
 	}
+}
+
+func showVersion() {
+	// Once https://github.com/golang/go/issues/29814 is resolved,
+	// we can use runtime/debug.BuildInfo instead of calling git(1) from Makefile
+	fmt.Printf("containerd Firecracker agent %s\n", revision)
 }

--- a/agent/main.go
+++ b/agent/main.go
@@ -171,5 +171,5 @@ func main() {
 func showVersion() {
 	// Once https://github.com/golang/go/issues/29814 is resolved,
 	// we can use runtime/debug.BuildInfo instead of calling git(1) from Makefile
-	fmt.Printf("containerd Firecracker agent %s\n", revision)
+	fmt.Printf("containerd Firecracker agent (git commit: %s)\n", revision)
 }

--- a/firecracker-control/cmd/containerd/Makefile
+++ b/firecracker-control/cmd/containerd/Makefile
@@ -17,16 +17,20 @@ EXTRAGOARGS:=
 SRC := $(shell find . -name '*.go')
 GOMOD := $(shell go env GOMOD)
 GOSUM := $(GOMOD:.mod=.sum)
+REVISION=$(shell git rev-parse HEAD)
+VERSION_LDFLAGS="-X github.com/containerd/containerd/version.Revision=$(REVISION)"
 
 all: build
 
 build: firecracker-containerd firecracker-ctr
 
 firecracker-containerd: $(SRC) $(GOMOD) $(GOSUM)
-	go build $(EXTRAGOARGS) -o firecracker-containerd
+	go build $(EXTRAGOARGS) \
+		-ldflags $(VERSION_LDFLAGS) -o firecracker-containerd
 
 firecracker-ctr: $(GOMOD) $(GOSUM)
-	GOBIN=$(CURDIR) go install -tags=no_cri $(EXTRAGOARGS) github.com/containerd/containerd/cmd/ctr
+	GOBIN=$(CURDIR) go install -tags=no_cri $(EXTRAGOARGS) \
+		-ldflags $(VERSION_LDFLAGS) github.com/containerd/containerd/cmd/ctr
 	mv ctr firecracker-ctr
 
 install: firecracker-containerd firecracker-ctr

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -22,6 +22,8 @@ DOCKER_IMAGE_TAG?=latest
 GO_CACHE_VOLUME_NAME?=gocache
 FIRECRACKER_CONTAINERD_TEST_IMAGE?=localhost/firecracker-containerd-test
 
+REVISION=$(shell git rev-parse HEAD)
+
 INTEG_TEST_SUFFIX := _Isolated
 INTEG_TESTNAMES=$(shell docker run --rm \
 	--network=none \
@@ -37,7 +39,7 @@ all: runtime
 runtime: containerd-shim-aws-firecracker
 
 containerd-shim-aws-firecracker: $(SOURCES) $(GOMOD) $(GOSUM)
-	go build -o containerd-shim-aws-firecracker $(EXTRAGOARGS)
+	go build -o containerd-shim-aws-firecracker $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)"
 
 install: containerd-shim-aws-firecracker
 	install -D -o root -g root -m755 -t $(INSTALLROOT)/bin containerd-shim-aws-firecracker

--- a/runtime/main.go
+++ b/runtime/main.go
@@ -23,6 +23,8 @@ import (
 
 const shimID = "aws.firecracker"
 
+var revision string
+
 func init() {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		TimestampFormat: log.RFC3339NanoFixed,

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -362,7 +362,7 @@ func (s *service) StartShim(shimCtx context.Context, containerID, containerdBina
 	if exitAfterAllTasksDeleted {
 		str = " The VM will be torn down after serving a single task."
 	}
-	log.WithField("vmID", s.vmID).Infof("successfully started shim (%s).%s", revision, str)
+	log.WithField("vmID", s.vmID).Infof("successfully started shim (git commit: %s).%s", revision, str)
 
 	return fcShim.SocketAddress(shimCtx, s.vmID)
 }


### PR DESCRIPTION
Investigating issues like #370 will be easier if the agent can report
the version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
