### PR TITLE
Set cgroup path when calling GetVMInfo

### DIFF
--- a/runtime/service.go
+++ b/runtime/service.go
@@ -597,11 +597,17 @@ func (s *service) GetVMInfo(requestCtx context.Context, request *proto.GetVMInfo
 		return nil, err
 	}
 
+	cgroupPath := ""
+	if c, ok := s.jailer.(cgroupPather); ok {
+		cgroupPath = c.CgroupPath()
+	}
+
 	return &proto.GetVMInfoResponse{
 		VMID:            s.vmID,
 		SocketPath:      s.shimDir.FirecrackerSockPath(),
 		LogFifoPath:     s.machineConfig.LogFifo,
 		MetricsFifoPath: s.machineConfig.MetricsFifo,
+		CgroupPath:      cgroupPath,
 	}, nil
 }
 

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -370,6 +370,7 @@ func TestMultipleVMs_Isolated(t *testing.T) {
 			require.Equal(t, vmInfoResp.SocketPath, filepath.Join(cfg.ShimBaseDir, defaultNamespace, strconv.Itoa(vmID), "firecracker.sock"))
 			require.Equal(t, vmInfoResp.LogFifoPath, filepath.Join(cfg.ShimBaseDir, defaultNamespace, strconv.Itoa(vmID), "fc-logs.fifo"))
 			require.Equal(t, vmInfoResp.MetricsFifoPath, filepath.Join(cfg.ShimBaseDir, defaultNamespace, strconv.Itoa(vmID), "fc-metrics.fifo"))
+			require.Equal(t, resp.CgroupPath, vmInfoResp.CgroupPath)
 
 			// just verify that updating the metadata doesn't return an error, a separate test case is needed
 			// to very the MMDS update propagates to the container correctly


### PR DESCRIPTION
GetVMInfo already had the CgroupPath field, but it looks like it was
never set. This commit sets the cgroup path if the jailer is a
cgroupPather.

Fixes #416 

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
