### PR TITLE
Update getting-started.md - microscopic but important add

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,7 @@ You need to have the following things in order to use firecracker-containerd:
   as `hello-rootfs.ext4`). 
 * A recent installation of [Docker CE](https://docker.com).
 * Go 1.11 or later, which you can download from [here](https://golang.org/dl/).
+* GCC compiler
 
 ## Setup
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ You need to have the following things in order to use firecracker-containerd:
   as `hello-rootfs.ext4`). 
 * A recent installation of [Docker CE](https://docker.com).
 * Go 1.11 or later, which you can download from [here](https://golang.org/dl/).
-* GCC compiler
+* GCC compiler 
 
 ## Setup
 


### PR DESCRIPTION
Add GCC compiler to pre-requisites - unable to perform build without one.

*Issue #, if available:*
N/A

*Description of changes:*
Added bullet for GCC requirement to pre-requisites so that any individual building in a clean environment is guaranteed to have a successful build.  A clean Ubuntu release in an on-prem install does not have GCC preloaded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
