### PR TITLE
Remove a shim directory on StopVM() correctly and synchronously

### DIFF
--- a/runtime/jailer_integ_test.go
+++ b/runtime/jailer_integ_test.go
@@ -99,15 +99,13 @@ func testJailer(t *testing.T, jailerConfig *proto.JailerConfig) {
 func TestJailerCPUSet_Isolated(t *testing.T) {
 	prepareIntegTest(t)
 
-	t.Run("TestJailerCPUSet_Isolated", func(t *testing.T) {
-		b := cpuset.Builder{}
-		cset := b.AddCPU(0).AddMem(0).Build()
-		config := &proto.JailerConfig{
-			CPUs: cset.CPUs(),
-			Mems: cset.Mems(),
-			UID:  300000,
-			GID:  300000,
-		}
-		testJailer(t, config)
-	})
+	b := cpuset.Builder{}
+	cset := b.AddCPU(0).AddMem(0).Build()
+	config := &proto.JailerConfig{
+		CPUs: cset.CPUs(),
+		Mems: cset.Mems(),
+		UID:  300000,
+		GID:  300000,
+	}
+	testJailer(t, config)
 }

--- a/runtime/noop_jailer.go
+++ b/runtime/noop_jailer.go
@@ -118,4 +118,6 @@ func (j *noopJailer) Stop() error {
 	return err
 }
 
-func (j *noopJailer) Close() error { return nil }
+func (j *noopJailer) Close() error {
+	return os.RemoveAll(j.shimDir.RootPath())
+}

--- a/runtime/runc_jailer.go
+++ b/runtime/runc_jailer.go
@@ -156,7 +156,7 @@ func (j *runcJailer) BuildJailedMachine(cfg *config.Config, machineConfig *firec
 func (j *runcJailer) BuildJailedRootHandler(cfg *config.Config, machineConfig *firecracker.Config, vmID string) firecracker.Handler {
 	ociBundlePath := j.OCIBundlePath()
 	rootPath := j.RootPath()
-	machineConfig.SocketPath = filepath.Join(rootPath, "api.socket")
+	machineConfig.SocketPath = filepath.Join(rootfsFolder, "api.socket")
 
 	return firecracker.Handler{
 		Name: jailerHandlerName,

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -20,7 +20,6 @@ import (
 	"math"
 	"net"
 	"os"
-	"path/filepath"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -497,8 +496,13 @@ func (s *service) createVM(requestCtx context.Context, request *proto.CreateVMRe
 		namespace = namespaces.Default
 	}
 
+	dir, err := vm.ShimDir(s.config.ShimBaseDir, namespace, s.vmID)
+	if err != nil {
+		return err
+	}
+
 	s.logger.Info("creating new VM")
-	s.jailer, err = newJailer(s.shimCtx, s.logger, filepath.Join(s.config.ShimBaseDir, namespace, s.vmID), s, request)
+	s.jailer, err = newJailer(s.shimCtx, s.logger, dir.RootPath(), s, request)
 	if err != nil {
 		return errors.Wrap(err, "failed to create jailer")
 	}

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -470,9 +470,12 @@ func testMultipleExecs(
 	close(execStdouts)
 
 	if jailerConfig != nil {
+		dir, err := vm.ShimDir(shimBaseDir(), "default", vmIDStr)
+		require.NoError(t, err)
+
 		jailer := &runcJailer{
 			Config: runcJailerConfig{
-				OCIBundlePath: filepath.Join(shimBaseDir(), vmIDStr),
+				OCIBundlePath: dir.RootPath(),
 			},
 			vmID: vmIDStr,
 		}


### PR DESCRIPTION
Previously the cleanup logic is in firecracker-control, but it doesn't
work correctly with a runc-based jailer, since the jailer is making
files without namespaces.

Morever the cleanup logic is running after StopVM() that makes our
contracts unclear. We should guarantee all resource are deleted at
the end of StopVM().

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

#415

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
