### PR TITLE
Measure only CreateVM

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -92,7 +92,7 @@ benchmark-%: logs
 		--workdir="/src/runtime" \
 		--init \
 		$(FIRECRACKER_CONTAINERD_TEST_IMAGE):$(DOCKER_IMAGE_TAG) \
-		"go test $(EXTRAGOARGS) -run IGNORE -bench '$(subst benchmark-,,$@)'"
+		"go test $(EXTRAGOARGS) -run '$(subst benchmark-,,$@)'"
 
 logs:
 	mkdir logs


### PR DESCRIPTION

*Issue #, if available:*

NA

*Description of changes:*

Previously the benchmark was measuring both CreateVM and StopVM due to
Go's benchmark's limitation.

Since we mostly care CreateVM, this change removes StopVM from
the measurement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
