### PR TITLE
Jailer leaves containers behind

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/containerd v1.3.3
 	github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac // indirect
 	github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
-	github.com/containerd/go-runc v0.0.0-20190226155025-7d11b49dc076 // indirect
+	github.com/containerd/go-runc v0.0.0-20190226155025-7d11b49dc076
 	github.com/containerd/ttrpc v0.0.0-20190613183316-1fb3814edf44
 	github.com/containerd/typeurl v0.0.0-20181015155603-461401dc8f19
 	github.com/containernetworking/cni v0.7.2-0.20190807151350-8c6c47d1c7fc

--- a/runtime/jailer.go
+++ b/runtime/jailer.go
@@ -55,6 +55,8 @@ type jailer interface {
 	// StubDrivesOptions will return a set of options used to create a new stub
 	// drive file
 	StubDrivesOptions() []FileOpt
+	// Close will do any necessary cleanup that the jailer has accrued.
+	Close() error
 }
 
 type cgroupPather interface {

--- a/runtime/noop_jailer.go
+++ b/runtime/noop_jailer.go
@@ -79,3 +79,5 @@ func (j noopJailer) StubDrivesOptions() []FileOpt {
 	j.logger.Debug("noop operation for StubDrivesOptions")
 	return []FileOpt{}
 }
+
+func (j noopJailer) Close() error { return nil }


### PR DESCRIPTION
The jailer will leave containers behind if the jailing process was
killed with SIGKILL.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
