### PR TITLE
Mount and start Agent instead of calling systemd

### DIFF
--- a/tools/image-builder/files_debootstrap/sbin/overlay-init
+++ b/tools/image-builder/files_debootstrap/sbin/overlay-init
@@ -57,6 +57,9 @@ fi
 
 do_overlay
 
-# invoke the actual system init program and procede with the boot
-# process.
-exec /usr/sbin/init $@
+mount -n -t devtmpfs -o rw,nosuid,relatime,mode=755 udev  /dev
+mount -n -t sysfs    -o nodev,noexec,nosuid         sysfs /sys
+mount -n -t proc     -o rw,nosuid,nodev,noexec      proc  /proc
+mount -n -t cgroup   -o all                         cgroup /sys/fs/cgroup
+
+PATH=/usr/local/bin /usr/local/bin/agent


### PR DESCRIPTION
It won't be suitable for production, but would be interesting to see
the baseline of our performance.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
