### PR TITLE
Make "make test-images" faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ GID:=$(shell id -g)
 FIRECRACKER_CONTAINERD_BUILDER_IMAGE?=golang:1.13-buster
 export FIRECRACKER_CONTAINERD_TEST_IMAGE?=localhost/firecracker-containerd-test
 export GO_CACHE_VOLUME_NAME?=gocache
+export ROOTFS_CACHE_VOLUME_NAME ?= rootfscache
 
 # This Makefile uses Firecracker's pre-build Linux kernels for x86_64 and aarch64.
 host_arch=$(shell arch)
@@ -98,8 +99,10 @@ distclean: clean
 	$(MAKE) -C tools/image-builder distclean
 	$(call rmi-if-exists,localhost/$(RUNC_BUILDER_NAME):$(DOCKER_IMAGE_TAG))
 	$(call rmi-if-exists,localhost/$(FIRECRACKER_BUILDER_NAME):$(DOCKER_IMAGE_TAG))
-	docker volume rm -f $(CARGO_CACHE_VOLUME_NAME)
-	docker volume rm -f $(GO_CACHE_VOLUME_NAME)
+	docker volume rm -f \
+		$(CARGO_CACHE_VOLUME_NAME) \
+		$(GO_CACHE_VOLUME_NAME) \
+		$(ROOTFS_CACHE_VOLUME_NAME)
 	$(call rmi-if-exists,$(FIRECRACKER_CONTAINERD_TEST_IMAGE):$(DOCKER_IMAGE_TAG))
 	$(call rmi-if-exists,localhost/$(PROTO_BUILDER_NAME):$(DOCKER_IMAGE_TAG))
 

--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -17,6 +17,8 @@ WORKDIRLOC := $(shell readlink -f $(WORKDIR))
 IMAGE_DIRS := /dev /bin /etc /etc/init.d /tmp /var /run /proc /sys /container/rootfs /agent /rom /overlay
 DIRS       := $(foreach dir,$(IMAGE_DIRS),"$(WORKDIR)$(dir)")
 DEBMIRROR  ?= http://deb.debian.org/debian
+ROOTFS_CACHE_VOLUME_NAME ?= rootfscache
+
 
 export DOCKER_IMAGE_TAG?=latest
 
@@ -103,7 +105,7 @@ builder_stamp:
 	docker run --rm \
 		--security-opt=apparmor=unconfined \
 		--volume $(CURDIR):/src \
-		--volume /src/tmp \
+		--volume $(ROOTFS_CACHE_VOLUME_NAME):/src/tmp \
 		--cap-add=sys_admin \
 		--cap-add=sys_chroot \
 		--env=DEBMIRROR \


### PR DESCRIPTION
The target was calling deboostrap but its file tree was in /src/tmp,
which was removed with the container.

This change moves /src/tmp from an anonymous volume to a named
volume to keep the result.

https://docs.docker.com/storage/volumes/

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
