### PR TITLE
Populate response for CreateVM in Runtime shim

### DIFF
--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -1849,13 +1849,15 @@ func TestCreateVM_Isolated(t *testing.T) {
 		t.Run(subtest.name, func(t *testing.T) {
 			request.VMID = testNameToVMID(t.Name())
 
-			_, err = fcClient.CreateVM(ctx, &request)
+			resp, err := fcClient.CreateVM(ctx, &request)
 			validate(t, err)
-
 			if err != nil {
 				// No VM to stop.
 				return
 			}
+
+			// Ensure the response fields are populated correctly
+			assert.Equal(t, request.VMID, resp.VMID)
 
 			_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: request.VMID})
 			require.Equal(t, status.Code(err), codes.OK)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Populate the response fields in the Runtime Shim's CreateVM method and refactor redundant calls to determine the shim directory and VM namespace. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
