### PR TITLE
Use Debian 10 (buster) on quickstart.md and as Docker images' variants

### DIFF
--- a/.buildkite/al2_pipeline.yml
+++ b/.buildkite/al2_pipeline.yml
@@ -24,7 +24,7 @@ steps:
       FICD_DM_VOLUME_GROUP: "fcci-vg"
     command:
       - ./.buildkite/setup_al2.sh
-      - docker run --rm -v $PWD:/mnt debian:stretch-slim rm -rf /mnt/tools/image-builder/rootfs
+      - docker run --rm -v $PWD:/mnt debian:buster-slim rm -rf /mnt/tools/image-builder/rootfs
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,7 @@ steps:
       EXTRAGOARGS: "-race"
     command:
       - make test-images
-      - docker run --rm -v $PWD:/mnt debian:stretch-slim rm -rf /mnt/tools/image-builder/rootfs
+      - docker run --rm -v $PWD:/mnt debian:buster-slim rm -rf /mnt/tools/image-builder/rootfs
       - sudo install -d -o root -g buildkite-agent -m 775 "/local/artifacts/$BUILDKITE_BUILD_NUMBER"
       - cp tools/image-builder/rootfs.img "/local/artifacts/$BUILDKITE_BUILD_NUMBER/"
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SUBMODULES=_submodules
 UID:=$(shell id -u)
 GID:=$(shell id -g)
 
-FIRECRACKER_CONTAINERD_BUILDER_IMAGE?=golang:1.13-stretch
+FIRECRACKER_CONTAINERD_BUILDER_IMAGE?=golang:1.13-buster
 export FIRECRACKER_CONTAINERD_TEST_IMAGE?=localhost/firecracker-containerd-test
 export GO_CACHE_VOLUME_NAME?=gocache
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,10 +15,10 @@ files into `/usr/local/bin`.
 1. Get an AWS account (see
    [this article](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
    if you need help creating one)
-2. Launch an i3.metal instance running Debian Stretch (you can find it in the
-   [AWS marketplace](http://deb.li/awsmp) or on [this
-   page](https://wiki.debian.org/Cloud/AmazonEC2Image/Stretch).  If you need
-   help launching an EC2 instance, see the
+2. Launch an i3.metal instance running Debian Buster (you can find it in the
+   [AWS marketplace](https://aws.amazon.com/marketplace/pp/B0859NK4HC) or
+   on [this page](https://wiki.debian.org/Cloud/AmazonEC2Image/Buster).
+   If you need help launching an EC2 instance, see the
    [EC2 getting started guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html).
 3. Run the script below to download and install all the required components.
    This script expects to be run from your `$HOME` directory.
@@ -30,11 +30,8 @@ cd ~
 
 # Install git, Go 1.11, make, curl
 sudo mkdir -p /etc/apt/sources.list.d
-echo "deb http://ftp.debian.org/debian stretch-backports main" | \
-     sudo tee /etc/apt/sources.list.d/stretch-backports.list
 sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get \
-  --target-release stretch-backports \
   install --yes \
   golang-go \
   make \
@@ -42,7 +39,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get \
   curl \
   e2fsprogs \
   util-linux \
-  bc
+  bc \
+  gnupg
 
 cd ~
 


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Use Debian 10 (buster) instead of Debian 9, since it is available on AWS Marketplace 🎉 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
