### PR TITLE
Restructure docs/architecture.md and add a new diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,53 +3,42 @@
 firecracker-containerd aims to make it easier to run containers with virtual
 machine isolation provided by the [Firecracker virtual machine monitor
 (VMM)](https://github.com/firecracker-microvm/firecracker).
-firecracker-containerd integrates with [containerd](https://containerd.io) by
-implementing its interfaces and extending its APIs.
 
-firecracker-containerd implements the following containerd interfaces:
+firecracker-containerd extends [containerd](https://containerd.io) by
+adding `firecracker-control` plugin and `aws.firecracker` runtime shim. The runtime shim is launching Firecracker with firecracker-containerd's custom Linux image, that launches `agent` in the guest Linux's userspace. The agent is taking requests from the runtime shim and launches containers through runc.
 
-* [V2 runtime](https://github.com/containerd/containerd/blob/v1.2.6/runtime/v2/task/shim.proto):
-  Runtimes provide the implementation for configuring and running containerized
-  processes.  The V2 runtime is a containerd-specific interface and is not
-  standardized as part of the [Open Containers Initiative
-  (OCI)](https://www.opencontainers.org/).
+A high-level diagram of the various components and their interactions can be seen below. The highlighted components are developled by ourselves and reside in this repository.
 
-firecracker-containerd also adds a new API, which we call the "control" API,
-intended to model the lifecycle of a Firecracker microVM that can run multiple
-containers.
+![firecracker-containerd architecture](img/overview.svg)
 
-This repository contains the components that implement those interfaces and
-APIs.
+## firecracker-control plugin
 
-There are currently several components in this repository:
+[firecracker-control](../firecracker-control) plugin is managing the lifecycle of the runtime and implementing our [control API](../proto/firecracker.proto) intended to model the lifecycle of a Firecracker microVM. A microVM can run multiple containers together.
 
-* A [control plugin](../firecracker-control) managing the lifecycle of the
-  runtime and implementing our [control API](../proto/firecracker.proto) by
-  proxying commands to the runtime.  The control plugin is compiled in to the
-  containerd binary, which requires us to build a specialized containerd binary
-  for firecracker-containerd.
-* A [runtime](../runtime) implementing both the control API and the V2 runtime
-  API.  The runtime links containerd (outside the microVM) to the Firecracker
-  virtual machine monitor (VMM) for VM lifecycle operations and to the agent
-  running inside the microVM for container lifecycle operations.  The runtime is
-  implemented as an out-of-process [shim](https://github.com/containerd/containerd/issues/2426)
-  communicating over ttrpc.
-* An [agent](../agent) running inside the microVM, which is responsible for
-  acting on control instructions received from the runtime, for emitting event
-  and metric information to the runtime, and for proxying STDIO for the
-  container processes.  The agent invokes [runC](https://runc.io) via
-  containerd's `containerd-shim-runc-v1` to create standard Linux containers
-  inside the microVM.
+The control plugin is compiled in to the containerd binary, which requires us to build a specialized containerd binary as `firecracker-containerd`.
 
-A high-level diagram of the various components and their interactions can be
-seen below:
+## aws.firecracker runtime shim.
 
-![firecracker-containerd architecture](img/architecture-diagram.png)
+[aws.firecracker runtime shim](../runtime) is implementing both the control API and the V2 runtime API.  The runtime links containerd (outside the microVM) to the Firecracker virtual machine monitor (VMM) for VM lifecycle operations and to the agent running inside the microVM for container lifecycle operations.
+
+The runtime is implemented as an out-of-process [shim](https://github.com/containerd/containerd/issues/2426) communicating over ttrpc.
+
+Note that the V2 runtime is a containerd-specific interface and is not standardized as part of the [Open Containers Initiative (OCI)](https://www.opencontainers.org/).
+
+## Linux filesystem image
+
+This repository has Debian-based Linux filesystem image that runs containers inside Firecracker. The image is designed to run inside Firecracker.
+
+firecracker-containerd's in-VM [agent](../agent) is running inside the microVM, which is responsible for acting on control instructions received from the runtime, for emitting event and metric information to the runtime, and for proxying STDIO for the container processes.  The agent invokes [runC](https://runc.io) via containerd's `containerd-shim-runc-v1` to create standard Linux containers inside the microVM.
+
+## Launch Sequence
 
 A high-level diagram of how the components interact for starting a container can
 be seen below:
 
 ![firecracker-containerd container launch sequence diagram](img/container-launch-sequence-diagram.svg)
+
+## See Also
 
 * Overview of possible design approaches can be found in the [design approaches
   doc](design-approaches.md).

--- a/docs/img/overview.ditaa
+++ b/docs/img/overview.ditaa
@@ -1,0 +1,57 @@
+Host Linux
+
++-----------+
+|containerd +<------+ gRPC/unix
+|client     |       |
++-----------+       |
+                    V
++-----------------------------------+
+|firecracker containerd             |
+|                                   |
++-------------------+ +-------------+
+|firecracker control| |devmapper    |
+|plugin             | |snapshotter  |
+|cFCC               | |             |
++-+-----------------+-+---------+---+
+  |            ^                |                    creates
+  | launches   | ttrpc/unix     +-------------+------------+
+  |            |                |             |            |
+  V            V                V             V            V
++---------------+              +---------+   +---------+   +---------+
+|aws.firecracker|              |block dev+-->|block dev+-->|block dev|
+|shim           |              |{d}      |   |{d}      |   |{d}      |
+|cFCC           |              ++--------+   +---------+   +---------+
++-+-------------+               |                device mapper devices
+  |            ^                |
+  | launches   |                |
+  V            | ttrpc/unix     |
++----+         |                |
+|runc|         |                |
++-+--+         |                |
+  |            |                |
+  | launches +-+              +-+ mounts
+  |          |                |
+  V          |                |
++------------+----------------+-------+
+|firecracker |                |       |
+|            |                |       |
+|  +---------+----------------+-------+
+|  |         |                |       |
+|  |         | ttrpc/vsock    |       |
+|  |         V                V       |
+|  |       +-----+        +---------+ |
+|  |       |agent|        |container| |
+|  |       |cFCC |        |rootfs   | |
+|  |       |     |        |{d}      | |
+|  |       +-+---+        +----+----+ |
+|  |         |                 |      |
+|  |         V launches        |      |
+|  |       +-----+             |      |
+|  |       |runc |<------------+      |
+|  |       +-+---+                    |
+|  |         |                        |
+|  |         V launches               |
+|  |       +---------+                |
+|  |       |container|                |
+|  |       +---------+     Guest Linux|
++--+----------------------------------+

--- a/docs/img/overview.svg
+++ b/docs/img/overview.svg
@@ -1,0 +1,122 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg 
+    xmlns='http://www.w3.org/2000/svg'
+    width='740'
+    height='854'
+    shape-rendering='geometricPrecision'
+    version='1.0'>
+  <defs>
+    <filter id='f2' x='0' y='0' width='200%' height='200%'>
+      <feOffset result='offOut' in='SourceGraphic' dx='5' dy='5' />
+      <feGaussianBlur result='blurOut' in='offOut' stdDeviation='3' />
+      <feBlend in='SourceGraphic' in2='blurOut' mode='normal' />
+    </filter>
+  </defs>
+  <g stroke-width='1' stroke-linecap='square' stroke-linejoin='round'>
+    <rect x='0' y='0' width='740' height='854' style='fill: #ffffff'/>
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M25.0 133.0 L25.0 175.0 L225.0 175.0 L225.0 231.0 L245.0 231.0 L245.0 175.0 L385.0 175.0 L385.0 133.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M155.0 511.0 L155.0 553.0 L55.0 553.0 L55.0 819.0 L25.0 819.0 L25.0 511.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M225.0 175.0 L225.0 231.0 L25.0 231.0 L25.0 175.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M25.0 301.0 L25.0 357.0 L185.0 357.0 L185.0 301.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M245.0 231.0 L245.0 175.0 L385.0 175.0 L385.0 231.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M325.0 511.0 L325.0 553.0 L155.0 553.0 L155.0 511.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M285.0 609.0 L385.0 609.0 L385.0 665.0 Q351.0 658.0 335.0 665.0 Q319.0 672.0 285.0 665.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M145.0 63.0 L145.0 105.0 L25.0 105.0 L25.0 63.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M335.0 301.0 L435.0 301.0 L435.0 343.0 Q401.0 338.0 385.0 343.0 Q369.0 348.0 335.0 343.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M615.0 301.0 L715.0 301.0 L715.0 343.0 Q681.0 338.0 665.0 343.0 Q649.0 348.0 615.0 343.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M475.0 301.0 L575.0 301.0 L575.0 343.0 Q541.0 338.0 525.0 343.0 Q509.0 348.0 475.0 343.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M405.0 511.0 L405.0 553.0 L325.0 553.0 L325.0 511.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M135.0 609.0 L195.0 609.0 L195.0 665.0 L135.0 665.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M235.0 777.0 L135.0 777.0 L135.0 805.0 L235.0 805.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M195.0 707.0 L195.0 735.0 L135.0 735.0 L135.0 707.0 z' />
+    <path stroke='gray' fill='gray' filter='url(#f2)' d='M25.0 413.0 L25.0 441.0 L75.0 441.0 L75.0 413.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M405.0 553.0 L405.0 819.0 L55.0 819.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M405.0 553.0 L405.0 819.0 L55.0 819.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M25.0 133.0 L25.0 175.0 L225.0 175.0 L225.0 231.0 L245.0 231.0 L245.0 175.0 L385.0 175.0 L385.0 133.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M155.0 511.0 L155.0 553.0 L55.0 553.0 L55.0 819.0 L25.0 819.0 L25.0 511.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#ffcccc' d='M225.0 175.0 L225.0 231.0 L25.0 231.0 L25.0 175.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#ffcccc' d='M25.0 301.0 L25.0 357.0 L185.0 357.0 L185.0 301.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M245.0 231.0 L245.0 175.0 L385.0 175.0 L385.0 231.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M325.0 511.0 L325.0 553.0 L155.0 553.0 L155.0 511.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M285.0 609.0 L385.0 609.0 L385.0 665.0 Q351.0 658.0 335.0 665.0 Q319.0 672.0 285.0 665.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M145.0 63.0 L145.0 105.0 L25.0 105.0 L25.0 63.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M335.0 301.0 L435.0 301.0 L435.0 343.0 Q401.0 338.0 385.0 343.0 Q369.0 348.0 335.0 343.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M615.0 301.0 L715.0 301.0 L715.0 343.0 Q681.0 338.0 665.0 343.0 Q649.0 348.0 615.0 343.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M475.0 301.0 L575.0 301.0 L575.0 343.0 Q541.0 338.0 525.0 343.0 Q509.0 348.0 475.0 343.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M205.0 721.0 L335.0 721.0 L335.0 665.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M405.0 511.0 L405.0 553.0 L325.0 553.0 L325.0 511.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#ffcccc' d='M135.0 609.0 L195.0 609.0 L195.0 665.0 L135.0 665.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M235.0 777.0 L135.0 777.0 L135.0 805.0 L235.0 805.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M485.0 259.0 L615.0 259.0 L615.0 287.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M195.0 707.0 L195.0 735.0 L135.0 735.0 L135.0 707.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M225.0 119.0 L225.0 77.0 L155.0 77.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='white' d='M25.0 413.0 L25.0 441.0 L75.0 441.0 L75.0 413.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M325.0 511.0 L325.0 469.0 L345.0 469.0 L345.0 343.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M175.0 371.0 L175.0 469.0 L155.0 469.0 L155.0 511.0 ' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M160.0 70.0 L150.0 77.0 L160.0 84.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M220.0 112.0 L225.0 126.0 L230.0 112.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M175.0 238.0 L170.0 252.0 L180.0 252.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M40.0 280.0 L45.0 294.0 L50.0 280.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M170.0 280.0 L175.0 294.0 L180.0 280.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M340.0 280.0 L345.0 294.0 L350.0 280.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M480.0 280.0 L485.0 294.0 L490.0 280.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M610.0 280.0 L615.0 294.0 L620.0 280.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M460.0 308.0 L470.0 315.0 L460.0 322.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M600.0 308.0 L610.0 315.0 L600.0 322.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M175.0 364.0 L170.0 378.0 L180.0 378.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M40.0 392.0 L45.0 406.0 L50.0 392.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M40.0 490.0 L45.0 504.0 L50.0 490.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M150.0 588.0 L155.0 602.0 L160.0 588.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M320.0 588.0 L325.0 602.0 L330.0 588.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M150.0 686.0 L155.0 700.0 L160.0 686.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M210.0 714.0 L200.0 721.0 L210.0 728.0 z' />
+    <path stroke='none' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='#000000' d='M150.0 756.0 L155.0 770.0 L160.0 756.0 z' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M155.0 735.0 L155.0 763.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M155.0 665.0 L155.0 693.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M175.0 287.0 L175.0 245.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M45.0 231.0 L45.0 287.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M345.0 259.0 L345.0 287.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M345.0 259.0 L345.0 231.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M485.0 259.0 L345.0 259.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M485.0 287.0 L485.0 259.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M435.0 315.0 L465.0 315.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M325.0 553.0 L325.0 595.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M155.0 595.0 L155.0 553.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M45.0 357.0 L45.0 399.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M45.0 441.0 L45.0 497.0 ' />
+    <path stroke='#000000' stroke-width='1.000000' stroke-linecap='round' stroke-linejoin='round' fill='none' d='M575.0 315.0 L605.0 315.0 ' />
+    <text x='30' y='40' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[Host Linux]]></text>
+    <text x='30' y='82' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[containerd]]></text>
+    <text x='30' y='96' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[client]]></text>
+    <text x='56' y='152' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[firecracker containerd]]></text>
+    <text x='30' y='194' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[firecracker control]]></text>
+    <text x='30' y='208' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[plugin]]></text>
+    <text x='201' y='404' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[ttrpc/unix]]></text>
+    <text x='201' y='264' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[ttrpc/unix]]></text>
+    <text x='362' y='474' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[mounts]]></text>
+    <text x='30' y='320' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[aws.firecracker]]></text>
+    <text x='30' y='334' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[shim]]></text>
+    <text x='290' y='628' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[container]]></text>
+    <text x='290' y='642' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[rootfs]]></text>
+    <text x='250' y='194' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[devmapper]]></text>
+    <text x='250' y='208' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[snapshotter]]></text>
+    <text x='66' y='390' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[launches]]></text>
+    <text x='66' y='264' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[launches]]></text>
+    <text x='245' y='82' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[gRPC/unix]]></text>
+    <text x='33' y='432' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[runc]]></text>
+    <text x='300' y='810' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[Guest Linux]]></text>
+    <text x='489' y='320' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[block dev]]></text>
+    <text x='529' y='362' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[device mapper devices]]></text>
+    <text x='44' y='530' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[firecracker]]></text>
+    <text x='176' y='698' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[launches]]></text>
+    <text x='176' y='768' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[launches]]></text>
+    <text x='144' y='628' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[agent]]></text>
+    <text x='143' y='726' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[runc]]></text>
+    <text x='558' y='250' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[creates]]></text>
+    <text x='66' y='474' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[launches]]></text>
+    <text x='629' y='320' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[block dev]]></text>
+    <text x='149' y='796' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[container]]></text>
+    <text x='349' y='320' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[block dev]]></text>
+    <text x='181' y='586' font-family='Courier' font-size='15' stroke='none' fill='#000000' ><![CDATA[ttrpc/vsock]]></text>
+  </g>
+</svg>


### PR DESCRIPTION
This change restructures architecture.md and add a new high-level
diagram.

The new diagram is highlighting components we own, clarify process
boundaries and omit details which we don't touch such as content
store.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
