### PR TITLE
Add ability to launch containers with vm local rootfs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/awslabs/tc-redirect-tap v0.0.0-20211025175357-e30dfca224c2
 	github.com/bits-and-blooms/bitset v1.2.1 // indirect
 	github.com/containerd/containerd v1.5.9
-	github.com/containerd/continuity v0.2.0 // indirect
+	github.com/containerd/continuity v0.2.0
 	github.com/containerd/fifo v1.0.0
 	github.com/containerd/go-cni v1.1.1 // indirect
 	github.com/containerd/go-runc v1.0.0
@@ -25,6 +25,7 @@ require (
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/mdlayher/vsock v1.1.0
 	github.com/miekg/dns v1.1.25
+	github.com/opencontainers/image-spec v1.0.2
 	github.com/opencontainers/runc v1.0.3
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210910115017-0d6cc581aeea
 	github.com/opencontainers/selinux v1.8.5 // indirect

--- a/internal/vm/mount.go
+++ b/internal/vm/mount.go
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package vm
+
+import (
+	"strings"
+
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/mount"
+)
+
+const vmLocalMountTypePrefix = "vm:"
+
+// IsLocalMount returns true if the mount source is inside the VM as opposed to the
+// default assumption that the mount source is a block device on the host.
+func IsLocalMount(mount *types.Mount) bool {
+	return mount != nil && strings.HasPrefix(mount.Type, vmLocalMountTypePrefix)
+}
+
+// AddLocalMountIdentifier adds an identifier to a mount so that it can be detected by IsLocalMount.
+// This is intended to be used by cooperating snapshotters to mark mounts as inside the VM so they
+// can be plumbed at the proper points inside/outside the VM.
+func AddLocalMountIdentifier(mnt mount.Mount) mount.Mount {
+	return mount.Mount{
+		Type:    vmLocalMountTypePrefix + mnt.Type,
+		Source:  mnt.Source,
+		Options: mnt.Options,
+	}
+}
+
+// StripLocalMountIdentifier removes the identifier that signals that a mount
+// is inside the VM. This is used before passing the mount information to runc
+func StripLocalMountIdentifier(mnt *types.Mount) *types.Mount {
+	options := make([]string, len(mnt.Options))
+	copy(options, mnt.Options)
+	return &types.Mount{
+		Type:    strings.Replace(mnt.Type, vmLocalMountTypePrefix, "", 1),
+		Source:  mnt.Source,
+		Target:  mnt.Target,
+		Options: options,
+	}
+}

--- a/internal/vm/mount_test.go
+++ b/internal/vm/mount_test.go
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package vm
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/mount"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLocalMount(t *testing.T) {
+	mnt := types.Mount{
+		Type:    "bind",
+		Source:  "/tmp/snapshots/1/fs",
+		Options: []string{"rbind"},
+	}
+	assert.False(t, IsLocalMount(&mnt), "Standard mount was considered vm local")
+}
+
+func TestAddLocalMountIdentifier(t *testing.T) {
+	mnt := mount.Mount{
+		Type:    "bind",
+		Source:  "/tmp/snapshots/1/fs",
+		Options: []string{"rbind"},
+	}
+	localMnt := AddLocalMountIdentifier(mnt)
+
+	mntProto := types.Mount{
+		Type:    mnt.Type,
+		Source:  mnt.Source,
+		Options: mnt.Options,
+	}
+	localMntProto := types.Mount{
+		Type:    localMnt.Type,
+		Source:  localMnt.Source,
+		Options: localMnt.Options,
+	}
+
+	assert.False(t, IsLocalMount(&mntProto), "Standard mount was considered vm local")
+	assert.True(t, IsLocalMount(&localMntProto), "Mount was not vm local after adding the local mount identifier")
+}
+
+func TestStripLocalMountIdentifier(t *testing.T) {
+	mnt := mount.Mount{
+		Type:    "bind",
+		Source:  "/tmp/snapshots/1/fs",
+		Options: []string{"rbind"},
+	}
+	localMnt := AddLocalMountIdentifier(mnt)
+	localMntProto := &types.Mount{
+		Type:    localMnt.Type,
+		Source:  localMnt.Source,
+		Options: localMnt.Options,
+	}
+	assert.True(t, IsLocalMount(localMntProto), "Mount was not vm local after adding the local mount identifier")
+	localMntProto = StripLocalMountIdentifier(localMntProto)
+	assert.False(t, IsLocalMount(localMntProto), "Mount was vm local after stripping the local mount identifier")
+}

--- a/internal/vm/oci.go
+++ b/internal/vm/oci.go
@@ -1,0 +1,277 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+/*
+   Copyright The containerd Authors.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/continuity/fs"
+	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// UpdateUserInSpec modifies a serialized json spec object with user information from inside the container.
+// If the client used firecrackeroci.WithVmLocalImageConfig or firecrakceroci.WithVmLocalUser, this
+// method will do the mapping between username -> uid, group name -> gid, and lookup additional groups for the user.
+// This is used to split where the user configures a spec via containerd's oci methods in the client
+// from where the data is actually present (from the agent inside the VM)
+func UpdateUserInSpec(ctx context.Context, specData []byte, rootfsMount mount.Mount) ([]byte, error) {
+	var spec specs.Spec
+	if err := json.Unmarshal(specData, &spec); err != nil {
+		return specData, err
+	}
+	if err := updateUserInSpec(ctx, &spec, rootfsMount); err != nil {
+		return specData, err
+	}
+	newSpecData, err := json.Marshal(&spec)
+	if err != nil {
+		return specData, err
+	}
+	return newSpecData, nil
+
+}
+
+func updateUserInSpec(ctx context.Context, s *specs.Spec, rootfsMount mount.Mount) error {
+	userstr := s.Process.User.Username
+	if userstr != "" {
+		s.Process.User.Username = ""
+		if err := withUser(ctx, s, rootfsMount, userstr); err != nil {
+			return err
+		}
+		return withAdditionalGIDs(ctx, s, rootfsMount, userstr)
+	}
+	return withAdditionalGIDs(ctx, s, rootfsMount, "root")
+}
+
+// The remaining methods in this file are copies of https://github.com/containerd/containerd/blob/main/oci/spec_opts.go
+// except that they operate directly on a spec rather than as functional arguments when creating a container.
+// We do this so that we can run these methods from the agent running inside the VM rather than in the containerd client.
+// These methods temporarily mount the container's rootfs to lookup information which is only possible inside the
+// VM for VM local container rootfs'
+
+// withUser sets the user to be used within the container.
+// It accepts a valid user string in OCI Image Spec v1.0.0:
+//   user, uid, user:group, uid:gid, uid:group, user:gid
+func withUser(ctx context.Context, s *specs.Spec, rootfsMount mount.Mount, userstr string) error {
+	parts := strings.Split(userstr, ":")
+	switch len(parts) {
+	case 1:
+		v, err := strconv.Atoi(parts[0])
+		if err != nil {
+			// if we cannot parse as a uint they try to see if it is a username
+			return withUsername(ctx, s, rootfsMount, parts[0])
+		}
+		return withUserID(ctx, s, rootfsMount, uint32(v))
+	case 2:
+		var (
+			username  string
+			groupname string
+		)
+		var uid, gid uint32
+		v, err := strconv.Atoi(parts[0])
+		if err != nil {
+			username = parts[0]
+		} else {
+			uid = uint32(v)
+		}
+		if v, err = strconv.Atoi(parts[1]); err != nil {
+			groupname = parts[1]
+		} else {
+			gid = uint32(v)
+		}
+		if username == "" && groupname == "" {
+			s.Process.User.UID, s.Process.User.GID = uid, gid
+			return nil
+		}
+		f := func(root string) error {
+			if username != "" {
+				user, err := userFromPath(root, func(u user.User) bool {
+					return u.Name == username
+				})
+				if err != nil {
+					return err
+				}
+				uid = uint32(user.Uid)
+			}
+			if groupname != "" {
+				gid, err = gIDFromPath(root, func(g user.Group) bool {
+					return g.Name == groupname
+				})
+				if err != nil {
+					return err
+				}
+			}
+			s.Process.User.UID, s.Process.User.GID = uid, gid
+			return nil
+		}
+		return mount.WithTempMount(ctx, []mount.Mount{rootfsMount}, f)
+	default:
+		return fmt.Errorf("invalid USER value %s", userstr)
+	}
+}
+
+// userFromPath inspects the user object using /etc/passwd in the specified rootfs.
+// filter can be nil.
+func userFromPath(root string, filter func(user.User) bool) (user.User, error) {
+	ppath, err := fs.RootPath(root, "/etc/passwd")
+	if err != nil {
+		return user.User{}, err
+	}
+	users, err := user.ParsePasswdFileFilter(ppath, filter)
+	if err != nil {
+		return user.User{}, err
+	}
+	if len(users) == 0 {
+		return user.User{}, oci.ErrNoUsersFound
+	}
+	return users[0], nil
+}
+
+// gIDFromPath inspects the GID using /etc/passwd in the specified rootfs.
+// filter can be nil.
+func gIDFromPath(root string, filter func(user.Group) bool) (gid uint32, err error) {
+	gpath, err := fs.RootPath(root, "/etc/group")
+	if err != nil {
+		return 0, err
+	}
+	groups, err := user.ParseGroupFileFilter(gpath, filter)
+	if err != nil {
+		return 0, err
+	}
+	if len(groups) == 0 {
+		return 0, oci.ErrNoGroupsFound
+	}
+	g := groups[0]
+	return uint32(g.Gid), nil
+}
+
+// withUserID sets the correct UID and GID for the container based
+// on the image's /etc/passwd contents. If /etc/passwd does not exist,
+// or uid is not found in /etc/passwd, it sets the requested uid,
+// additionally sets the gid to 0, and does not return an error.
+func withUserID(ctx context.Context, s *specs.Spec, rootfsMount mount.Mount, uid uint32) error {
+	return mount.WithTempMount(ctx, []mount.Mount{rootfsMount}, func(root string) error {
+		user, err := userFromPath(root, func(u user.User) bool {
+			return u.Uid == int(uid)
+		})
+		if err != nil {
+			if os.IsNotExist(err) || err == oci.ErrNoUsersFound {
+				s.Process.User.UID, s.Process.User.GID = uid, 0
+				return nil
+			}
+			return err
+		}
+		s.Process.User.UID, s.Process.User.GID = uint32(user.Uid), uint32(user.Gid)
+		return nil
+	})
+}
+
+// withUsername sets the correct UID and GID for the container
+// based on the image's /etc/passwd contents. If /etc/passwd
+// does not exist, or the username is not found in /etc/passwd,
+// it returns error.
+func withUsername(ctx context.Context, s *specs.Spec, rootfsMount mount.Mount, username string) error {
+	return mount.WithTempMount(ctx, []mount.Mount{rootfsMount}, func(root string) error {
+		user, err := userFromPath(root, func(u user.User) bool {
+			return u.Name == username
+		})
+		if err != nil {
+			return err
+		}
+		s.Process.User.UID, s.Process.User.GID = uint32(user.Uid), uint32(user.Gid)
+		return nil
+	})
+}
+
+func withAdditionalGIDs(ctx context.Context, s *specs.Spec, rootfsMount mount.Mount, userstr string) error {
+	setAdditionalGids := func(root string) error {
+		var username string
+		uid, err := strconv.Atoi(userstr)
+		if err == nil {
+			user, err := userFromPath(root, func(u user.User) bool {
+				return u.Uid == uid
+			})
+			if err != nil {
+				if os.IsNotExist(err) || err == oci.ErrNoUsersFound {
+					return nil
+				}
+				return err
+			}
+			username = user.Name
+		} else {
+			username = userstr
+		}
+		gids, err := getSupplementalGroupsFromPath(root, func(g user.Group) bool {
+			// we only want supplemental groups
+			if g.Name == username {
+				return false
+			}
+			for _, entry := range g.List {
+				if entry == username {
+					return true
+				}
+			}
+			return false
+		})
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		s.Process.User.AdditionalGids = gids
+		return nil
+	}
+	return mount.WithTempMount(ctx, []mount.Mount{rootfsMount}, setAdditionalGids)
+}
+
+func getSupplementalGroupsFromPath(root string, filter func(user.Group) bool) ([]uint32, error) {
+	gpath, err := fs.RootPath(root, "/etc/group")
+	if err != nil {
+		return []uint32{}, err
+	}
+	groups, err := user.ParseGroupFileFilter(gpath, filter)
+	if err != nil {
+		return []uint32{}, err
+	}
+	if len(groups) == 0 {
+		// if there are no additional groups; just return an empty set
+		return []uint32{}, nil
+	}
+	addlGids := []uint32{}
+	for _, grp := range groups {
+		addlGids = append(addlGids, uint32(grp.Gid))
+	}
+	return addlGids, nil
+}

--- a/runtime/firecrackeroci/vm.go
+++ b/runtime/firecrackeroci/vm.go
@@ -1,0 +1,153 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+/*
+   Copyright The containerd Authors.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package firecrackeroci
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/oci"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+var (
+	defaultUnixEnv = []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	}
+)
+
+// WithVmLocalImageConfig configures a spec with the content of the image's config.
+// It is similar to containerd's oci.WithImageConfig except that it does not access
+// the image's rootfs on the host. Instead, it configures what it can on the host and
+// passes information to the agent running in the VM to inspect the image's rootfs.
+func WithVmLocalImageConfig(image containerd.Image) oci.SpecOpts {
+	return func(ctx context.Context, client oci.Client, container *containers.Container, spec *oci.Spec) error {
+		ic, err := image.Config(ctx)
+		if err != nil {
+			return err
+		}
+		var (
+			ociimage v1.Image
+			config   v1.ImageConfig
+		)
+		switch ic.MediaType {
+		case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
+			p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
+			if err != nil {
+				return err
+			}
+
+			if err := json.Unmarshal(p, &ociimage); err != nil {
+				return err
+			}
+			config = ociimage.Config
+		default:
+			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
+		}
+		if spec.Process == nil {
+			spec.Process = &specs.Process{}
+		}
+
+		defaults := config.Env
+		if len(defaults) == 0 {
+			defaults = defaultUnixEnv
+		}
+		spec.Process.Env = replaceOrAppendEnvValues(defaults, spec.Process.Env)
+		cmd := config.Cmd
+		spec.Process.Args = append(config.Entrypoint, cmd...)
+
+		cwd := config.WorkingDir
+		if cwd == "" {
+			cwd = "/"
+		}
+		spec.Process.Cwd = cwd
+		if config.User != "" {
+			WithVmLocalUser(config.User)(ctx, client, container, spec)
+		}
+		return nil
+	}
+}
+
+// WithVmLocalUser configures the user of the spec.
+// It is similar to oci.WithUser except that it doesn't map
+// username -> uid or group name -> gid. It passes the user to the
+// agent running inside the VM to do that mapping.
+func WithVmLocalUser(user string) oci.SpecOpts {
+	return func(ctx context.Context, client oci.Client, container *containers.Container, spec *oci.Spec) error {
+		// This is technically an LCOW specific field, but we piggy back
+		// to get the string user into the VM where will will do the uid/gid mapping
+		spec.Process.User.Username = user
+		return nil
+	}
+}
+
+// replaceOrAppendEnvValues returns the defaults with the overrides either
+// replaced by env key or appended to the list
+func replaceOrAppendEnvValues(defaults, overrides []string) []string {
+	cache := make(map[string]int, len(defaults))
+	results := make([]string, 0, len(defaults))
+	for i, e := range defaults {
+		parts := strings.SplitN(e, "=", 2)
+		results = append(results, e)
+		cache[parts[0]] = i
+	}
+
+	for _, value := range overrides {
+		// Values w/o = means they want this env to be removed/unset.
+		if !strings.Contains(value, "=") {
+			if i, exists := cache[value]; exists {
+				results[i] = "" // Used to indicate it should be removed
+			}
+			continue
+		}
+
+		// Just do a normal set/update
+		parts := strings.SplitN(value, "=", 2)
+		if i, exists := cache[parts[0]]; exists {
+			results[i] = value
+		} else {
+			results = append(results, value)
+		}
+	}
+
+	// Now remove all entries that we want to "unset"
+	for i := 0; i < len(results); i++ {
+		if results[i] == "" {
+			results = append(results[:i], results[i+1:]...)
+			i--
+		}
+	}
+
+	return results
+}

--- a/runtime/vm/mount.go
+++ b/runtime/vm/mount.go
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package vm
+
+import (
+	"github.com/containerd/containerd/mount"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/vm"
+)
+
+// AddLocalMountIdentifier adds an identifier to a mount so that it can be detected by IsLocalMount.
+// This is intended to be used by cooperating snapshotters to mark mounts as inside the VM so they
+// can be plumbed at the proper points inside/outside the VM.
+func AddLocalMountIdentifier(mnt mount.Mount) mount.Mount {
+	return vm.AddLocalMountIdentifier(mnt)
+}


### PR DESCRIPTION
With this change, if a mount is returned from a snapshotter
where the type is prefixed with "vm:", then firecracker-containerd
will not assume it is a block device and will pass the mount
information directly to the agent in the VM to handle mounting
the container's rootfs.

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
