### PR TITLE
Fix for integ-test failure in docker based example.

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -52,7 +52,7 @@ TEST_GATEWAY?=172.16.0.1
 TEST_IP?=172.16.0.2
 TEST_SUBNET?=/24
 FICD_DM_VOLUME_GROUP?=
-TEST_POOL?=
+TEST_POOL?=testpool
 testtap:
 	ip link add br0 type bridge
 	ip tuntap add tap0 mode tap


### PR DESCRIPTION
TEST_POOL is used to pass a pool name for the example we use for testing
firecracker-containerd inside the docker container. However in the Makefile
TEST_POOL is passed empty to the thinpool.sh thich causes the script to
return without creating any pool. Similarly in the entrypoint.sh which
is run by the docker container we end up using an empty string for
pool_name to be added in the generated devmapper.toml file. This leads
to an issue where firecracker-containerd starts without devmapper
configiured and hence the taskworkflow program fails as it passed
devicemapper as the snapshotter to use for this example. The fix is to have
a default value for TEST_POOL in Makefile. Buildkite is not impacted because
there we explicitly pass the build number as the test pool name.

Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>

*Issue #, if available:* https://github.com/firecracker-microvm/firecracker-containerd/issues/515

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
