### PR TITLE
Update thinpool setup script in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,6 +167,10 @@ set -ex
 
 DIR=/var/lib/firecracker-containerd/snapshotter/devmapper
 POOL=fc-dev-thinpool
+	
+if [[ ! -d "${DIR}" ]]; then
+mkdir -p "${DIR}"
+fi
 
 if [[ ! -f "${DIR}/data" ]]; then
 touch "${DIR}/data"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The example thinpool setup in this guide script assumes the /var/lib/firecracker-containerd/snapshotter/devmapper directory exists. If fails if not. Added a directory check/create if needed block.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
