### PR TITLE
Update outdated slack invitation & kernel download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ GitHub issues, but instead follow
 guidelines](https://github.com/firecracker-microvm/firecracker/blob/master/SECURITY-POLICY.md).
 
 Other discussion: For general discussion, please join us in the `#containerd`
-channel on the [Firecracker Slack](https://tinyurl.com/firecracker-microvm).
+channel on the [Firecracker Slack](https://join.slack.com/t/firecracker-microvm/shared_invite/zt-oxbm7tqt-GLlze9zZ7sdRSDY6OnXXHg).
 
 ## License
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ You need to have the following things in order to use firecracker-containerd:
 You can use the following kernel:
 
 ```bash
-curl -fsSL -o hello-vmlinux.bin https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin
+curl -fsSL -o hello-vmlinux.bin https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin
 ```
 
 ### Install Docker

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -127,7 +127,7 @@ sudo make install install-firecracker demo-network
 cd ~
 
 # Download kernel
-curl -fsSL -o hello-vmlinux.bin https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin
+curl -fsSL -o hello-vmlinux.bin https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin
 
 # Configure our firecracker-containerd binary to use our new snapshotter and
 # separate storage from the default containerd binary


### PR DESCRIPTION
This PR has two things changed. 
1. There is a merged PR #495 for updating kernel download link on Makefile. I think we should also update the kernel download link on docs to keep them consistent. The new kernel download link comes from https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md#running-firecracker

2. Update the slack channel invitation link, as https://github.com/firecracker-microvm/firecracker-go-sdk/issues/340 is pointing out. 

Signed-off-by: Royce Zhao <qiqinzha@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
