### PR TITLE
Upgrade containerd to 1.3.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/containerd/cgroups v0.0.0-20181105182409-82cb49fc1779 // indirect
 	github.com/containerd/console v0.0.0-20191219165238-8375c3424e4d // indirect
-	github.com/containerd/containerd v1.3.8-0.20200824223617-f99bb2cc4483
+	github.com/containerd/containerd v1.3.9
 	github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac // indirect
 	github.com/containerd/fifo v0.0.0-20191213151349-ff969a566b00
 	github.com/containerd/go-runc v0.0.0-20190226155025-7d11b49dc076

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/containerd/cgroups v0.0.0-20181105182409-82cb49fc1779 h1:j1IsLW6/hNZP
 github.com/containerd/cgroups v0.0.0-20181105182409-82cb49fc1779/go.mod h1:X9rLEHIqSf/wfK8NsPqxJmeZgW4pcfzdXITDrUSJ6uI=
 github.com/containerd/console v0.0.0-20191219165238-8375c3424e4d h1:VuiIRfgJ2M3vYEU0F6E5lg3+V0l9YpbGQr3jpZor5fo=
 github.com/containerd/console v0.0.0-20191219165238-8375c3424e4d/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=
-github.com/containerd/containerd v1.3.8-0.20200824223617-f99bb2cc4483 h1:MP+VxQ5PX5mTeoAFwsOd2JmGU2KIJH0ZK9bCLga0ks0=
-github.com/containerd/containerd v1.3.8-0.20200824223617-f99bb2cc4483/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.3.9 h1:K2U/F4jGAMBqeUssfgJRbFuomLcS2Fxo1vR3UM/Mbh8=
+github.com/containerd/containerd v1.3.9/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac h1:PThQaO4yCvJzJBUW1XoFQxLotWRhvX2fgljJX8yrhFI=
 github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/fifo v0.0.0-20191213151349-ff969a566b00 h1:lsjC5ENBl+Zgf38+B0ymougXFp0BaubeIVETltYZTQw=

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -15,24 +15,18 @@ package shim
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/containerd/containerd/runtime/v2/shim"
 )
 
-// SocketAddress is the abstract unix socket address at which a shim
-// with the given namespace and vmID will listen and serve the shim api
-func SocketAddress(namespacedCtx context.Context, vmID string) (string, error) {
-	return shim.SocketAddress(namespacedCtx, vmID)
-}
-
-// FCControlSocketAddress is the abstract unix socket address at which a shim
-// with the given namespace and vmID will listen and serve the fccontrol api
-func FCControlSocketAddress(namespacedCtx context.Context, vmID string) (string, error) {
-	shimSocketAddr, err := SocketAddress(namespacedCtx, vmID)
+// FCControlSocketAddress is a unix socket address at which a shim
+// with the given namespace, the containerd socket address, and the vmID will listen and serve
+// the fccontrol api
+func FCControlSocketAddress(namespacedCtx context.Context, socketPath, vmID string) (string, error) {
+	shimSocketAddr, err := shim.SocketAddress(namespacedCtx, socketPath, vmID)
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(shimSocketAddr, "fccontrol"), nil
+	return shimSocketAddr + "-fccontrol", nil
 }

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -57,7 +57,6 @@ import (
 	"github.com/firecracker-microvm/firecracker-containerd/eventbridge"
 	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/firecracker-microvm/firecracker-containerd/internal/bundle"
-	fcShim "github.com/firecracker-microvm/firecracker-containerd/internal/shim"
 	"github.com/firecracker-microvm/firecracker-containerd/internal/vm"
 	"github.com/firecracker-microvm/firecracker-containerd/proto"
 	drivemount "github.com/firecracker-microvm/firecracker-containerd/proto/service/drivemount/ttrpc"
@@ -379,7 +378,7 @@ func (s *service) StartShim(shimCtx context.Context, containerID, containerdBina
 	}
 	log.WithField("vmID", s.vmID).Infof("successfully started shim (git commit: %s).%s", revision, str)
 
-	return fcShim.SocketAddress(shimCtx, s.vmID)
+	return shim.SocketAddress(shimCtx, containerdAddress, s.vmID)
 }
 
 func logPanicAndDie(logger *logrus.Entry) {

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -748,7 +748,7 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 	}
 	err = syscall.Mkfifo(logPath, 0700)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to create %q for logging", logPath)
 	}
 
 	metricsPath := s.shimDir.FirecrackerMetricsFifoPath()
@@ -757,7 +757,7 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 	}
 	err = syscall.Mkfifo(metricsPath, 0700)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to create %q for metrics", metricsPath)
 	}
 
 	// The Config struct has LogFifo and MetricsFifo, but they will be deprecated since


### PR DESCRIPTION
- The version has a CVE fix, while we may not be affected.
- It is better to use relesed versions if possible.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
