### PR TITLE
stop tickers in defer to prevent leak

### DIFF
--- a/internal/psutil.go
+++ b/internal/psutil.go
@@ -30,7 +30,9 @@ func WaitForProcessToExist(
 	queryInterval time.Duration,
 	matcher func(context.Context, *process.Process) (bool, error),
 ) ([]*process.Process, error) {
-	for range time.NewTicker(queryInterval).C {
+	ticker := time.NewTicker(queryInterval)
+	defer ticker.Stop()
+	for range ticker.C {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -63,7 +65,9 @@ func WaitForProcessToExist(
 // WaitForPidToExit queries running processes every `queryInterval` duration, blocking until the provided pid is found
 // to not exist or the context is canceled.
 func WaitForPidToExit(ctx context.Context, queryInterval time.Duration, pid int32) error {
-	for range time.NewTicker(queryInterval).C {
+	ticker := time.NewTicker(queryInterval)
+	defer ticker.Stop()
+	for range ticker.C {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -138,7 +142,9 @@ func sampleCPUTimes(ctx context.Context, sampleInterval time.Duration) <-chan *c
 		defer close(returnCh)
 
 		var index int
-		for range time.NewTicker(sampleInterval).C {
+		ticker := time.NewTicker(sampleInterval)
+		defer ticker.Stop()
+		for range ticker.C {
 			select {
 			case <-ctx.Done():
 				return

--- a/internal/vm/vsock.go
+++ b/internal/vm/vsock.go
@@ -38,7 +38,9 @@ const (
 // path and port. It will retry connect attempts if a temporary error is encountered (up
 // to a fixed timeout) or the provided request is canceled.
 func VSockDial(ctx context.Context, logger *logrus.Entry, udsPath string, port uint32) (net.Conn, error) {
-	tickerCh := time.NewTicker(vsockRetryInterval).C
+	ticker := time.NewTicker(vsockRetryInterval)
+	defer ticker.Stop()
+	tickerCh := ticker.C
 	var attemptCount int
 	for {
 		attemptCount++
@@ -92,7 +94,9 @@ func (l vsockListener) Accept() (net.Conn, error) {
 	defer cancel()
 
 	var attemptCount int
-	tickerCh := time.NewTicker(vsockRetryInterval).C
+	ticker := time.NewTicker(vsockRetryInterval)
+	defer ticker.Stop()
+	tickerCh := ticker.C
 	for {
 		attemptCount++
 		logger := l.logger.WithField("attempt", attemptCount)


### PR DESCRIPTION
Signed-off-by: Jeremy Williams <ctrlaltdel121@gmail.com>

This change updates the usage of time.NewTicker to stop the tickers that it creates when the relevant function ends. In Go, when the ticker goes out of scope it does not stop being managed by the runtime (see https://github.com/golang/go/issues/8001).

When testing firecracker-containerd with frequent starts and stops of VMs, I noticed that over time the `containerd` process consumed more and more CPU. Via profiling I determined that this was because WaitForPidToExit() had been called over 100k times and had leaked over 100k 10ms tickers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
