### PR TITLE
Use main instead of master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -32,7 +32,7 @@ jobs:
           #
           # While DCO check (on Makefile) checks latest 20 commits,
           # the checkout action automatically creates a merge commit
-          # for merging "master" into a pull request branch.
+          # for merging "main" into a pull request branch.
           # In addition to that, Git cannot recognize merge commits when
           # one of the parents is missing.
           # So, we will fetch 30 commits just in case to have

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 | Automation | Status |
 |------------|--------|
-| Tests      | [![Build status](https://badge.buildkite.com/aab4ae547d5e5079a5915522e8cdb18492349aef67aae5a8c5.svg?branch=master)](https://buildkite.com/firecracker-microvm/firecracker-containerd)
-| Lint       | [![Build Status](https://travis-ci.org/firecracker-microvm/firecracker-containerd.svg?branch=master)](https://travis-ci.org/firecracker-microvm/firecracker-containerd)
+| Tests      | [![Build status](https://badge.buildkite.com/aab4ae547d5e5079a5915522e8cdb18492349aef67aae5a8c5.svg?branch=main)](https://buildkite.com/firecracker-microvm/firecracker-containerd)
+| Lint       | [![Build Status](https://travis-ci.org/firecracker-microvm/firecracker-containerd.svg?branch=main)](https://travis-ci.org/firecracker-microvm/firecracker-containerd)
 
 This repository enables the use of a container runtime,
 [containerd](https://containerd.io), to manage
@@ -87,7 +87,7 @@ If you've discovered an issue that may have security implications to
 users or developers of this software, please do not report it using
 GitHub issues, but instead follow
 [Firecracker's security reporting
-guidelines](https://github.com/firecracker-microvm/firecracker/blob/master/SECURITY-POLICY.md).
+guidelines](https://github.com/firecracker-microvm/firecracker/blob/main/SECURITY-POLICY.md).
 
 Other discussion: For general discussion, please join us in the `#containerd`
 channel on the [Firecracker Slack](https://tinyurl.com/firecracker-microvm).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ You need to have the following things in order to use firecracker-containerd:
   </details>
 * git
 * A root filesystem image (you can use the one
-  [described here](https://github.com/firecracker-microvm/firecracker/blob/master/docs/getting-started.md#running-firecracker)
+  [described here](https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md#running-firecracker)
   as `hello-rootfs.ext4`). 
 * A recent installation of [Docker CE](https://docker.com).
 * Go 1.13 or later, which you can download from [here](https://golang.org/dl/).
@@ -356,7 +356,7 @@ quick summary:
   - Sets up firewall rules on the host that allows traffic to/from VMs via the host
     network.
 * [`tc-redirect-tap` CNI
-  plugin](https://github.com/firecracker-microvm/firecracker-go-sdk/tree/master/cni)
+  plugin](https://github.com/firecracker-microvm/firecracker-go-sdk/tree/main/cni)
   - A CNI plugin that adapts other CNI plugins to be usable by Firecracker VMs.
   [See this doc for more details](networking.md). It is used here to adapt veth
   devices created by the `ptp` plugin to tap devices provided to VMs.

--- a/examples/taskworkflow.md
+++ b/examples/taskworkflow.md
@@ -15,7 +15,7 @@ $ sudo /path/to/firecracker-containerd/examples/taskworkflow
 ```
 
 For a workflow with networking setup for the container, create a tap device
-for the VM by following [these instructions](https://github.com/firecracker-microvm/firecracker/blob/master/docs/network-setup.md).
+for the VM by following [these instructions](https://github.com/firecracker-microvm/firecracker/blob/main/docs/network-setup.md).
 
 This creates a tap device named `tap0`, in the local `172.16.0.1/24` subnet.
 Since the example does not rely on a DHCP client running within the VM to

--- a/internal/vm/vsock.go
+++ b/internal/vm/vsock.go
@@ -185,7 +185,7 @@ func vsockConnectMsg(port uint32) string {
 	// The message a host-side connection must write after connecting to a firecracker
 	// vsock unix socket in order to establish a connection with a guest-side listener
 	// at the provided port number. This is specified in Firecracker documentation:
-	// https://github.com/firecracker-microvm/firecracker/blob/master/docs/vsock.md#host-initiated-connections
+	// https://github.com/firecracker-microvm/firecracker/blob/main/docs/vsock.md#host-initiated-connections
 	return fmt.Sprintf("CONNECT %d\n", port)
 }
 
@@ -223,7 +223,7 @@ func tryConnect(logger *logrus.Entry, udsPath string, port uint32) (net.Conn, er
 	}
 
 	// The line would be "OK <assigned_hostside_port>\n", but we don't use the hostside port here.
-	// https://github.com/firecracker-microvm/firecracker/blob/master/docs/vsock.md#host-initiated-connections
+	// https://github.com/firecracker-microvm/firecracker/blob/main/docs/vsock.md#host-initiated-connections
 	if !strings.HasPrefix(line, "OK ") {
 		return nil, vsockAckError{
 			cause: errors.Errorf(`expected to read "OK <port>", but instead read %q`, line),

--- a/tools/docker/Dockerfile.firecracker-builder
+++ b/tools/docker/Dockerfile.firecracker-builder
@@ -13,7 +13,7 @@
 
 # Firecracker tends to use latest Rust versions.
 # The Rust version below should be matched with
-# https://github.com/firecracker-microvm/firecracker/blob/master/tools/devctr/Dockerfile.x86_64.
+# https://github.com/firecracker-microvm/firecracker/blob/main/tools/devctr/Dockerfile.x86_64.
 FROM rust:1.43.1-buster
 
 ENV DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
firecracker-containerd no longer uses `master` branch since 435ade4.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
