### PR TITLE
Remove unneeded rootfs prerequisite from getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,9 +38,6 @@ You need to have the following things in order to use firecracker-containerd:
 
   </details>
 * git
-* A root filesystem image (you can use the one
-  [described here](https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md#running-firecracker)
-  as `hello-rootfs.ext4`).
 * A recent installation of [Docker CE](https://docker.com).
 * Go 1.13 or later, which you can download from [here](https://golang.org/dl/).
 


### PR DESCRIPTION
The suggested rootfs won't work because it doesn't have runc or the firecracker-containerd agent and the document already has a step for building a working rootfs

Fixes #494 
