### PR TITLE
fix docker config to import firecracker-containerd's config

### DIFF
--- a/tools/docker/config.toml
+++ b/tools/docker/config.toml
@@ -1,3 +1,3 @@
-imports = ["/etc/containerd/snapshotter/*.toml"]
+imports = ["/etc/firecracker-containerd/snapshotter/*.toml"]
 [grpc]
   address = "/run/firecracker-containerd/containerd.sock"


### PR DESCRIPTION
The docker config should import firecracker-containerd's config rather
than containerd's config. Without this, the make integ-test fails in
running tests in examples.

Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>

*Issue #, if available:*

make integ-test throws following error.

```
make -C examples integ-test
make[1]: Entering directory `/home/ec2-user/firecracker-containerd/examples'
mkdir -p /home/ec2-user/firecracker-containerd/examples/logs
/home/ec2-user/firecracker-containerd/examples/../tools/thinpool.sh reset ""
docker run --rm -it \
        --privileged \
        --ipc=host \
        --volume /dev:/dev \
        --volume /run/udev/control:/run/udev/control \
        --volume /home/ec2-user/firecracker-containerd/examples/etc/containerd/firecracker-runtime.json:/etc/containerd/firecracker-runtime.json \
        --volume /home/ec2-user/firecracker-containerd/examples/logs:/var/log/firecracker-containerd-test \
        --volume /home/ec2-user/firecracker-containerd/examples/..:/src \
        --env FICD_DM_VOLUME_GROUP= \
        --env FICD_DM_POOL= \
        --env EXTRAGOARGS="" \
        --workdir="/src/examples" \
        localhost/firecracker-containerd-test:latest \
        "make examples && make testtap && sleep 3 && ./taskworkflow -ip 172.16.0.2/24 -gw 172.16.0.1 -ss devmapper"
make: Nothing to be done for 'examples'.
ip link add br0 type bridge
ip tuntap add tap0 mode tap
ip link set tap0 master br0
ip link set dev tap0 up
ip link set dev br0 up
ip addr add dev br0 172.16.0.1/24
2021/05/10 17:55:38.865069 Creating containerd client
2021/05/10 17:55:38.865601 Created containerd client
2021/05/10 17:55:40.165137 creating container: unpack: failed to stat snapshot sha256:3e207b409db364b595ba862cdc12be96dcdad8e36c59a03b7b3b61c946a5741a: snapshotter not loaded: devmapper: invalid argument
make[1]: *** [integ-test] Error 1
```



*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
