### PR TITLE
Make integration tests work with loopback devices

### DIFF
--- a/.buildkite/al2_pipeline.yml
+++ b/.buildkite/al2_pipeline.yml
@@ -21,6 +21,7 @@ steps:
     env:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
       EXTRAGOARGS: "-race"
+      FICD_DM_VOLUME_GROUP: "fcci-vg"
     command:
       - ./.buildkite/setup_al2.sh
       - docker run --rm -v $PWD:/mnt debian:stretch-slim rm -rf /mnt/tools/image-builder/rootfs

--- a/.buildkite/al2_test.sh
+++ b/.buildkite/al2_test.sh
@@ -6,7 +6,8 @@ source ./.buildkite/al2env.sh
 export PATH=$bin_path:$PATH
 export FIRECRACKER_CONTAINERD_RUNTIME_CONFIG_PATH=$runtime_config_path
 export ENABLE_ISOLATED_TESTS=true
-export CONTAINERD_SOCKET=$dir/containerd.sock 
+export CONTAINERD_SOCKET=$dir/containerd.sock
+
 export SHIM_BASE_DIR=$dir
 
 sudo -E PATH=$PATH $bin_path/firecracker-containerd --config $dir/config.toml &

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,7 +101,7 @@ steps:
     artifact_paths:
       - "runtime/logs/*"
     command:
-      - make -C runtime integ-test FICD_SNAPSHOTTER=devmapper FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_runtime
+      - make -C runtime integ-test FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_runtime
     timeout_in_minutes: 15
 
   - label: ":rotating_light: :exclamation: example tests (devmapper)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -98,13 +98,14 @@ steps:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
       NUMBER_OF_VMS: 100
       EXTRAGOARGS: "-v -count=1 -race"
+      FICD_DM_VOLUME_GROUP: fcci-vg
     artifact_paths:
       - "runtime/logs/*"
     command:
       - make -C runtime integ-test FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_runtime
     timeout_in_minutes: 15
 
-  - label: ":rotating_light: :exclamation: example tests (devmapper)"
+  - label: ":rotating_light: :exclamation: example tests"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
@@ -112,9 +113,10 @@ steps:
     env:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
       EXTRAGOARGS: "-v -count=1"
+      FICD_DM_VOLUME_GROUP: fcci-vg
     artifact_paths:
       - "examples/logs/*"
     command:
-      - make -C examples integ-test TEST_SS=devmapper TEST_POOL=build_${BUILDKITE_BUILD_NUMBER}_example
+      - make -C examples integ-test TEST_POOL=build_${BUILDKITE_BUILD_NUMBER}_example
     timeout_in_minutes: 10
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -41,17 +41,15 @@ integ-test:
 		--volume $(CURDIR)/etc/containerd/firecracker-runtime.json:/etc/containerd/firecracker-runtime.json \
 		--volume $(CURDIR)/logs:/var/log/firecracker-containerd-test \
 		--volume $(CURDIR)/..:/src \
-		--env FICD_SNAPSHOTTER=$(TEST_SS) \
 		--env FICD_DM_POOL=$(TEST_POOL) \
 		--env EXTRAGOARGS="${EXTRAGOARGS}" \
 		--workdir="/src/examples" \
 		$(FIRECRACKER_CONTAINERD_TEST_IMAGE):${DOCKER_IMAGE_TAG} \
-		"make examples && make testtap && sleep 3 && ./taskworkflow -ip $(TEST_IP)$(TEST_SUBNET) -gw $(TEST_GATEWAY) -ss $(TEST_SS)"
+		"make examples && make testtap && sleep 3 && ./taskworkflow -ip $(TEST_IP)$(TEST_SUBNET) -gw $(TEST_GATEWAY) -ss devmapper"
 
 TEST_GATEWAY?=172.16.0.1
 TEST_IP?=172.16.0.2
 TEST_SUBNET?=/24
-TEST_SS?=devmapper
 TEST_POOL?=
 testtap:
 	ip link add br0 type bridge

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -41,6 +41,7 @@ integ-test:
 		--volume $(CURDIR)/etc/containerd/firecracker-runtime.json:/etc/containerd/firecracker-runtime.json \
 		--volume $(CURDIR)/logs:/var/log/firecracker-containerd-test \
 		--volume $(CURDIR)/..:/src \
+		--env FICD_DM_VOLUME_GROUP=$(FICD_DM_VOLUME_GROUP) \
 		--env FICD_DM_POOL=$(TEST_POOL) \
 		--env EXTRAGOARGS="${EXTRAGOARGS}" \
 		--workdir="/src/examples" \
@@ -50,6 +51,7 @@ integ-test:
 TEST_GATEWAY?=172.16.0.1
 TEST_IP?=172.16.0.2
 TEST_SUBNET?=/24
+FICD_DM_VOLUME_GROUP?=
 TEST_POOL?=
 testtap:
 	ip link add br0 type bridge

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -62,7 +62,6 @@ integ-test-%: logs
 		--volume $(CURDIR)/..:/src \
 		--volume $(GO_CACHE_VOLUME_NAME):/go \
 		--env ENABLE_ISOLATED_TESTS=1 \
-		--env FICD_SNAPSHOTTER=$(FICD_SNAPSHOTTER) \
 		--env FICD_DM_POOL=$(FICD_DM_POOL) \
 		--env GOPROXY=direct \
 		--env GOSUMDB=off \
@@ -81,7 +80,6 @@ PERF_RUNTIME_SECONDS?=600
 PERF_VM_MEMSIZE_MB?=1024
 PERF_TARGET_BANDWIDTH?=1G
 
-FICD_SNAPSHOTTER?=devmapper
 FICD_DM_POOL?=
 
 tc-redirect-tap-perf:
@@ -109,7 +107,6 @@ perf-test:
 		--env PERF_RUNTIME_SECONDS=$(PERF_RUNTIME_SECONDS) \
 		--env PERF_VM_MEMSIZE_MB=$(PERF_VM_MEMSIZE_MB) \
 		--env PERF_TARGET_BANDWIDTH=$(PERF_TARGET_BANDWIDTH) \
-		--env FICD_SNAPSHOTTER=$(FICD_SNAPSHOTTER) \
 		--env FICD_DM_POOL=$(FICD_DM_POOL) \
 		--env GOPROXY=direct \
 		--env GOSUMDB=off \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -62,6 +62,7 @@ integ-test-%: logs
 		--volume $(CURDIR)/..:/src \
 		--volume $(GO_CACHE_VOLUME_NAME):/go \
 		--env ENABLE_ISOLATED_TESTS=1 \
+		--env FICD_DM_VOLUME_GROUP=$(FICD_DM_VOLUME_GROUP) \
 		--env FICD_DM_POOL=$(FICD_DM_POOL) \
 		--env GOPROXY=direct \
 		--env GOSUMDB=off \
@@ -80,6 +81,7 @@ PERF_RUNTIME_SECONDS?=600
 PERF_VM_MEMSIZE_MB?=1024
 PERF_TARGET_BANDWIDTH?=1G
 
+FICD_DM_VOLUME_GROUP?=
 FICD_DM_POOL?=
 
 tc-redirect-tap-perf:
@@ -107,6 +109,7 @@ perf-test:
 		--env PERF_RUNTIME_SECONDS=$(PERF_RUNTIME_SECONDS) \
 		--env PERF_VM_MEMSIZE_MB=$(PERF_VM_MEMSIZE_MB) \
 		--env PERF_TARGET_BANDWIDTH=$(PERF_TARGET_BANDWIDTH) \
+		--env FICD_DM_VOLUME_GROUP=$(FICD_DM_VOLUME_GROUP) \
 		--env FICD_DM_POOL=$(FICD_DM_POOL) \
 		--env GOPROXY=direct \
 		--env GOSUMDB=off \

--- a/runtime/cni_integ_test.go
+++ b/runtime/cni_integ_test.go
@@ -53,7 +53,7 @@ func TestCNISupport_Isolated(t *testing.T) {
 	pluginClient, err := ttrpcutil.NewClient(containerdSockPath + ".ttrpc")
 	require.NoError(t, err, "failed to create ttrpc client")
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
 	numVMs := 5
@@ -127,7 +127,7 @@ func TestCNISupport_Isolated(t *testing.T) {
 
 			newContainer, err := client.NewContainer(ctx,
 				containerName,
-				containerd.WithSnapshotter(defaultSnapshotterName()),
+				containerd.WithSnapshotter(defaultSnapshotterName),
 				containerd.WithNewSnapshot(snapshotName, image),
 				containerd.WithNewSpec(
 					oci.WithProcessArgs("/usr/bin/wget",
@@ -160,7 +160,7 @@ func TestAutomaticCNISupport_Isolated(t *testing.T) {
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
 	defer client.Close()
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
 	numVMs := 5
@@ -194,7 +194,7 @@ func TestAutomaticCNISupport_Isolated(t *testing.T) {
 
 			newContainer, err := client.NewContainer(ctx,
 				taskID,
-				containerd.WithSnapshotter(defaultSnapshotterName()),
+				containerd.WithSnapshotter(defaultSnapshotterName),
 				containerd.WithNewSnapshot(snapshotName, image),
 				containerd.WithNewSpec(
 					oci.WithProcessArgs("/usr/bin/wget",
@@ -237,7 +237,7 @@ func TestCNIPlugin_Performance(t *testing.T) {
 
 	fcClient := fccontrol.NewFirecrackerClient(pluginClient.Client())
 
-	image, err := iperf3Image(ctx, client, defaultSnapshotterName())
+	image, err := iperf3Image(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get iperf3 image")
 
 	cniNetworkName := "fcnet"
@@ -296,7 +296,7 @@ func TestCNIPlugin_Performance(t *testing.T) {
 
 			newContainer, err := client.NewContainer(ctx,
 				containerName,
-				containerd.WithSnapshotter(defaultSnapshotterName()),
+				containerd.WithSnapshotter(defaultSnapshotterName),
 				containerd.WithNewSnapshot(snapshotName, image),
 				containerd.WithNewSpec(
 					oci.WithProcessArgs("/usr/bin/iperf3",

--- a/runtime/integ_test.go
+++ b/runtime/integ_test.go
@@ -55,13 +55,8 @@ func shimBaseDir() string {
 	return defaultShimBaseDir
 }
 
-func defaultSnapshotterName() string {
-	if name := os.Getenv("FICD_SNAPSHOTTER"); name != "" {
-		return name
-	}
-
-	return "devmapper"
-}
+// devmapper is the only snapshotter we can use with Firecracker
+const defaultSnapshotterName = "devmapper"
 
 func prepareIntegTest(t *testing.T, options ...func(*config.Config)) {
 	t.Helper()

--- a/runtime/jailer_integ_test.go
+++ b/runtime/jailer_integ_test.go
@@ -52,7 +52,7 @@ func testJailer(t *testing.T, jailerConfig *proto.JailerConfig) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(err, "failed to get alpine image")
 
 	pluginClient, err := ttrpcutil.NewClient(containerdSockPath + ".ttrpc")
@@ -69,7 +69,7 @@ func testJailer(t *testing.T, jailerConfig *proto.JailerConfig) {
 
 	c, err := client.NewContainer(ctx,
 		"container",
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot("snapshot", image),
 		containerd.WithNewSpec(oci.WithProcessArgs("/bin/echo", "-n", "hello"), firecrackeroci.WithVMID(vmID)),
 	)

--- a/runtime/limits_integ_test.go
+++ b/runtime/limits_integ_test.go
@@ -35,7 +35,7 @@ func TestDiskLimit_Isolated(t *testing.T) {
 	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
 	defer client.Close()
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(err, "failed to get alpine image")
 
 	// Right now, both naive snapshotter and devmapper snapshotter are configured to have 1024MB image size.
@@ -47,7 +47,7 @@ func TestDiskLimit_Isolated(t *testing.T) {
 
 	container, err := client.NewContainer(ctx,
 		"container",
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot("snapshot", image),
 		sh,
 	)

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -119,7 +119,7 @@ func TestShimExitsUponContainerDelete_Isolated(t *testing.T) {
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
 	defer client.Close()
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
 	testTimeout := 60 * time.Second
@@ -131,7 +131,7 @@ func TestShimExitsUponContainerDelete_Isolated(t *testing.T) {
 	container, err := client.NewContainer(testCtx,
 		containerName,
 		containerd.WithRuntime(firecrackerRuntime, nil),
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot(snapshotName, image),
 		containerd.WithNewSpec(
 			oci.WithProcessArgs("sleep", fmt.Sprintf("%d", testTimeout/time.Second)),
@@ -143,7 +143,7 @@ func TestShimExitsUponContainerDelete_Isolated(t *testing.T) {
 	_, err = client.NewContainer(testCtx,
 		fmt.Sprintf("should-fail-%s-%d", t.Name(), time.Now().UnixNano()),
 		containerd.WithRuntime(firecrackerRuntime, nil),
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot(snapshotName, image),
 		containerd.WithNewSpec(
 			oci.WithProcessArgs("sleep", fmt.Sprintf("%d", testTimeout/time.Second)),
@@ -316,7 +316,7 @@ func (runner *testMultipleVMsRunner) TestMultipleVMs(t *testing.T) {
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
 	defer client.Close()
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
 	pluginClient, err := ttrpcutil.NewClient(containerdSockPath + ".ttrpc")
@@ -446,7 +446,7 @@ func (runner *testMultipleVMsRunner) testMultipleExecs(
 	// spawn a container that just prints the VM's eth0 mac address (which we have set uniquely per VM)
 	newContainer, err := client.NewContainer(ctx,
 		containerName,
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot(snapshotName, image),
 		containerd.WithNewSpec(
 			processArgs,
@@ -646,7 +646,7 @@ func TestStubBlockDevices_Isolated(t *testing.T) {
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
 	defer client.Close()
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
 	tapName := fmt.Sprintf("tap%d", vmID)
@@ -677,7 +677,7 @@ func TestStubBlockDevices_Isolated(t *testing.T) {
 
 	newContainer, err := client.NewContainer(ctx,
 		containerName,
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot(snapshotName, image),
 		containerd.WithNewSpec(
 			firecrackeroci.WithVMID(strconv.Itoa(vmID)),
@@ -808,7 +808,7 @@ func testCreateContainerWithSameName(t *testing.T, vmID string) {
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
 	defer client.Close()
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
 	containerName := fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano())
@@ -818,7 +818,7 @@ func testCreateContainerWithSameName(t *testing.T, vmID string) {
 
 	c1, err := client.NewContainer(ctx,
 		containerName,
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot(snapshotName, image),
 		withNewSpec,
 	)
@@ -844,7 +844,7 @@ func testCreateContainerWithSameName(t *testing.T, vmID string) {
 	// So, we can launch a new container with the same name
 	c2, err := client.NewContainer(ctx,
 		containerName,
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot(snapshotName, image),
 		withNewSpec,
 	)
@@ -884,14 +884,14 @@ func TestStubDriveReserveAndReleaseByContainers_Isolated(t *testing.T) {
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
 	defer client.Close()
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
 	runEchoHello := containerd.WithNewSpec(oci.WithProcessArgs("echo", "-n", "hello"), firecrackeroci.WithVMID("reuse-same-vm"), oci.WithDefaultPathEnv)
 
 	c1, err := client.NewContainer(ctx,
 		"c1",
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot("c1", image),
 		runEchoHello,
 	)
@@ -905,7 +905,7 @@ func TestStubDriveReserveAndReleaseByContainers_Isolated(t *testing.T) {
 
 	c2, err := client.NewContainer(ctx,
 		"c2",
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot("c2", image),
 		runEchoHello,
 	)
@@ -936,7 +936,7 @@ func TestDriveMount_Isolated(t *testing.T) {
 	fcClient, err := fcClient.New(containerdSockPath + ".ttrpc")
 	require.NoError(t, err, "failed to create fccontrol client")
 
-	image, err := alpineImage(ctx, ctrdClient, defaultSnapshotterName())
+	image, err := alpineImage(ctx, ctrdClient, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
 	vmID := "test-drive-mount"
@@ -1041,7 +1041,7 @@ func TestDriveMount_Isolated(t *testing.T) {
 
 	newContainer, err := ctrdClient.NewContainer(ctx,
 		containerName,
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot(snapshotName, image),
 		containerd.WithNewSpec(
 			oci.WithProcessArgs("/bin/sh", "-c", strings.Join(append(ctrCommands,
@@ -1211,13 +1211,13 @@ func TestUpdateVMMetadata_Isolated(t *testing.T) {
 	assert.Equal(t, expected, resp.Metadata)
 
 	// Check inside the vm
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 	containerName := "mmds-test"
 
 	newContainer, err := client.NewContainer(ctx,
 		containerName,
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot("mmds-test-all", image),
 		containerd.WithNewSpec(
 			oci.WithProcessArgs("/usr/bin/wget",
@@ -1237,7 +1237,7 @@ func TestUpdateVMMetadata_Isolated(t *testing.T) {
 	containerName += "-entry"
 	newContainer, err = client.NewContainer(ctx,
 		containerName,
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot("mmds-test-entry", image),
 		containerd.WithNewSpec(
 			oci.WithProcessArgs("/usr/bin/wget",
@@ -1277,14 +1277,14 @@ func TestRandomness_Isolated(t *testing.T) {
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
 	defer client.Close()
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 	containerName := "test-entropy"
 
 	const blockCount = 1024
 	ddContainer, err := client.NewContainer(ctx,
 		containerName,
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot("test-entropy-snapshot", image),
 		containerd.WithNewSpec(
 			oci.WithDefaultUnixDevices,
@@ -1412,7 +1412,7 @@ func TestStopVM_Isolated(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(err, "failed to get alpine image")
 
 	pluginClient, err := ttrpcutil.NewClient(containerdSockPath + ".ttrpc")
@@ -1530,7 +1530,7 @@ func TestStopVM_Isolated(t *testing.T) {
 
 			c, err := client.NewContainer(ctx,
 				"container-"+vmID,
-				containerd.WithSnapshotter(defaultSnapshotterName()),
+				containerd.WithSnapshotter(defaultSnapshotterName),
 				containerd.WithNewSnapshot("snapshot-"+vmID, image),
 				containerd.WithNewSpec(oci.WithProcessArgs("/bin/echo", "-n", "hello"), firecrackeroci.WithVMID(vmID)),
 			)
@@ -1604,7 +1604,7 @@ func TestEvents_Isolated(t *testing.T) {
 	defer subscribeCancel()
 	eventCh, errCh := client.Subscribe(subscribeCtx, "topic")
 
-	image, err := alpineImage(ctx, client, defaultSnapshotterName())
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(err, "failed to get alpine image")
 
 	pluginClient, err := ttrpcutil.NewClient(containerdSockPath + ".ttrpc")
@@ -1618,7 +1618,7 @@ func TestEvents_Isolated(t *testing.T) {
 
 	c, err := client.NewContainer(ctx,
 		"container-"+vmID,
-		containerd.WithSnapshotter(defaultSnapshotterName()),
+		containerd.WithSnapshotter(defaultSnapshotterName),
 		containerd.WithNewSnapshot("snapshot-"+vmID, image),
 		containerd.WithNewSpec(oci.WithProcessArgs("/bin/echo", "-n", "hello"), firecrackeroci.WithVMID(vmID)),
 	)

--- a/tools/docker/Dockerfile.integ-test
+++ b/tools/docker/Dockerfile.integ-test
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 ARG FIRECRACKER_TARGET=x86_64-unknown-linux-musl
 ENV FICD_LOG_DIR="/var/log/firecracker-containerd-test"
-ENV FICD_SNAPSHOTTER="devmapper"
-ENV FICD_SNAPSHOTTER_OUTFILE="${FICD_LOG_DIR}/snapshotter.out"
 ENV FICD_CONTAINERD_OUTFILE="${FICD_LOG_DIR}/containerd.out"
 
 RUN apt-get update && apt-get install --yes --no-install-recommends \

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -5,20 +5,12 @@ chmod a+rwx ${FICD_LOG_DIR}
 
 mkdir -p /etc/containerd/snapshotter
 
-case "$FICD_SNAPSHOTTER" in
-    devmapper)
-        cat > /etc/containerd/snapshotter/devmapper.toml <<EOF
+cat > /etc/containerd/snapshotter/devmapper.toml <<EOF
 [plugins]
   [plugins.devmapper]
     pool_name = "fcci--vg-${FICD_DM_POOL}"
     base_image_size = "1024MB"
 EOF
-        ;;
-    *)
-        echo "This Docker image doesn't support $FICD_SNAPSHOTTER snapshotter"
-        exit 1
-        ;;
-esac
 
 touch ${FICD_CONTAINERD_OUTFILE}
 chmod a+rw ${FICD_CONTAINERD_OUTFILE}

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -5,10 +5,16 @@ chmod a+rwx ${FICD_LOG_DIR}
 
 mkdir -p /etc/containerd/snapshotter
 
+if [[ -z "$FICD_DM_VOLUME_GROUP" ]]; then
+   pool_name="${FICD_DM_POOL}"
+else
+   pool_name="$(echo "$FICD_DM_VOLUME_GROUP" | sed s/-/--/g)-${FICD_DM_POOL}"
+fi
+
 cat > /etc/containerd/snapshotter/devmapper.toml <<EOF
 [plugins]
   [plugins.devmapper]
-    pool_name = "fcci--vg-${FICD_DM_POOL}"
+    pool_name = "${pool_name}"
     base_image_size = "1024MB"
 EOF
 


### PR DESCRIPTION
*Issue #, if available:*

On both "Getting Started" and "Quickstart", we explain the way to configure devmapper with loopback devices, but thinpool.sh assumes that a thinpool is backed by LVM.

*Description of changes:*

Make thinpool.sh work with loopback devices. Also remove snapshotter-related environment variables and if's.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
