### PR TITLE
Use "testpool" as a loopback-based thinpool 

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -52,7 +52,7 @@ TEST_GATEWAY?=172.16.0.1
 TEST_IP?=172.16.0.2
 TEST_SUBNET?=/24
 FICD_DM_VOLUME_GROUP?=
-TEST_POOL?=testpool
+TEST_POOL?=fc-test-thinpool
 testtap:
 	ip link add br0 type bridge
 	ip tuntap add tap0 mode tap


### PR DESCRIPTION
runtime/Makefile and examples/Makefile are using different pools, while
tools/thinpool.sh is assuming that we only have a single loopback-based
thinpool.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
