### PR TITLE
Enable tests regarding Pause/Resume

### DIFF
--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -2152,6 +2152,10 @@ func TestPauseResume_Isolated(t *testing.T) {
 		// Ensure the response fields are populated correctly
 		assert.Equal(t, request.VMID, resp.VMID)
 
+		// Currently StopVM doesn't work when the VM is paused, since StopVM calls its in-VM agent.
+		_, err = fcClient.ResumeVM(ctx, &proto.ResumeVMRequest{VMID: request.VMID})
+		require.Equal(t, status.Code(err), codes.OK)
+
 		_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: request.VMID})
 		require.Equal(t, status.Code(err), codes.OK)
 	}

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -2040,7 +2040,7 @@ func TestCreateVM_Isolated(t *testing.T) {
 	}
 }
 
-func TestPauseResume(t *testing.T) {
+func TestPauseResume_Isolated(t *testing.T) {
 	prepareIntegTest(t)
 
 	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))


### PR DESCRIPTION
The test must have _Isolated suffix to make it work on
"make integ-test".

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

NA

*Description of changes:*

Renamed the test function to be picked-up by Makefile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
