### PR TITLE
Make Firecracker's instance ID configurable

### DIFF
--- a/runtime/integ_test.go
+++ b/runtime/integ_test.go
@@ -93,7 +93,7 @@ func writeRuntimeConfig(options ...func(*config.Config)) error {
 	return nil
 }
 
-var testNameToVMIDReplacer = strings.NewReplacer("/", "_")
+var testNameToVMIDReplacer = strings.NewReplacer("/", "-", "_", "-")
 
 func testNameToVMID(s string) string {
 	return testNameToVMIDReplacer.Replace(s)

--- a/runtime/noop_jailer.go
+++ b/runtime/noop_jailer.go
@@ -44,7 +44,7 @@ func newNoopJailer(ctx context.Context, logger *logrus.Entry, shimDir vm.Dir) *n
 	}
 }
 
-func (j *noopJailer) BuildJailedMachine(cfg *config.Config, machineConfig *firecracker.Config, vmID string) ([]firecracker.Opt, error) {
+func (j *noopJailer) BuildJailedMachine(cfg *config.Config, _ *firecracker.Config, vmID string) ([]firecracker.Opt, error) {
 	if len(cfg.FirecrackerBinaryPath) == 0 {
 		return []firecracker.Opt{}, nil
 	}
@@ -57,6 +57,7 @@ func (j *noopJailer) BuildJailedMachine(cfg *config.Config, machineConfig *firec
 	cmd := firecracker.VMCommandBuilder{}.
 		WithBin(cfg.FirecrackerBinaryPath).
 		WithSocketPath(relSocketPath).
+		WithArgs([]string{"--id", vmID}).
 		Build(j.ctx)
 
 	if cfg.DebugHelper.LogFirecrackerOutput() {

--- a/runtime/runc_jailer.go
+++ b/runtime/runc_jailer.go
@@ -451,6 +451,7 @@ func (j *runcJailer) setDefaultConfigValues(cfg *config.Config, socketPath strin
 		cmd := firecracker.VMCommandBuilder{}.
 			WithBin("/" + firecrackerFileName).
 			WithSocketPath(socketPath).
+			WithArgs([]string{"--id", j.vmID}).
 			// Don't need to pass in an actual context here as we are only building
 			// the command arguments and not actually building a command
 			Build(context.Background())

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -579,13 +579,14 @@ func TestLongUnixSocketPath_Isolated(t *testing.T) {
 	// Verify that if the absolute path of the Firecracker unix sockets are longer
 	// than the max length enforced by the kernel (UNIX_PATH_MAX, usually 108), we
 	// don't fail (due to the internal implementation using relative paths).
-	// We do this by using the max VMID len (76 chars), which in combination with the
+	// We do this by using the max VMID len (64 chars), which in combination with the
 	// default location we store state results in a path like
-	// "/run/firecracker-containerd/default/<vmID>" (with len 112).
+	// "/run/firecracker-containerd/<namespace>/<vmID>" (with len 112).
 	const maxUnixSockLen = 108
-	vmID := strings.Repeat("x", 76)
+	namespace := strings.Repeat("n", 20)
+	vmID := strings.Repeat("v", 64)
 
-	ctx := namespaces.WithNamespace(context.Background(), "default")
+	ctx := namespaces.WithNamespace(context.Background(), namespace)
 
 	pluginClient, err := ttrpcutil.NewClient(containerdSockPath + ".ttrpc")
 	require.NoError(t, err, "failed to create ttrpc client")
@@ -624,7 +625,7 @@ func TestLongUnixSocketPath_Isolated(t *testing.T) {
 
 			// double-check that the sockets are at the expected path and that their absolute
 			// length exceeds 108 bytes
-			shimDir, err := vm.ShimDir(cfg.ShimBaseDir, "default", vmID)
+			shimDir, err := vm.ShimDir(cfg.ShimBaseDir, namespace, vmID)
 			require.NoError(t, err, "failed to get shim dir")
 
 			if request.JailerConfig == nil {


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Firecracker's instance ID is appeared in Firecracker's log
file. Setting the ID makes the log easily trackable from clients.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
