### PR TITLE
Remove resume before stopVM in test, as it is no longer needed for stopVM

### DIFF
--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -2239,10 +2239,6 @@ func TestPauseResume_Isolated(t *testing.T) {
 		// Ensure the response fields are populated correctly
 		assert.Equal(t, request.VMID, resp.VMID)
 
-		// Currently StopVM doesn't work when the VM is paused, since StopVM calls its in-VM agent.
-		_, err = fcClient.ResumeVM(ctx, &proto.ResumeVMRequest{VMID: request.VMID})
-		require.Equal(t, status.Code(err), codes.OK)
-
 		_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: request.VMID})
 		require.Equal(t, status.Code(err), codes.OK)
 	}


### PR DESCRIPTION
Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>

*Issue #, if available:*

*Description of changes:*
StopVM works even when VM is in Paused state. Hence this addition call to resume in the test is no longer required.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
