### PR TITLE
Revert "Make "make test-images" faster"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ GID:=$(shell id -g)
 FIRECRACKER_CONTAINERD_BUILDER_IMAGE?=golang:1.13-buster
 export FIRECRACKER_CONTAINERD_TEST_IMAGE?=localhost/firecracker-containerd-test
 export GO_CACHE_VOLUME_NAME?=gocache
-export ROOTFS_CACHE_VOLUME_NAME ?= rootfscache
 
 # This Makefile uses Firecracker's pre-build Linux kernels for x86_64 and aarch64.
 host_arch=$(shell arch)
@@ -99,10 +98,8 @@ distclean: clean
 	$(MAKE) -C tools/image-builder distclean
 	$(call rmi-if-exists,localhost/$(RUNC_BUILDER_NAME):$(DOCKER_IMAGE_TAG))
 	$(call rmi-if-exists,localhost/$(FIRECRACKER_BUILDER_NAME):$(DOCKER_IMAGE_TAG))
-	docker volume rm -f \
-		$(CARGO_CACHE_VOLUME_NAME) \
-		$(GO_CACHE_VOLUME_NAME) \
-		$(ROOTFS_CACHE_VOLUME_NAME)
+	docker volume rm -f $(CARGO_CACHE_VOLUME_NAME)
+	docker volume rm -f $(GO_CACHE_VOLUME_NAME)
 	$(call rmi-if-exists,$(FIRECRACKER_CONTAINERD_TEST_IMAGE):$(DOCKER_IMAGE_TAG))
 	$(call rmi-if-exists,localhost/$(PROTO_BUILDER_NAME):$(DOCKER_IMAGE_TAG))
 

--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -17,8 +17,6 @@ WORKDIRLOC := $(shell readlink -f $(WORKDIR))
 IMAGE_DIRS := /dev /bin /etc /etc/init.d /tmp /var /run /proc /sys /container/rootfs /agent /rom /overlay
 DIRS       := $(foreach dir,$(IMAGE_DIRS),"$(WORKDIR)$(dir)")
 DEBMIRROR  ?= http://deb.debian.org/debian
-ROOTFS_CACHE_VOLUME_NAME ?= rootfscache
-
 
 export DOCKER_IMAGE_TAG?=latest
 
@@ -105,7 +103,7 @@ builder_stamp:
 	docker run --rm \
 		--security-opt=apparmor=unconfined \
 		--volume $(CURDIR):/src \
-		--volume $(ROOTFS_CACHE_VOLUME_NAME):/src/tmp \
+		--volume /src/tmp \
 		--cap-add=sys_admin \
 		--cap-add=sys_chroot \
 		--env=DEBMIRROR \


### PR DESCRIPTION
Caching /src/tmp doesn't work since debootstrap assumes an empty directory.
In addition to that, sharing the volume across multiple BuildKite jobs
wouldn't work correctly.

This reverts commit 0df8c044428a756fddc2abaf57e8b0b7eaa54c52.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
