### PR TITLE
Don't share `err` between multiple goroutines

### DIFF
--- a/runtime/cni_integ_test.go
+++ b/runtime/cni_integ_test.go
@@ -90,7 +90,7 @@ func TestCNISupport_Isolated(t *testing.T) {
 			defer vmGroup.Done()
 
 			fcClient := fccontrol.NewFirecrackerClient(pluginClient.Client())
-			_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{
+			_, err := fcClient.CreateVM(ctx, &proto.CreateVMRequest{
 				VMID: vmID,
 				MachineCfg: &proto.FirecrackerMachineConfiguration{
 					MemSizeMib: 512,


### PR DESCRIPTION
Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

This was originally in #383, but since the PR has been open for 2+ weeks. I'd like to merge changes that we can have, to make the PR smaller.

*Description of changes:*

The `err` is unnecessary shared by multiple goroutines.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
