### PR TITLE
Fetch 30 commits just in case to correctly check 20 commits

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,9 +33,11 @@ jobs:
           # While DCO check (on Makefile) checks latest 20 commits,
           # the checkout action automatically creates a merge commit
           # for merging "master" into a pull request branch.
-          # So we need to fetch 21 commits (including the merge commit)
-          # to have 20 actual commits from a pull request.
-          fetch-depth: 21
+          # In addition to that, Git cannot recognize merge commits when
+          # one of the parents is missing.
+          # So, we will fetch 30 commits just in case to have
+          # 20 actual commits with associated merged commits.
+          fetch-depth: 30
       - uses: actions/setup-go@v1
         with:
           go-version: ${{ matrix.go }}


### PR DESCRIPTION
git-validation doesn't check Signed-off-by: line (aka DCO) in
merge commits. However, apparently Git cannot recognize merge
commits when one of the parents is missing.

This change fetches 30 commites instead of 21 just in case to
make sure we fetch merge commits with the associated parents.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
