### PR TITLE
Use codes.AlreadyExists correctly on Exec()

### DIFF
--- a/agent/service.go
+++ b/agent/service.go
@@ -255,7 +255,7 @@ func (ts *TaskService) Create(requestCtx context.Context, req *taskAPI.CreateTas
 
 	resp, err := ts.taskManager.CreateTask(requestCtx, req, ts.runcService, ioConnectorSet)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create runc shim")
+		return nil, err
 	}
 
 	logger.WithField("pid", resp.Pid).Debugf("create succeeded")

--- a/internal/vm/task.go
+++ b/internal/vm/task.go
@@ -22,6 +22,8 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -110,7 +112,7 @@ func (m *taskManager) newProc(taskID, execID string) (*vmProc, error) {
 
 	_, procExists := m.tasks[taskID][execID]
 	if procExists {
-		return nil, errors.Errorf("cannot add duplicate exec %q to task %q", execID, taskID)
+		return nil, status.Errorf(codes.AlreadyExists, "exec %q already exists", execID)
 	}
 
 	proc := &vmProc{}


### PR DESCRIPTION
Clients would use errdefs package to programatically process the error.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
