### PR TITLE
Disable systemd's getty services for debain based rootfs.

### DIFF
--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/getty.target
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/getty.target
@@ -1,1 +1,1 @@
-/lib/systemd/system/getty.target
+/dev/null


### PR DESCRIPTION
*Issue #477  :*

*Description of changes: In the Debian root filesystem getty service is masked, but getty target is not masked and still pointing to systemd binaries. Masking it by pointing it to /dev/null. With this we no longer see the messages like this

DEBU[2021-02-19T10:07:03.428545928Z] [    1.471698] systemd[756]: serial-getty@ttyS0.service: Executable /sbin/agetty missing, skipping: No such file or directory  jailer=noop runtime=aws.firecracker vmID=f7ac9a76-637a-4fb0-ac9c-8d933fabc4ab vmm_stream=stdout

This also saves 0.1 second for the VM to start up, as systemd repeatedly tries to enable serial consoles.

 *


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
