### PR TITLE
Fix Exec()'s timeout issue

### DIFF
--- a/agent/service.go
+++ b/agent/service.go
@@ -228,7 +228,7 @@ func (ts *TaskService) Create(requestCtx context.Context, req *taskAPI.CreateTas
 			req.Stdin = fifoSet.Stdin
 			stdinConnectorPair = &vm.IOConnectorPair{
 				ReadConnector:  vm.VSockAcceptConnector(extraData.StdinPort),
-				WriteConnector: vm.FIFOConnector(fifoSet.Stdin),
+				WriteConnector: vm.WriteFIFOConnector(fifoSet.Stdin),
 			}
 		}
 
@@ -236,7 +236,7 @@ func (ts *TaskService) Create(requestCtx context.Context, req *taskAPI.CreateTas
 		if req.Stdout != "" {
 			req.Stdout = fifoSet.Stdout
 			stdoutConnectorPair = &vm.IOConnectorPair{
-				ReadConnector:  vm.FIFOConnector(fifoSet.Stdout),
+				ReadConnector:  vm.ReadFIFOConnector(fifoSet.Stdout),
 				WriteConnector: vm.VSockAcceptConnector(extraData.StdoutPort),
 			}
 		}
@@ -245,7 +245,7 @@ func (ts *TaskService) Create(requestCtx context.Context, req *taskAPI.CreateTas
 		if req.Stderr != "" {
 			req.Stderr = fifoSet.Stderr
 			stderrConnectorPair = &vm.IOConnectorPair{
-				ReadConnector:  vm.FIFOConnector(fifoSet.Stderr),
+				ReadConnector:  vm.ReadFIFOConnector(fifoSet.Stderr),
 				WriteConnector: vm.VSockAcceptConnector(extraData.StderrPort),
 			}
 		}
@@ -454,7 +454,7 @@ func (ts *TaskService) Exec(requestCtx context.Context, req *taskAPI.ExecProcess
 			req.Stdin = fifoSet.Stdin
 			stdinConnectorPair = &vm.IOConnectorPair{
 				ReadConnector:  vm.VSockAcceptConnector(extraData.StdinPort),
-				WriteConnector: vm.FIFOConnector(fifoSet.Stdin),
+				WriteConnector: vm.WriteFIFOConnector(fifoSet.Stdin),
 			}
 			ts.addCleanup(taskExecID, func() error {
 				return os.RemoveAll(req.Stdin)
@@ -465,7 +465,7 @@ func (ts *TaskService) Exec(requestCtx context.Context, req *taskAPI.ExecProcess
 		if req.Stdout != "" {
 			req.Stdout = fifoSet.Stdout
 			stdoutConnectorPair = &vm.IOConnectorPair{
-				ReadConnector:  vm.FIFOConnector(fifoSet.Stdout),
+				ReadConnector:  vm.ReadFIFOConnector(fifoSet.Stdout),
 				WriteConnector: vm.VSockAcceptConnector(extraData.StdoutPort),
 			}
 			ts.addCleanup(taskExecID, func() error {
@@ -477,7 +477,7 @@ func (ts *TaskService) Exec(requestCtx context.Context, req *taskAPI.ExecProcess
 		if req.Stderr != "" {
 			req.Stderr = fifoSet.Stderr
 			stderrConnectorPair = &vm.IOConnectorPair{
-				ReadConnector:  vm.FIFOConnector(fifoSet.Stderr),
+				ReadConnector:  vm.ReadFIFOConnector(fifoSet.Stderr),
 				WriteConnector: vm.VSockAcceptConnector(extraData.StderrPort),
 			}
 			ts.addCleanup(taskExecID, func() error {

--- a/internal/vm/ioproxy.go
+++ b/internal/vm/ioproxy.go
@@ -128,7 +128,7 @@ func (connectorPair *IOConnectorPair) proxy(
 		logger.Debug("begin copying io")
 		defer logger.Debug("end copying io")
 
-		_, err := io.CopyBuffer(writer, reader, make([]byte, internal.DefaultBufferSize))
+		size, err := io.CopyBuffer(writer, reader, make([]byte, internal.DefaultBufferSize))
 		if err != nil {
 			if strings.Contains(err.Error(), "use of closed network connection") ||
 				strings.Contains(err.Error(), "file already closed") {
@@ -138,6 +138,8 @@ func (connectorPair *IOConnectorPair) proxy(
 			}
 			copyDone <- err
 		}
+		logger.Debugf("copied %d", size)
+		defer logClose(logger, reader, writer)
 	}()
 
 	return initDone, copyDone

--- a/internal/vm/ioproxy_test.go
+++ b/internal/vm/ioproxy_test.go
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package vm
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fileConnector(path string, flag int) IOConnector {
+	return func(procCtx context.Context, logger *logrus.Entry) <-chan IOConnectorResult {
+		returnCh := make(chan IOConnectorResult, 1)
+		defer close(returnCh)
+
+		file, err := os.OpenFile(path, flag, 0600)
+		returnCh <- IOConnectorResult{
+			ReadWriteCloser: file,
+			Err:             err,
+		}
+
+		return returnCh
+	}
+}
+
+func TestProxy(t *testing.T) {
+	dir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	ctx := context.Background()
+	content := "hello world"
+
+	err = ioutil.WriteFile(filepath.Join(dir, "input"), []byte(content), 0600)
+	require.NoError(t, err)
+
+	pair := &IOConnectorPair{
+		ReadConnector:  fileConnector(filepath.Join(dir, "input"), os.O_RDONLY),
+		WriteConnector: fileConnector(filepath.Join(dir, "output"), os.O_CREATE|os.O_WRONLY),
+	}
+	initCh, copyCh := pair.proxy(ctx, logrus.WithFields(logrus.Fields{}), 0)
+
+	assert.Nil(t, <-initCh)
+	assert.Nil(t, <-copyCh)
+
+	bytes, err := ioutil.ReadFile(filepath.Join(dir, "output"))
+	require.NoError(t, err)
+	assert.Equal(t, content, string(bytes))
+}

--- a/internal/vm/task.go
+++ b/internal/vm/task.go
@@ -269,6 +269,9 @@ func (m *taskManager) monitorExit(proc *vmProc, taskService taskAPI.TaskService)
 		ID:     proc.taskID,
 		ExecID: proc.execID,
 	})
+
+	<-proc.ioCopyDone
+
 	proc.cancel()
 
 	if waitErr == context.Canceled {

--- a/internal/vm/task.go
+++ b/internal/vm/task.go
@@ -269,9 +269,6 @@ func (m *taskManager) monitorExit(proc *vmProc, taskService taskAPI.TaskService)
 		ID:     proc.taskID,
 		ExecID: proc.execID,
 	})
-
-	<-proc.ioCopyDone
-
 	proc.cancel()
 
 	if waitErr == context.Canceled {

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -1556,6 +1556,112 @@ func TestStopVM_Isolated(t *testing.T) {
 		})
 	}
 }
+
+func TestExec_Isolated(t *testing.T) {
+	prepareIntegTest(t)
+
+	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	defer client.Close()
+
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
+	require.NoError(t, err, "failed to get alpine image")
+
+	pluginClient, err := ttrpcutil.NewClient(containerdSockPath + ".ttrpc")
+	require.NoError(t, err, "failed to create ttrpc client")
+
+	vmID := testNameToVMID(t.Name())
+
+	fcClient := fccontrol.NewFirecrackerClient(pluginClient.Client())
+	_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{VMID: vmID})
+	require.NoError(t, err)
+
+	c, err := client.NewContainer(ctx,
+		"container-"+vmID,
+		containerd.WithSnapshotter(defaultSnapshotterName),
+		containerd.WithNewSnapshot("snapshot-"+vmID, image),
+		containerd.WithNewSpec(oci.WithProcessArgs("/bin/sleep", "3"), firecrackeroci.WithVMID(vmID)),
+	)
+	require.NoError(t, err)
+
+	var taskStdout bytes.Buffer
+	var taskStderr bytes.Buffer
+
+	task, err := c.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, &taskStdout, &taskStderr)))
+	require.NoError(t, err, "failed to create task for container %s", c.ID())
+
+	taskExitCh, err := task.Wait(ctx)
+	require.NoError(t, err, "failed to wait on task for container %s", c.ID())
+
+	err = task.Start(ctx)
+	require.NoError(t, err, "failed to start task for container %s", c.ID())
+
+	var execStdout bytes.Buffer
+	var execStderr bytes.Buffer
+
+	taskExec, err := task.Exec(ctx, "exec", &specs.Process{
+		Args: []string{"/bin/date"},
+		Cwd:  "/",
+	}, cio.NewCreator(cio.WithStreams(nil, &execStdout, &execStderr)))
+	require.NoError(t, err)
+
+	execExitCh, err := taskExec.Wait(ctx)
+	require.NoError(t, err, "failed to wait on exec %s", "exec")
+
+	execBegin := time.Now()
+	err = taskExec.Start(ctx)
+	require.NoError(t, err, "failed to start exec %s", "exec")
+
+	select {
+	case execStatus := <-execExitCh:
+		assert.NoError(t, execStatus.Error())
+		assert.Equal(t, uint32(0), execStatus.ExitCode())
+
+		execElapsed := time.Since(execBegin)
+		assert.Truef(
+			t, execElapsed < 1*time.Second,
+			"The exec took %s to finish, which was too slow.", execElapsed,
+		)
+
+		_, err := taskExec.Delete(ctx)
+		assert.NoError(t, err)
+
+		deleteElapsed := time.Since(execBegin)
+		assert.Truef(
+			t, deleteElapsed < 1*time.Second,
+			"The deletion of the exec took %s to finish, which was too slow.", deleteElapsed,
+		)
+
+		assert.NotEqual(t, "", execStdout.String())
+		assert.Equal(t, "", execStderr.String())
+	case <-ctx.Done():
+		require.Fail(t, "context cancelled",
+			"context cancelled while waiting for container %s to exit, err: %v", c.ID(), ctx.Err())
+	}
+
+	select {
+	case taskStatus := <-taskExitCh:
+		assert.NoError(t, taskStatus.Error())
+		assert.Equal(t, uint32(0), taskStatus.ExitCode())
+
+		deleteResult, err := task.Delete(ctx)
+		assert.NoErrorf(t, err, "failed to delete task %q after exit", c.ID())
+		assert.NoError(t, deleteResult.Error())
+
+		assert.Equal(t, "", taskStdout.String())
+		assert.Equal(t, "", taskStderr.String())
+	case <-ctx.Done():
+		require.Fail(t, "context cancelled",
+			"context cancelled while waiting for container %s to exit, err: %v", c.ID(), ctx.Err())
+	}
+
+	_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: vmID})
+	assert.NoError(t, err)
+	require.Equal(t, status.Code(err), codes.OK)
+}
+
 func TestEvents_Isolated(t *testing.T) {
 	prepareIntegTest(t)
 	require := require.New(t)

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -1589,7 +1589,7 @@ func TestExec_Isolated(t *testing.T) {
 	var taskStdout bytes.Buffer
 	var taskStderr bytes.Buffer
 
-	task, err := c.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, &taskStdout, &taskStderr)))
+	task, err := c.NewTask(ctx, cio.NewCreator(cio.WithStreams(os.Stdin, &taskStdout, &taskStderr)))
 	require.NoError(t, err, "failed to create task for container %s", c.ID())
 
 	taskExitCh, err := task.Wait(ctx)
@@ -1604,7 +1604,7 @@ func TestExec_Isolated(t *testing.T) {
 	taskExec, err := task.Exec(ctx, "exec", &specs.Process{
 		Args: []string{"/bin/date"},
 		Cwd:  "/",
-	}, cio.NewCreator(cio.WithStreams(nil, &execStdout, &execStderr)))
+	}, cio.NewCreator(cio.WithStreams(os.Stdin, &execStdout, &execStderr)))
 	require.NoError(t, err)
 
 	execExitCh, err := taskExec.Wait(ctx)


### PR DESCRIPTION
Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

NA

*Description of changes:*

* The first commit reproduces the issue
* The second commit fixes the issue. Opening a FIFO with O_RDWR is unnecessary and makes EOF invisible.
* The third commit fixes a timing issue. Closing all connectors by the cancellation of the passed context seems too early. We need to copy bytes even after the end of the process, since a pipe can buffer some bytes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
