### PR TITLE
Remove vm metadata from debug logs

### DIFF
--- a/firecracker-control/service.go
+++ b/firecracker-control/service.go
@@ -83,16 +83,16 @@ func (s *service) GetVMInfo(ctx context.Context, req *proto.GetVMInfoRequest) (*
 }
 
 func (s *service) SetVMMetadata(ctx context.Context, req *proto.SetVMMetadataRequest) (*empty.Empty, error) {
-	log.G(ctx).Debugf("set vm metadata: %+v", req)
+	log.G(ctx).Debug("Setting vm metadata")
 	return s.local.SetVMMetadata(ctx, req)
 }
 
 func (s *service) UpdateVMMetadata(ctx context.Context, req *proto.UpdateVMMetadataRequest) (*empty.Empty, error) {
-	log.G(ctx).Debugf("update vm metadata: %+v", req)
+	log.G(ctx).Debug("Updating vm metadata")
 	return s.local.UpdateVMMetadata(ctx, req)
 }
 
 func (s *service) GetVMMetadata(ctx context.Context, req *proto.GetVMMetadataRequest) (*proto.GetVMMetadataResponse, error) {
-	log.G(ctx).Debugf("get vm metadata: %+v", req)
+	log.G(ctx).Debug("Getting vm metadata")
 	return s.local.GetVMMetadata(ctx, req)
 }


### PR DESCRIPTION
The vm metadata is potentially sensitive and we don't want to log it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
