### PR TITLE
Rename log_level to log_levels

### DIFF
--- a/.buildkite/setup_al2.sh
+++ b/.buildkite/setup_al2.sh
@@ -43,7 +43,7 @@ cat << EOF > $runtime_config_path
 	"shim_base_dir": "$dir",
 	"kernel_image_path": "$dir/default-vmlinux.bin",
 	"kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.log_color=false systemd.unit=firecracker.target init=/sbin/overlay-init",
-	"log_level": "DEBUG",
+	"log_levels": ["debug"],
 	"root_drive": "$dir/default-rootfs.img",
 	"jailer": {
 		"runc_binary_path": "$bin_path/runc",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -232,7 +232,7 @@ configuration file has the following fields:
   values are "C3" and "T2".
 * `additional_drives` (unused)
 * `log_fifo` (optional) - Named pipe where Firecracker logs should be delivered.
-* `log_level` (optional) - Log level for the Firecracker logs
+* `log_levels` (optional) - Log level for the Firecracker logs.
 * `metrics_fifo` (optional) - Named pipe where Firecracker metrics should be
   delivered.
 * `ht_enabled` (unused) - Reserved for future use.
@@ -255,7 +255,7 @@ configuration file has the following fields:
   "root_drive": "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
   "cpu_template": "T2",
   "log_fifo": "fc-logs.fifo",
-  "log_level": "Debug",
+  "log_levels": ["debug"],
   "metrics_fifo": "fc-metrics.fifo"
 }
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -161,7 +161,7 @@ sudo tee /etc/containerd/firecracker-runtime.json <<EOF
   "firecracker_binary_path": "/usr/local/bin/firecracker",
   "cpu_template": "T2",
   "log_fifo": "fc-logs.fifo",
-  "log_level": "Debug",
+  "log_levels": ["debug"],
   "metrics_fifo": "fc-metrics.fifo",
   "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules ro systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
   "default_network_interfaces": [{


### PR DESCRIPTION
The log_level field doesn't work anymore.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
