### PR TITLE
Adds debug helper

### DIFF
--- a/config/config.json.example
+++ b/config/config.json.example
@@ -4,6 +4,6 @@
   "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw",
   "root_drive": "./vsock.img",
   "cpu_template": "T2",
-  "log_level": "Debug",
+  "log_levels": ["debug"],
   "ht_enabled": false
 }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,65 @@
+## Logging Congiguration
+--
+
+firecracker-containerd allows for users to specify per application/library
+logging. We do this by setting the `log_levels` field in the
+firecracker-runtime.json file.
+
+```json
+{
+  "firecracker_binary_path": "/usr/local/bin/firecracker",
+  "kernel_image_path": "/var/lib/firecracker-containerd/runtime/default-vmlinux.bin",
+  "kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
+  "root_drive": "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
+  "cpu_count": 1,
+  "cpu_template": "T2",
+  "log_levels": ["debug"],
+  "jailer": {
+    "runc_binary_path": "/usr/local/bin/runc"
+  }
+}
+```
+
+| log levels                     | description                                                                     |
+| :---------------------------:  | :-----------------------------------------------------------------------------: |
+| error                          | This will set all log levels to error                                           |
+| warning                        | This will set all log levels to warning                                         |
+| info                           | This will set all log levels to info                                            |
+| debug                          | This will set all log levels to debug                                           |
+| firecracker:error              | Logs any error information in Firecracker's lifecycle                           |
+| firecracker:warning            | Logs any error and warning information in Firecracker's lifecycle               |
+| firecracker:info               | Logs any error, warning, info information in Firecracker's lifecycle            |
+| firecracker:debug              | Most verbose log level for firecracker                                          |
+| firecracker:output             | Logs Firecracker's stdout and stderr. Can be used with other firecracker levels |
+| firecracker-go-sdk:error       | Logs any errors information in firecracker-go-sdk                               |
+| firecracker-go-sdk:warning     | Logs any errors or warnings in firracker-go-sdk                                 |
+| firecracker-go-sdk:info        | Logs any errors, warnings, or infos in firecracker-go-sdk                       |
+| firecracker-go-sdk:debug       | Most verbose logging for firecracker-go-sdk                                     |
+| firecracker-containerd:error   | Logs any error information during the container/vm lifecycle                    |
+| firecracker-containerd:warning | Logs any error level logs along with any warn level logs                        |
+| firecracker-containerd:info    | Logs any error, warn, and info level logs                                       |
+| firecracker-containerd:debug   | Most verbose logging for firecracker-containerd                                 |
+
+The firecracker:XX are mutually exclusive with other firecracker-YY meaning only one of the log levels can be set at a time. 
+However, firecracker:output may be set with other firecracker:YY settings.
+The firecracker-containerd:XX are also mutually exclusive with other firecracker-containerd-YY levels
+info, error, warning, and debug are mutually exclusive and only one can be set at a time.
+
+```json
+{
+  "firecracker_binary_path": "/usr/local/bin/firecracker",
+  "kernel_image_path": "/var/lib/firecracker-containerd/runtime/default-vmlinux.bin",
+  "kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
+  "root_drive": "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
+  "cpu_count": 1,
+  "cpu_template": "T2",
+  "log:levels": ["info","firecracker:debug","firecracker-containerd:error"],
+  "jailer": {
+    "runc_binary_path": "/usr/local/bin/runc"
+  }
+}
+```
+
+The example above shows that setting the log levels to info, but specifies that
+firecracker to be on a debug level and firecracker-containerd to be logging at
+the error level

--- a/examples/etc/containerd/firecracker-runtime.json
+++ b/examples/etc/containerd/firecracker-runtime.json
@@ -5,8 +5,7 @@
   "root_drive": "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
   "cpu_count": 1,
   "cpu_template": "T2",
-  "log_level": "Debug",
-  "debug": true,
+  "log_levels": ["debug"],
   "jailer": {
     "runc_binary_path": "/usr/local/bin/runc"
   }

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,0 +1,326 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package debug
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// LogLevelDebug will enable debugging for all applciations and SDKs. This
+	// uses log levels of firecracker:debug, firecracker-go-sdk:debug,
+	// firecracker:output, and firecracker-containerd:debug
+	LogLevelDebug = "debug"
+	// LogLevelError will enable error logging for all applciations and SDKs.
+	// This uses log levels of firecracker:error, firecracker-go-sdk:error,
+	// and firecracker-containerd:error
+	LogLevelError = "error"
+	// LogLevelInfo will enable info logging for all applciations and SDKs.
+	// This uses log levels of firecracker:info, firecracker-go-sdk:info,
+	// and firecracker-containerd:info
+	LogLevelInfo = "info"
+	// LogLevelWarning will enable warning logging for all applciations and SDKs.
+	// This uses log levels of firecracker:warning, firecracker-go-sdk:warning,
+	// firecracker:output, and firecracker-containerd:warning
+	LogLevelWarning = "warning"
+	// LogLevelFirecrackerDebug enables debug level logging on Firecracker
+	// MicroVMs
+	LogLevelFirecrackerDebug = "firecracker:debug"
+	// LogLevelFirecrackerError enables error level logging on Firecracker
+	// MicroVMs
+	LogLevelFirecrackerError = "firecracker:error"
+	// LogLevelFirecrackerInfo enables info level logging on Firecracker MicroVMs
+	LogLevelFirecrackerInfo = "firecracker:info"
+	// LogLevelFirecrackerWarning enables warning level logging on Firecracker
+	// MicroVMs
+	LogLevelFirecrackerWarning = "firecracker:warning"
+	// LogLevelFirecrackerOutput will redirect stdout and stderr of Firecracker
+	// to logging. By default, stdout and stderr is ignored
+	LogLevelFirecrackerOutput = "firecracker:output"
+	// LogLevelFirecrackerSDKDebug enables debug level logging on
+	// firecracker-go-sdk
+	LogLevelFirecrackerSDKDebug = "firecracker-go-sdk:debug"
+	// LogLevelFirecrackerSDKError enables error level logging on
+	// firecracker-go-sdk
+	LogLevelFirecrackerSDKError = "firecracker-go-sdk:error"
+	// LogLevelFirecrackerSDKInfo enables info level logging on
+	// firecracker-go-sdk
+	LogLevelFirecrackerSDKInfo = "firecracker-go-sdk:info"
+	// LogLevelFirecrackerSDKWarning enables warning level logging on
+	// firecracker-go-sdk
+	LogLevelFirecrackerSDKWarning = "firecracker-go-sdk:warning"
+	// LogLevelFirecrackerContainerdDebug enables debug level logging on
+	// firecracker-containerd
+	LogLevelFirecrackerContainerdDebug = "firecracker-containerd:debug"
+	// LogLevelFirecrackerContainerdError enables error level logging on
+	// firecracker-containerd
+	LogLevelFirecrackerContainerdError = "firecracker-containerd:error"
+	// LogLevelFirecrackerContainerdInfo enables info level logging on
+	// firecracker-containerd
+	LogLevelFirecrackerContainerdInfo = "firecracker-containerd:info"
+	// LogLevelFirecrackerContainerdWarning enables warning level logging on
+	// firecracker-containerd
+	LogLevelFirecrackerContainerdWarning = "firecracker-containerd:warning"
+)
+
+// ErrLogLevelAlreadySet will return if a log level has been previously set.
+var ErrLogLevelAlreadySet = fmt.Errorf("only one value for top level log level can be set")
+
+// ErrFCLogLevelAlreadySet will return if a log level has been previously set.
+var ErrFCLogLevelAlreadySet = fmt.Errorf("only one value of firecracker log level can be set")
+
+// ErrFCSDKLogLevelAlreadySet will return if a log level has been previously set.
+var ErrFCSDKLogLevelAlreadySet = fmt.Errorf("only one value of firecracker-go-sdk log level can be set")
+
+// ErrFCContainerdLogLevelAlreadySet will return if a log level has been previously set.
+var ErrFCContainerdLogLevelAlreadySet = fmt.Errorf("only one value of firecracker-containerd log level can be set")
+
+// Helper is used to abstract away the complications of multilevel log levels.
+type Helper struct {
+	logLevels []string
+	ShimDebug bool
+
+	logDebug        bool
+	logError        bool
+	logInfo         bool
+	logWarning      bool
+	logFCSDK        logrus.Level
+	logFCOutput     bool
+	logFC           string
+	logFCContainerd logrus.Level
+
+	fcSDKLogLevelSet        bool
+	fcContainerdLogLevelSet bool
+}
+
+// New will return a new Helper in the event an error does not occur. This will
+// parse the logLevel provided to figure out what logging is enabled. New will
+// also validate that the log level is a valid value along with any mutually
+// exclusive values.
+func New(logLevels ...string) (*Helper, error) {
+	h := &Helper{
+		logLevels: logLevels,
+	}
+
+	if err := h.setLogLevels(logLevels); err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+// GetFirecrackerLogLevel will return the current log level for Firecracker.
+func (h *Helper) GetFirecrackerLogLevel() string {
+	if h.logFC != "" {
+		return h.logFC
+	}
+
+	if h.logDebug {
+		return "Debug"
+	}
+
+	if h.logError {
+		return "Error"
+	}
+
+	if h.logInfo {
+		return "Info"
+	}
+
+	if h.logWarning {
+		return "Warning"
+	}
+
+	return h.logFC
+}
+
+// LogFirecrackerOutput will return whether our not we want to redirect stdout
+// and stderr to our logging
+func (h *Helper) LogFirecrackerOutput() bool {
+	return h.logDebug || h.logFCOutput
+}
+
+// GetFirecrackerSDKLogLevel returns what log level to log the
+// firecracker-go-sdk at. This also return whether or not the value was set
+func (h *Helper) GetFirecrackerSDKLogLevel() (logrus.Level, bool) {
+	if h.fcSDKLogLevelSet {
+		return h.logFCSDK, true
+	}
+
+	if h.logDebug {
+		return logrus.DebugLevel, true
+	}
+
+	if h.logError {
+		return logrus.ErrorLevel, true
+	}
+
+	if h.logInfo {
+		return logrus.InfoLevel, true
+	}
+
+	if h.logWarning {
+		return logrus.WarnLevel, true
+	}
+
+	return h.logFCSDK, false
+}
+
+// GetFirecrackerContainerdLogLevel return the log level for
+// firecracker-containerd
+func (h *Helper) GetFirecrackerContainerdLogLevel() (logrus.Level, bool) {
+	if h.fcContainerdLogLevelSet {
+		return h.logFCContainerd, h.fcContainerdLogLevelSet
+	}
+
+	if h.logDebug || h.ShimDebug {
+		return logrus.DebugLevel, true
+	}
+
+	if h.logError {
+		return logrus.ErrorLevel, true
+	}
+
+	if h.logInfo {
+		return logrus.InfoLevel, true
+	}
+
+	if h.logWarning {
+		return logrus.WarnLevel, true
+	}
+
+	return logrus.PanicLevel, false
+}
+
+func (h *Helper) setFirecrackerLogLevel(level string) error {
+	if h.logFC != "" {
+		return ErrFCLogLevelAlreadySet
+	}
+
+	h.logFC = level
+	return nil
+}
+
+func (h *Helper) setFirecrackerContainerdLogLevel(level logrus.Level) error {
+	if h.fcContainerdLogLevelSet {
+		return ErrFCContainerdLogLevelAlreadySet
+	}
+
+	h.fcContainerdLogLevelSet = true
+	h.logFCContainerd = level
+	return nil
+}
+
+func (h *Helper) setFirecrackerSDKLogLevel(level logrus.Level) error {
+	if h.fcSDKLogLevelSet {
+		return ErrFCSDKLogLevelAlreadySet
+	}
+	h.fcSDKLogLevelSet = true
+	h.logFCSDK = level
+	return nil
+}
+
+func (h *Helper) isTopLogLevelSet() bool {
+	return h.logDebug || h.logError || h.logInfo || h.logWarning
+}
+
+func (h *Helper) setLogLevels(logLevels []string) error {
+	if len(logLevels) == 0 {
+		return nil
+	}
+
+	for _, level := range logLevels {
+		cleanedLevel := strings.TrimSpace(level)
+
+		switch cleanedLevel {
+		case LogLevelDebug:
+			if h.isTopLogLevelSet() {
+				return ErrLogLevelAlreadySet
+			}
+			h.logDebug = true
+		case LogLevelError:
+			if h.isTopLogLevelSet() {
+				return ErrLogLevelAlreadySet
+			}
+			h.logError = true
+		case LogLevelInfo:
+			if h.isTopLogLevelSet() {
+				return ErrLogLevelAlreadySet
+			}
+			h.logInfo = true
+		case LogLevelWarning:
+			if h.isTopLogLevelSet() {
+				return ErrLogLevelAlreadySet
+			}
+			h.logWarning = true
+		case LogLevelFirecrackerDebug:
+			if err := h.setFirecrackerLogLevel("Debug"); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerError:
+			if err := h.setFirecrackerLogLevel("Error"); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerInfo:
+			if err := h.setFirecrackerLogLevel("Info"); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerWarning:
+			if err := h.setFirecrackerLogLevel("Warning"); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerOutput:
+			h.logFCOutput = true
+		case LogLevelFirecrackerSDKDebug:
+			if err := h.setFirecrackerSDKLogLevel(logrus.DebugLevel); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerSDKError:
+			if err := h.setFirecrackerSDKLogLevel(logrus.ErrorLevel); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerSDKInfo:
+			if err := h.setFirecrackerSDKLogLevel(logrus.InfoLevel); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerSDKWarning:
+			if err := h.setFirecrackerSDKLogLevel(logrus.WarnLevel); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerContainerdDebug:
+			if err := h.setFirecrackerContainerdLogLevel(logrus.DebugLevel); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerContainerdError:
+			if err := h.setFirecrackerContainerdLogLevel(logrus.ErrorLevel); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerContainerdInfo:
+			if err := h.setFirecrackerContainerdLogLevel(logrus.InfoLevel); err != nil {
+				return err
+			}
+		case LogLevelFirecrackerContainerdWarning:
+			if err := h.setFirecrackerContainerdLogLevel(logrus.WarnLevel); err != nil {
+				return err
+			}
+		default:
+			return NewInvalidLogLevelError(cleanedLevel)
+		}
+	}
+
+	return nil
+}

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -1,0 +1,228 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package debug
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	cases := []struct {
+		Name           string
+		LogLevels      []string
+		ExpectedError  error
+		ExpectedHelper *Helper
+	}{
+		{
+			Name:           "empty",
+			ExpectedHelper: &Helper{},
+		},
+		{
+			Name:          "invalid",
+			LogLevels:     []string{"invalid"},
+			ExpectedError: NewInvalidLogLevelError("invalid"),
+		},
+		{
+			Name:          "multiple with invalid",
+			LogLevels:     []string{LogLevelDebug, LogLevelFirecrackerDebug, "invalid"},
+			ExpectedError: NewInvalidLogLevelError("invalid"),
+		},
+		{
+			Name:      "debug",
+			LogLevels: []string{LogLevelDebug},
+			ExpectedHelper: &Helper{
+				logDebug: true,
+			},
+		},
+		{
+			Name:      "error",
+			LogLevels: []string{LogLevelError},
+			ExpectedHelper: &Helper{
+				logError: true,
+			},
+		},
+		{
+			Name:      "info",
+			LogLevels: []string{LogLevelInfo},
+			ExpectedHelper: &Helper{
+				logInfo: true,
+			},
+		},
+		{
+			Name:      "warning",
+			LogLevels: []string{LogLevelWarning},
+			ExpectedHelper: &Helper{
+				logWarning: true,
+			},
+		},
+		{
+			Name:          "multiple top log levels",
+			LogLevels:     []string{LogLevelDebug, LogLevelError, LogLevelInfo, LogLevelWarning},
+			ExpectedError: ErrLogLevelAlreadySet,
+		},
+		{
+			Name:      "firecracker debug",
+			LogLevels: []string{LogLevelFirecrackerDebug},
+			ExpectedHelper: &Helper{
+				logFC: "Debug",
+			},
+		},
+		{
+			Name:      "firecracker error",
+			LogLevels: []string{LogLevelFirecrackerError},
+			ExpectedHelper: &Helper{
+				logFC: "Error",
+			},
+		},
+		{
+			Name:      "firecracker info",
+			LogLevels: []string{LogLevelFirecrackerInfo},
+			ExpectedHelper: &Helper{
+				logFC: "Info",
+			},
+		},
+		{
+			Name:      "firecracker warning",
+			LogLevels: []string{LogLevelFirecrackerWarning},
+			ExpectedHelper: &Helper{
+				logFC: "Warning",
+			},
+		},
+		{
+			Name:      "firecracker output",
+			LogLevels: []string{LogLevelFirecrackerOutput},
+			ExpectedHelper: &Helper{
+				logFCOutput: true,
+			},
+		},
+		{
+			Name:          "multiple firecracker log levels",
+			LogLevels:     []string{LogLevelFirecrackerWarning, LogLevelFirecrackerDebug, LogLevelFirecrackerError},
+			ExpectedError: ErrFCLogLevelAlreadySet,
+		},
+		{
+			Name:      "firecracker-go-sdk debug level",
+			LogLevels: []string{LogLevelFirecrackerSDKDebug},
+			ExpectedHelper: &Helper{
+				fcSDKLogLevelSet: true,
+				logFCSDK:         logrus.DebugLevel,
+			},
+		},
+		{
+			Name:      "firecracker-go-sdk error level",
+			LogLevels: []string{LogLevelFirecrackerSDKError},
+			ExpectedHelper: &Helper{
+				fcSDKLogLevelSet: true,
+				logFCSDK:         logrus.ErrorLevel,
+			},
+		},
+		{
+			Name:      "firecracker-go-sdk info level",
+			LogLevels: []string{LogLevelFirecrackerSDKInfo},
+			ExpectedHelper: &Helper{
+				fcSDKLogLevelSet: true,
+				logFCSDK:         logrus.InfoLevel,
+			},
+		},
+		{
+			Name:      "firecracker-go-sdk warning level",
+			LogLevels: []string{LogLevelFirecrackerSDKWarning},
+			ExpectedHelper: &Helper{
+				fcSDKLogLevelSet: true,
+				logFCSDK:         logrus.WarnLevel,
+			},
+		},
+		{
+			Name:      "firecracker-go-sdk multiple levels",
+			LogLevels: []string{LogLevelDebug, LogLevelFirecrackerSDKWarning},
+			ExpectedHelper: &Helper{
+				logFC:                   "Debug",
+				fcSDKLogLevelSet:        true,
+				logFCSDK:                logrus.WarnLevel,
+				fcContainerdLogLevelSet: true,
+				logFCContainerd:         logrus.DebugLevel,
+			},
+		},
+		{
+			Name:          "firecracker-go-sdk multiple levels",
+			LogLevels:     []string{LogLevelDebug, LogLevelFirecrackerSDKWarning, LogLevelFirecrackerSDKDebug},
+			ExpectedError: ErrFCSDKLogLevelAlreadySet,
+		},
+		{
+			Name:      "firecracker containerd debug",
+			LogLevels: []string{LogLevelFirecrackerContainerdDebug},
+			ExpectedHelper: &Helper{
+				fcContainerdLogLevelSet: true,
+				logFCContainerd:         logrus.DebugLevel,
+			},
+		},
+		{
+			Name:      "firecracker containerd error",
+			LogLevels: []string{LogLevelFirecrackerContainerdError},
+			ExpectedHelper: &Helper{
+				fcContainerdLogLevelSet: true,
+				logFCContainerd:         logrus.ErrorLevel,
+			},
+		},
+		{
+			Name:      "firecracker containerd info",
+			LogLevels: []string{LogLevelFirecrackerContainerdInfo},
+			ExpectedHelper: &Helper{
+				fcContainerdLogLevelSet: true,
+				logFCContainerd:         logrus.InfoLevel,
+			},
+		},
+		{
+			Name:      "firecracker containerd warning",
+			LogLevels: []string{LogLevelFirecrackerContainerdWarning},
+			ExpectedHelper: &Helper{
+				fcContainerdLogLevelSet: true,
+				logFCContainerd:         logrus.WarnLevel,
+			},
+		},
+		{
+			Name:          "multiple firecracker containerd log levels",
+			LogLevels:     []string{LogLevelFirecrackerContainerdWarning, LogLevelFirecrackerContainerdDebug, LogLevelFirecrackerContainerdError},
+			ExpectedError: ErrFCContainerdLogLevelAlreadySet,
+		},
+	}
+
+	for _, _c := range cases {
+		c := _c
+
+		t.Run(c.Name, func(t *testing.T) {
+			h, err := New(c.LogLevels...)
+			require.Equalf(t, c.ExpectedError, err, "expected errors to be equal")
+			if c.ExpectedError != nil {
+				return
+			}
+
+			require.NotNilf(t, h, "expected Helper to be non-nil")
+
+			assert.Equal(t, c.ExpectedHelper.GetFirecrackerLogLevel(), h.GetFirecrackerLogLevel())
+			expectedLogLevel, expectedOk := c.ExpectedHelper.GetFirecrackerSDKLogLevel()
+			logLevel, ok := h.GetFirecrackerSDKLogLevel()
+			assert.Equal(t, expectedOk, ok)
+			assert.Equal(t, expectedLogLevel, logLevel)
+			expectedLogLevel, expectedOk = c.ExpectedHelper.GetFirecrackerContainerdLogLevel()
+			logLevel, ok = h.GetFirecrackerContainerdLogLevel()
+			assert.Equal(t, expectedOk, ok)
+			assert.Equal(t, expectedLogLevel, logLevel)
+		})
+	}
+}

--- a/internal/debug/error.go
+++ b/internal/debug/error.go
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package debug
+
+import (
+	"fmt"
+)
+
+// InvalidLogLevelError is an error that will be returned in the event that an
+// invalid log level was provided
+type InvalidLogLevelError struct {
+	logLevel string
+}
+
+// NewInvalidLogLevelError will constract an InvalidLogLevelError
+func NewInvalidLogLevelError(logLevel string) error {
+	return &InvalidLogLevelError{
+		logLevel: logLevel,
+	}
+}
+
+func (e *InvalidLogLevelError) Error() string {
+	return fmt.Sprintf("log level %q is an invalid log level", e.logLevel)
+}

--- a/runtime/integ_test.go
+++ b/runtime/integ_test.go
@@ -38,8 +38,7 @@ var defaultRuntimeConfig = config.Config{
 	KernelArgs:            "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.log_color=false systemd.unit=firecracker.target init=/sbin/overlay-init",
 	RootDrive:             "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
 	CPUTemplate:           "T2",
-	LogLevel:              "Debug",
-	Debug:                 true,
+	LogLevels:             []string{"debug"},
 	ShimBaseDir:           shimBaseDir(),
 	JailerConfig: config.JailerConfig{
 		RuncBinaryPath: "/usr/local/bin/runc",

--- a/runtime/noop_jailer.go
+++ b/runtime/noop_jailer.go
@@ -59,7 +59,7 @@ func (j *noopJailer) BuildJailedMachine(cfg *config.Config, machineConfig *firec
 		WithSocketPath(relSocketPath).
 		Build(j.ctx)
 
-	if cfg.Debug {
+	if cfg.DebugHelper.LogFirecrackerOutput() {
 		cmd.Stdout = j.logger.WithField("vmm_stream", "stdout").WriterLevel(logrus.DebugLevel)
 		cmd.Stderr = j.logger.WithField("vmm_stream", "stderr").WriterLevel(logrus.DebugLevel)
 	}

--- a/runtime/runc_jailer.go
+++ b/runtime/runc_jailer.go
@@ -132,7 +132,7 @@ func (j *runcJailer) BuildJailedMachine(cfg *config.Config, machineConfig *firec
 	}
 
 	opts := []firecracker.Opt{
-		firecracker.WithProcessRunner(j.jailerCommand(vmID, cfg.Debug)),
+		firecracker.WithProcessRunner(j.jailerCommand(vmID, cfg.DebugHelper.LogFirecrackerOutput())),
 		firecracker.WithClient(client),
 		func(m *firecracker.Machine) {
 			m.Handlers.FcInit = m.Handlers.FcInit.Prepend(handler)

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -157,14 +157,12 @@ func NewService(shimCtx context.Context, id string, remotePublisher shim.Publish
 		return nil, err
 	}
 
-	if !cfg.Debug {
-		opts, err := shimOpts(shimCtx)
-		if err != nil {
-			return nil, err
-		}
-
-		cfg.Debug = opts.Debug
+	opts, err := shimOpts(shimCtx)
+	if err != nil {
+		return nil, err
 	}
+
+	cfg.DebugHelper.ShimDebug = opts.Debug
 
 	namespace, ok := namespaces.Namespace(shimCtx)
 	if !ok {
@@ -183,9 +181,10 @@ func NewService(shimCtx context.Context, id string, remotePublisher shim.Publish
 		}
 	}
 
-	if cfg.Debug {
-		logrus.SetLevel(logrus.DebugLevel)
-		logger.Logger.SetLevel(logrus.DebugLevel)
+	logrusLevel, ok := cfg.DebugHelper.GetFirecrackerContainerdLogLevel()
+	if ok {
+		logrus.SetLevel(logrusLevel)
+		logger.Logger.SetLevel(logrusLevel)
 	}
 
 	s := &service{
@@ -503,10 +502,13 @@ func (s *service) createVM(requestCtx context.Context, request *proto.CreateVMRe
 		return errors.Wrapf(err, "failed to build VM configuration")
 	}
 
-	opts := []firecracker.Opt{
-		firecracker.WithLogger(s.logger),
-	}
+	opts := []firecracker.Opt{}
 
+	if v, ok := s.config.DebugHelper.GetFirecrackerSDKLogLevel(); ok {
+		logger := log.G(s.shimCtx)
+		logger.Logger.SetLevel(v)
+		opts = append(opts, firecracker.WithLogger(logger))
+	}
 	relVSockPath, err := s.jailer.JailPath().FirecrackerVSockRelPath()
 	if err != nil {
 		return errors.Wrapf(err, "failed to get relative path to firecracker vsock")
@@ -709,8 +711,7 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 		LogFifo:     s.shimDir.FirecrackerLogFifoPath(),
 		MetricsFifo: s.shimDir.FirecrackerMetricsFifoPath(),
 		MachineCfg:  machineConfigurationFromProto(s.config, req.MachineCfg),
-		LogLevel:    s.config.LogLevel,
-		Debug:       s.config.Debug,
+		LogLevel:    s.config.DebugHelper.GetFirecrackerLogLevel(),
 		VMID:        s.vmID,
 	}
 


### PR DESCRIPTION
This adds the debug package and debug.Helper which allows for easier
management of debug log levels. This also gets rid of the Debug field in
Config as it was really confusing on what logging that enabled, and also
firecracker-runtime.json. The log_level/LogLevel field in Config and the
firecracker-runtime.json has been renamed to log_levels and LogLevels.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
