### PR TITLE
Updated taskworkflow.go: fixes in socket name and readme.

### DIFF
--- a/examples/taskworkflow.go
+++ b/examples/taskworkflow.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	containerdAddress      = "/run/containerd/containerd.sock"
+	containerdAddress      = "/run/firecracker-containerd/containerd.sock"
 	containerdTTRPCAddress = containerdAddress + ".ttrpc"
 	namespaceName          = "firecracker-containerd-example"
 	macAddress             = "AA:FC:00:00:00:01"

--- a/examples/taskworkflow.md
+++ b/examples/taskworkflow.md
@@ -19,22 +19,20 @@ for the VM by following [these instructions](https://github.com/firecracker-micr
 
 This creates a tap device named `tap0`, in the local `172.16.0.1/24` subnet.
 Since the example does not rely on a DHCP client running within the VM to
-initialize the network interface, `gw` and `mask` flags should be used to
-specify the gateway and subnet mask values.
+initialize the network interface, `gw` flag should be used to
+specify the gateway value.
 
 The following example sets:
-* The IP address to `172.16.0.2`
+* The IP address (CIDR) to `172.16.0.2/24`
 * The gateway IP address to `172.16.0.1`
-* The subnet mask to `255.255.255.0` (`/24`)
 
 ** NOTE: This example will not work if you're running more than 1 container
 on a host at the same time **
 
 Now, run the example by passing the `-ip` argument:
 ```bash
-$ sudo /path/to/firecracker-containerd/examples/taskworkflow -ip 172.16.0.2 \
-    -gw 172.16.0.1 \
-    -mask 255.255.255.0
+$ sudo /path/to/firecracker-containerd/examples/taskworkflow -ip 172.16.0.2/24 \
+    -gw 172.16.0.1
 ```
 
 You should see output similar to this:

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -75,7 +75,7 @@ var (
 	findShim        = findProcWithName(shimProcessName)
 	findFirecracker = findProcWithName(firecrackerProcessName)
 
-	containerdSockPath = "/run/containerd/containerd.sock"
+	containerdSockPath = "/run/firecracker-containerd/containerd.sock"
 )
 
 func init() {

--- a/tools/docker/Dockerfile.integ-test
+++ b/tools/docker/Dockerfile.integ-test
@@ -37,8 +37,8 @@ RUN --mount=type=bind,source=firecracker-control/cmd/containerd,target=/src \
   ln -sv /usr/local/bin/firecracker-containerd /usr/local/bin/containerd && \
   ln -sv /usr/local/bin/firecracker-ctr /usr/local/bin/ctr
 RUN containerd 2>/dev/null & \
-  ctr content fetch docker.io/library/alpine:3.10.1 >/dev/null && \
-  ctr content fetch docker.io/mlabbe/iperf3:3.6-r0 >/dev/null
+  ctr --address /run/firecracker-containerd/containerd.sock content fetch docker.io/library/alpine:3.10.1 >/dev/null && \
+  ctr --address /run/firecracker-containerd/containerd.sock content fetch docker.io/mlabbe/iperf3:3.6-r0 >/dev/null
 
 # Install everything we need in this image. Due to the bind-mount, if the host has already
 # up-to-date versions of everything built, this step will be a very quick copy

--- a/tools/docker/config.toml
+++ b/tools/docker/config.toml
@@ -1,1 +1,3 @@
 imports = ["/etc/containerd/snapshotter/*.toml"]
+[grpc]
+  address = "/run/firecracker-containerd/containerd.sock"


### PR DESCRIPTION
*Issue #387 *

*Description of changes:*

Socket name was aligned with the quickstart guidelines. Removed the `-mask` argument from the readme as it is not supported anymore. Specified that `-ip` argument requires CIDR and not just an IP address.

Signed-off-by: Dmitrii Ustiugov <dmitrii.ustiugov@ed.ac.uk>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
