### PR TITLE
Override Process.Args regardless of the existing value

### DIFF
--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -1602,13 +1602,13 @@ func TestStopVM_Isolated(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			req := test.createVMRequest
-			req.VMID = testNameToVMID(test.name)
+			req.VMID = testNameToVMID(t.Name())
 			testFunc(t, req)
 		})
 
 		t.Run(test.name+"/Jailer", func(t *testing.T) {
 			req := test.createVMRequest
-			req.VMID = testNameToVMID(test.name) + "_Jailer"
+			req.VMID = testNameToVMID(t.Name())
 			req.JailerConfig = &proto.JailerConfig{
 				UID: 300000,
 				GID: 300000,
@@ -2007,7 +2007,7 @@ func TestCreateVM_Isolated(t *testing.T) {
 			UID: 30000,
 			GID: 30000,
 		}
-		t.Run(subtest.name+" with Jailer", func(t *testing.T) {
+		t.Run(subtest.name+"/Jailer", func(t *testing.T) {
 			runTest(t, requestWithJailer, validate)
 		})
 	}


### PR DESCRIPTION
Previously firecracker-containerd keeps
/etc/containerd/firecracker-runc-config.json's Process.Args as is
if the value exists.

However passing VM ID (39e0475) doesn't work when it uses the exising
fixed value.

This change removes this confusing behavior and always overrides
Process.Args.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
