### PR TITLE
docker build and run needs root privilege

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,14 +291,14 @@ $(FIRECRACKER_DIR)/Cargo.toml:
 	git submodule update --init --recursive $(FIRECRACKER_DIR)
 
 tools/firecracker-builder-stamp: tools/docker/Dockerfile.firecracker-builder
-	docker build \
+	sudo docker build \
 		-t localhost/$(FIRECRACKER_BUILDER_NAME):$(DOCKER_IMAGE_TAG) \
 		-f tools/docker/Dockerfile.firecracker-builder \
 		tools/docker
 	touch $@
 
 $(FIRECRACKER_BIN): $(FIRECRACKER_DIR)/Cargo.toml tools/firecracker-builder-stamp
-	docker run --rm -it --user $(UID) \
+	sudo docker run --rm -it --user $(UID) \
 		--volume $(CURDIR)/$(FIRECRACKER_DIR):/src \
 		--volume $(CARGO_CACHE_VOLUME_NAME):/usr/local/cargo/registry \
 		-e HOME=/tmp \


### PR DESCRIPTION
On a fresh checkout and build of firecracker containerd as non-root user
would fail as docker build and run need root privilege.

Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>

*Issue #, if available:*

*Description of changes:*

To prevent checkout and build using root account, we can just run these two steps in Makefile with root privilege.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
