### PR TITLE
Make FICD_DM_POOL and NUMBER_OF_VMS optional

### DIFF
--- a/.buildkite/al2_cleanup.sh
+++ b/.buildkite/al2_cleanup.sh
@@ -2,4 +2,4 @@
 source .buildkite/al2env.sh
 
 sudo rm -rf $dir
-./tools/thinpool.sh remove $unique_id
+FICD_DM_VOLUME_GROUP=fcci-vg ./tools/thinpool.sh remove $unique_id

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 tools/image-builder/rootfs/
+tmp/

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -21,6 +21,7 @@ GOSUM := $(GOMOD:.mod=.sum)
 DOCKER_IMAGE_TAG?=latest
 GO_CACHE_VOLUME_NAME?=gocache
 FIRECRACKER_CONTAINERD_TEST_IMAGE?=localhost/firecracker-containerd-test
+FICD_DM_POOL?=fc-test-thinpool
 
 REVISION=$(shell git rev-parse HEAD)
 

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -251,10 +251,10 @@ func TestMultipleVMs_Isolated(t *testing.T) {
 	require.NoError(t, err, "failed to get a namespace")
 
 	// numberOfVmsEnvName = NUMBER_OF_VMS ENV and is configurable from buildkite
-	numberOfVms, err := strconv.Atoi(os.Getenv(numberOfVmsEnvName))
-	require.NoError(t, err, "failed to get NUMBER_OF_VMS env")
-	if numberOfVms == 0 {
-		numberOfVms = defaultNumberOfVms
+	numberOfVms := defaultNumberOfVms
+	if str := os.Getenv(numberOfVmsEnvName); str != "" {
+		numberOfVms, err = strconv.Atoi(str)
+		require.NoError(t, err, "failed to get NUMBER_OF_VMS env")
 	}
 	t.Logf("TestMultipleVMs_Isolated: will run %d vm's", numberOfVms)
 

--- a/tools/thinpool.sh
+++ b/tools/thinpool.sh
@@ -15,7 +15,11 @@
 
 FICD_DM_VOLUME_GROUP="$FICD_DM_VOLUME_GROUP"
 
-set -eu
+# The tmp/devmapper/ directory will be created on this project's
+# root directory.
+DIR=$(dirname $BASH_SOURCE)/../tmp/devmapper
+
+set -euo pipefail
 
 subcommand="$1"
 name="$2"
@@ -24,21 +28,55 @@ if [ -z "$name" ]; then
     exit 0
 fi
 
+create_loopback_device() {
+    local path=$1
+    local size=$2
+
+    if [[ ! -f "$path" ]]; then
+        touch "$path"
+        truncate -s "$size" "$path"
+    fi
+
+    local dev=$(sudo losetup --output NAME --noheadings --associated "$path")
+    if [[ -z "$dev" ]]; then
+        dev=$(sudo losetup --find --show $path)
+    fi
+    echo $dev
+}
+
 if [[ -z "$FICD_DM_VOLUME_GROUP" ]]; then
     pool_create() {
-        echo
+        mkdir -p $DIR
+
+        local datadev=$(create_loopback_device "$DIR/data" '10G')
+        local metadev=$(create_loopback_device "$DIR/metadata" '1G')
+
+        local sectorsize=512
+        local datasize="$(sudo blockdev --getsize64 -q ${datadev})"
+        local length_sectors=$(bc <<< "${datasize}/${sectorsize}")
+        local thinp_table="0 ${length_sectors} thin-pool ${metadev} ${datadev} 128 32768 1 skip_block_zeroing"
+        sudo dmsetup create "$name" --table "${thinp_table}"
     }
 
     pool_remove() {
-        echo
-    }
+        for snapshot in $(sudo dmsetup ls | awk "/^$name-snap-/ { print \$1 }"); do
+            sudo dmsetup remove $snapshot
+        done
 
-    pool_reset() {
         local dev_no=1
         while true; do
             sudo dmsetup message "$name" 0 "delete $dev_no" || break
             dev_no=$(($dev_no + 1))
         done
+
+        sudo dmsetup remove "$name"
+    }
+
+    pool_reset() {
+        if sudo dmsetup info "$name"; then
+            pool_remove
+        fi
+        pool_create
     }
 else
     dm_device="/dev/mapper/$(echo ${FICD_DM_VOLUME_GROUP} | sed -e s/-/--/g)-$name"


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Make FICD_DM_POOL and NUMBER_OF_VMS optional.
- For FICD_DM_POOL, thinpool.sh makes a loopback-based thinpool automatically.
- For NUMBER_OF_VMS, service_integ_test.go correctly handles `""`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
