### PR TITLE
Redirect firecrakcer-containerd's logs to runtime/logs/containerd.out

### DIFF
--- a/.buildkite/al2_pipeline.yml
+++ b/.buildkite/al2_pipeline.yml
@@ -35,6 +35,8 @@ steps:
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
     env:
       NUMBER_OF_VMS: "100"
+    artifact_paths:
+      - "runtime/logs/*"
     command:
       - ./.buildkite/al2_test.sh
     timeout_in_minutes: 10

--- a/.buildkite/al2_test.sh
+++ b/.buildkite/al2_test.sh
@@ -10,8 +10,13 @@ export CONTAINERD_SOCKET=$dir/containerd.sock
 
 export SHIM_BASE_DIR=$dir
 
-sudo -E PATH=$PATH $bin_path/firecracker-containerd --config $dir/config.toml &
+mkdir -p runtime/logs
+
+sudo -E PATH=$PATH \
+     $bin_path/firecracker-containerd \
+     --config $dir/config.toml &>> runtime/logs/containerd.out &
 containerd_pid=$!
+
 sudo $bin_path/firecracker-ctr --address $dir/containerd.sock content fetch docker.io/library/alpine:3.10.1
 sudo -E PATH=$bin_path:$PATH /usr/local/bin/go test -count=1 -run TestMultipleVMs_Isolated ./... -v
 


### PR DESCRIPTION
*Issue #, if available:*

NA, but it will fix "Warning: This log has exceeded the 1MB display limit. Below we are only showing the last 1MB of output." on https://buildkite.com/firecracker-microvm/firecracker-containerd-al2/builds/177#1e4dc126-d811-4e4f-b6af-d3ffbbe6b432

*Description of changes:*

As like the Docker-based build, keep logs under runtime/logs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
