### PR TITLE
Fix bind-mount for additional drive files

### DIFF
--- a/runtime/jailer.go
+++ b/runtime/jailer.go
@@ -105,5 +105,5 @@ func newJailer(
 		CgroupPath:        request.JailerConfig.CgroupPath,
 		DriveExposePolicy: request.JailerConfig.DriveExposePolicy,
 	}
-	return newRuncJailer(ctx, l, service.vmID, config)
+	return newRuncJailer(ctx, l, service.vmID, config, request.DriveMounts)
 }


### PR DESCRIPTION
The previous change (666cb5e) covers root filesystem files but it
doesn't work when a micro VM has additional drive mounts.

Since bind-mounts are created by modifying runc's configuration file,
calling bindMountFileToJail after starting runc is no-op.

To fix the issue, the jailer needs to scan through its additional drive
files and prepare them before they are replaced with stub drive files.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
