### PR TITLE
Fix extra block device bind mounting

### DIFF
--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -1007,7 +1007,7 @@ func TestDriveMount_Isolated(t *testing.T) {
 		},
 		{
 			VMPath:         "/mnt",
-			FilesystemType: "ext3",
+			FilesystemType: "ext4",
 			// don't specify "ro" to validate it's automatically set via "IsWritable: false"
 			VMMountOptions: []string{"relatime"},
 			ContainerPath:  "/bar",


### PR DESCRIPTION
# General Description  TLDR;
We tried to attach an extra block device containing filesystems but received **file exists** error. This error is only existed when we used runc_jailer (will call it jailer in the following context) + `DriveExposePolicy_BIND`. Not surprisingly, without the jailer, the extra block device was successfully mounted without any issue.

**Root cause is that the same block device being mounted twice. The duplicated mountings cause an error returned.**

Detailed error message is below
```
An error is returned "rpc error: code = Unknown desc = failed to create VM: failed to patch drive mount stub: failed to expose
patched drive contents to jail: file exists". This commit is for fixing it.
```

## What is the problem in detail?
### Setup
The jailer config was
```
proto.JailerConfig{
    UID:               300001,
    GID:               300001,
    DriveExposePolicy: proto.DriveExposePolicy_BIND,
}
```
The FirecrackerDriveMount definition we used was
```
    driveMounts := []*proto.FirecrackerDriveMount{&proto.FirecrackerDriveMount{
        HostPath: "/dev/nvme5n1",
        VMPath: "/mnt",
        FilesystemType: "ext4",
    }}
```
/dev/nvme5n1 is a block device, aks *block special file*, and has a ext4 filesystem as shown below
```
admin@xxx:~$ sudo ls -al /dev/nvme5n1
brw-rw---- 1 root disk 259, 8 Jul  9 20:40 /dev/nvme5n1

admin@xxx:~$ sudo file -sL /dev/nvme5n1
/dev/nvme5n1: Linux rev 1.0 ext4 filesystem data, UUID=99fae2c1-aaae-4e40-8f90-620b696a0c65 (extents) (64bit) (large files) (huge files)
```

### Stacktrace
Before deep dive into this problem, we want to clarify that the above error is returned only when we used `DriveExposePolicy: proto.DriveExposePolicy_BIND` in the jailer configuration. If we don't use `DriveExposePolicy_BIND`, no error is returned.

In the current implementation, when a new runc_jailer or jailer is created, it will check if the DriveExposePolicy as shown below. or you can click the [LINK](https://github.com/firecracker-microvm/firecracker-containerd/blob/c2323bc71886b3abfefd9afa53244740f70db0b8/runtime/runc_jailer.go#L129) to find the code snippet.
```
	if j.Config.DriveExposePolicy == proto.DriveExposePolicy_BIND {
		err := j.prepareBindMounts(mounts)
		if err != nil {
			return nil, err
		}
	}
```
**prepareBindMounts()** will then call **bindMountFileToJail()** to bind mount all files, in this case, either block special files or regular files. If these files are regular files contain filesystem images, we can bind mount them into VM and ultimately into the container without any problem. **BUT** if they are block devices, or block special files, then the problem comes into play. 

Before you understand why it is problematic, you need to remeber runc_jailer creation is happened at very beginning, before **CreateVM()**, which means **bindMountFileToJail()** mentioned above is called even before **CreateVM()**. Remember, inside runc_jailer creation, we first check DriveExposePolicy, if it is *DriveExposePolicy_BIND*, we call **prepareBindMounts()** which then calls **bindMountFileToJail()**. All of these calls are happened in the jailer creation, at the very first stage, and all of them are happened before **CreateVM()**. The order is crucial because it explains why the **file exists** error is returned.

Inside **CreateVM()**, there is a **createVM()** which is a helper function, and it calls **mountDrives()** at very end. [LINK to the code](https://github.com/firecracker-microvm/firecracker-containerd/blob/c2323bc71886b3abfefd9afa53244740f70db0b8/runtime/service.go#L618). **mountDrives()** will call **PatchAndMount()** which is then call **jail.ExposeFileToJail(Your_HostPath)**.

**jail.ExposeFileToJail(Your_HostPath)** will inspect the given file at *Your_HostPath* and based on the file type, proper handling will occur to ensure that the file is visible in the jail.
- block device or block special file: call **exposeBlockDeviceToJail()** which then call **syscall.Mknod()** to create a block device, as you may notice, we first check DriveExposePoly at **bindMountFileToJail** in the jailer creation, and then called **mountDrives()** at very end again in createVM(). **syscall.Mknod()** will not create a block file if there is a file with the same name already existed. So **file exists** error is returned.
- regular file: call **exposeFileToJail()**

So the overall timestamp looks like:
CreateVM()-->createVM()-->newJailer() which then call newRuncJailer() to create a jailer--> mountDrives()--> PatchAndMount()

Meanwhile,
**newJailer() => Check DriveExposePolicy and then call prepareBindMounts() is possible**

**PatchAndMount => jail.ExposeFileToJail(Your_HostPath) => exposeBlockDeviceToJail() or exposeFileToJail()**

### Conclusion
With the above stack trace, we found out that when we create a VM using **createVM()** and want to attach an extra block device as well, there are two places gonna create a block special file. One place is when runc_jailer is created, **prepareBindMounts()** is called which means the block special file will be bind mounted into the VM. A second place is after the jailer is created, **createVM()** calls **mountDrives()** and eventually a syscall.Mknod will be made to create a block special file. However, if the file is a regular file, calling **prepareBindMounts()** and both **mountDrives()** will not be problematic, seems the regular file can be truncated.

### Description of changes
Given what we found out, a solution will focus on avoiding create a block special file twice.

More specifically, **prepareBindMounts()**  will be only called for regular files. If they are block devices, we don't need to bind mount them at the runc_jailer creation step.

## Q&A and some interesting findings
- If we ultimately call ExposeFileToJail(), what is the responsibility of prepareBindMounts()?
  - See the conversation below.

- Can we simply set permissions if block device already exists, otherwise call mknod?
  - No, the error message is shown below. This solution doesn't work due to the permission issue. It seems syscall.Mknod() has handled the permission while creating the device file.
```
2021/06/22 22:00:43 failed to create a VM: rpc error: code = Unknown desc = failed to create VM: failed to patch drive mount stub: failed to patch drive: [PATCH /drives/{drive_id}][400] patchGuestDriveByIdBadRequest  &{FaultMessage:Error during drive update (patch): device error: Permission denied (os error 13)}
exit status 1
```
- Can we remove **s.mountDrives()** instead? 
  - No. Because **mountDrives()** is needed to mount stubDrives. And each stubDrive contains a block device information that are needed by **fc-ctrd Agent** for future mounting. [More implementation details about stubDrive](https://github.com/firecracker-microvm/firecracker-containerd/blob/7cf94848ae2e587f7469d42037e54607a461ff34/docs/drive-mounts-proposal.md).
- We also tried to use `bb` to create a disk image from a block device, then the VM is created just fine. 
  - This is because `bb` creates a regular file, not block special file.

- What is the difference bw. mount a root drive and attach extra block device?
  - root drive is handled differently. It is exposed to jailer at [BuildJailedRootHandler](https://github.com/firecracker-microvm/firecracker-containerd/blob/f320d3636aee41661eb525b284ce6213f6c7a3d5/runtime/runc_jailer.go#L256). It doesn't rely on **prepareBindMounts()**, neither on **s.mountDrive()**
  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Royce Zhao <qiqinzha@amazon.com>