### PR TITLE
Use Debian 12 "bookworm" to workaround Linux's sublevel issue

### DIFF
--- a/.buildkite/setup_al2.sh
+++ b/.buildkite/setup_al2.sh
@@ -43,7 +43,7 @@ cat << EOF > $runtime_config_path
 	"firecracker_binary_path": "$bin_path/firecracker",
 	"shim_base_dir": "$dir",
 	"kernel_image_path": "$dir/default-vmlinux.bin",
-	"kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.log_color=false systemd.unit=firecracker.target init=/sbin/overlay-init",
+	"kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.unified_cgroup_hierarchy=0 systemd.journald.forward_to_console systemd.log_color=false systemd.unit=firecracker.target init=/sbin/overlay-init",
 	"log_levels": ["debug"],
 	"root_drive": "$dir/default-rootfs.img",
 	"jailer": {

--- a/examples/etc/containerd/firecracker-runtime.json
+++ b/examples/etc/containerd/firecracker-runtime.json
@@ -1,7 +1,7 @@
 {
   "firecracker_binary_path": "/usr/local/bin/firecracker",
   "kernel_image_path": "/var/lib/firecracker-containerd/runtime/default-vmlinux.bin",
-  "kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
+  "kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.unified_cgroup_hierarchy=0 systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
   "root_drive": "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
   "cpu_template": "T2",
   "log_levels": ["debug"],

--- a/runtime/integ_test.go
+++ b/runtime/integ_test.go
@@ -36,7 +36,7 @@ const defaultShimBaseDir = "/srv/firecracker_containerd_tests"
 var defaultRuntimeConfig = config.Config{
 	FirecrackerBinaryPath: "/usr/local/bin/firecracker",
 	KernelImagePath:       "/var/lib/firecracker-containerd/runtime/default-vmlinux.bin",
-	KernelArgs:            "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.log_color=false systemd.unit=firecracker.target init=/sbin/overlay-init",
+	KernelArgs:            "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.unified_cgroup_hierarchy=0 systemd.journald.forward_to_console systemd.log_color=false systemd.unit=firecracker.target init=/sbin/overlay-init",
 	RootDrive:             "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
 	LogLevels:             []string{"debug"},
 	ShimBaseDir:           shimBaseDir(),

--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -56,7 +56,7 @@ endif
 	debootstrap \
 		--variant=minbase \
 		--include=udev,systemd,systemd-sysv,procps,libseccomp2,haveged \
-		buster \
+		bookworm \
 		"$(WORKDIR)" $(DEBMIRROR)
 	rm -rf "$(WORKDIR)/var/cache/apt/archives" \
 	       "$(WORKDIR)/usr/share/doc" \


### PR DESCRIPTION
Linux kernel's sublevel exceeded 255 in 4.9.x and 4.14.x releases.
However Debian's libc6 package assumed that the sublevel < 255 and had
an explicit check in the package.

While the check has been removed, we have to upgrade our Debian to
at least Debian 11 "bookwarm" to have the change.

https://lwn.net/Articles/845120/
https://lore.kernel.org/stable/YVAhOlTsb0NK0BVi@kroah.com/T/
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=987266

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
