### PR TITLE
Rebuild binaries when dependencies change

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -15,13 +15,13 @@ EXTRAGOARGS?=
 
 GOMOD := $(shell go env GOMOD)
 GOSUM := $(GOMOD:.mod=.sum)
-SOURCES:=$(shell find . -name '*.go')
+SOURCES := $(shell find ../eventbridge ../internal ../proto . -name '*.go')
 DOCKER_IMAGE_TAG?=latest
 REVISION := $(shell git rev-parse HEAD)
 
 all: agent
 
-agent: *.go $(GOMOD) $(GOSUM)
+agent: $(SOURCES) $(GOMOD) $(GOSUM)
 ifneq ($(STATIC_AGENT),)
 	CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "-s -X main.revision=$(REVISION)" $(EXTRAGOARGS) -o agent
 else

--- a/firecracker-control/cmd/containerd/Makefile
+++ b/firecracker-control/cmd/containerd/Makefile
@@ -14,7 +14,7 @@
 # Set this to pass additional commandline flags to the go compiler, e.g. "make test EXTRAGOARGS=-v"
 EXTRAGOARGS:=
 
-SRC := $(shell find . -name '*.go')
+SOURCES := $(shell find ../../../config ../../../internal ../../../proto ../../ -name '*.go')
 GOMOD := $(shell go env GOMOD)
 GOSUM := $(GOMOD:.mod=.sum)
 REVISION=$(shell git rev-parse HEAD)
@@ -24,7 +24,7 @@ all: build
 
 build: firecracker-containerd firecracker-ctr
 
-firecracker-containerd: $(SRC) $(GOMOD) $(GOSUM)
+firecracker-containerd: $(SOURCES) $(GOMOD) $(GOSUM)
 	go build $(EXTRAGOARGS) \
 		-ldflags $(VERSION_LDFLAGS) -o firecracker-containerd
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -15,7 +15,7 @@
 EXTRAGOARGS?=
 NUMBER_OF_VMS?=
 
-SOURCES:=$(shell find . -name '*.go')
+SOURCES := $(shell find ../config ../eventbridge ../firecracker-control ../internal ../proto . -name '*.go')
 GOMOD := $(shell go env GOMOD)
 GOSUM := $(GOMOD:.mod=.sum)
 DOCKER_IMAGE_TAG?=latest


### PR DESCRIPTION
Most of the binaries use internal/ and other packages inside this
source tree. So, Makefile should have them to correctly rebuild
binaries when dependencies change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
