### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/vm/dir_test.go
+++ b/internal/vm/dir_test.go
@@ -14,22 +14,17 @@
 package vm
 
 import (
-	"io/ioutil"
-	"os"
 	"path"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var invalidContainerIDs = []string{"", "id?", "*", "id/1", "id\\"}
 
 func TestShimDir(t *testing.T) {
-	runDir, err := ioutil.TempDir("", "run")
-	require.NoError(t, err)
-	defer os.RemoveAll(runDir)
+	runDir := t.TempDir()
 
 	tests := []struct {
 		name   string

--- a/internal/vm/ioproxy_test.go
+++ b/internal/vm/ioproxy_test.go
@@ -41,14 +41,12 @@ func fileConnector(path string, flag int) IOConnector {
 }
 
 func TestProxy(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ctx := context.Background()
 	content := "hello world"
 
-	err = ioutil.WriteFile(filepath.Join(dir, "input"), []byte(content), 0600)
+	err := ioutil.WriteFile(filepath.Join(dir, "input"), []byte(content), 0600)
 	require.NoError(t, err)
 
 	pair := &IOConnectorPair{

--- a/runtime/drive_handler_test.go
+++ b/runtime/drive_handler_test.go
@@ -15,12 +15,11 @@ package main
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
-
-	"io/ioutil"
 
 	"github.com/containerd/containerd/log"
 	"github.com/firecracker-microvm/firecracker-containerd/internal/vm"
@@ -54,12 +53,10 @@ func TestContainerStubs(t *testing.T) {
 	ctx := context.Background()
 	logger := log.G(ctx)
 
-	tmpDir, err := ioutil.TempDir("", "TestCreateContainerStubs")
-	require.NoError(t, err, "failed to create temporary directory")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	stubDir := filepath.Join(tmpDir, "stubs")
-	err = os.MkdirAll(stubDir, 0700)
+	err := os.MkdirAll(stubDir, 0700)
 	require.NoError(t, err, "failed to create stub dir")
 
 	patchedSrcDir := filepath.Join(tmpDir, "patchedSrcs")
@@ -127,12 +124,10 @@ func TestDriveMountStubs(t *testing.T) {
 	ctx := context.Background()
 	logger := log.G(ctx)
 
-	tmpDir, err := ioutil.TempDir("", "Test-CreateContainerStubs")
-	require.NoError(t, err, "failed to create temporary directory")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	stubDir := filepath.Join(tmpDir, "stubs")
-	err = os.MkdirAll(stubDir, 0700)
+	err := os.MkdirAll(stubDir, 0700)
 	require.NoError(t, err, "failed to create stub dir")
 
 	patchedSrcDir := filepath.Join(tmpDir, "patchedSrcs")

--- a/runtime/jailer_test.go
+++ b/runtime/jailer_test.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,14 +61,12 @@ func createSparseFile(path string, size int) error {
 }
 
 func TestCopyFile_sparse(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	expectedSize := 1024
 
 	src := filepath.Join(dir, "original-sparse-file")
-	err = createSparseFile(src, expectedSize)
+	err := createSparseFile(src, expectedSize)
 	require.NoError(t, err)
 
 	dst := filepath.Join(dir, "copied-as-sparse")
@@ -104,9 +101,7 @@ func TestJailer_invalidUIDGID(t *testing.T) {
 func TestNewJailer_Isolated(t *testing.T) {
 	prepareIntegTest(t)
 
-	ociBundlePath, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(ociBundlePath)
+	ociBundlePath := t.TempDir()
 	b, err := exec.Command(
 		"cp",
 		"firecracker-runc-config.json.example",

--- a/runtime/runc_jailer_test.go
+++ b/runtime/runc_jailer_test.go
@@ -35,10 +35,8 @@ import (
 
 func TestBuildJailedRootHandler_Isolated(t *testing.T) {
 	internal.RequiresIsolation(t)
-	dir, err := ioutil.TempDir("", "TestBuildJailedRootHandler")
-	require.NoError(t, err, "failed to create temporary directory")
+	dir := t.TempDir()
 
-	defer os.RemoveAll(dir)
 	kernelImagePath := filepath.Join(dir, "kernel-image")
 	kernelImageFd, err := os.OpenFile(kernelImagePath, os.O_CREATE, 0600)
 	require.NoError(t, err, "failed to create kernel image")
@@ -107,12 +105,11 @@ func TestMkdirAllWithPermissions_Isolated(t *testing.T) {
 	// requires isolation so we can change uid/gid of files
 	internal.RequiresIsolation(t)
 
-	tmpdir, err := ioutil.TempDir("", "TestMkdirAllWithPermissions")
-	require.NoError(t, err, "failed to create temporary directory")
+	tmpdir := t.TempDir()
 
 	existingPath := filepath.Join(tmpdir, "exists")
 	existingMode := os.FileMode(0700)
-	err = os.Mkdir(existingPath, existingMode)
+	err := os.Mkdir(existingPath, existingMode)
 	require.NoError(t, err, "failed to create existing part of test directory")
 
 	nonExistingPath := filepath.Join(existingPath, "nonexistent")
@@ -139,9 +136,7 @@ func TestBindMountToJail_Isolated(t *testing.T) {
 	// The user must be root to call chown.
 	internal.RequiresIsolation(t)
 
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	f, err := os.Create(filepath.Join(dir, "src1"))
 	require.NoError(t, err)
@@ -196,13 +191,12 @@ func TestFifoHandler_Isolated(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", testNameToVMID(t.Name()))
-			require.NoError(t, err)
+			dir := t.TempDir()
 
 			logPath := filepath.Join(dir, tc.logPath)
 			metricsPath := filepath.Join(dir, tc.metricsPath)
 
-			err = os.MkdirAll(filepath.Dir(logPath), 0750)
+			err := os.MkdirAll(filepath.Dir(logPath), 0750)
 			require.NoError(t, err)
 			err = ioutil.WriteFile(logPath, []byte("log"), 0644)
 			require.NoError(t, err)

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -2196,9 +2196,7 @@ func TestCreateVM_Isolated(t *testing.T) {
 		}
 		vmID := testNameToVMID(t.Name())
 
-		tempDir, err := ioutil.TempDir("", vmID)
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
+		tempDir := t.TempDir()
 
 		logFile := filepath.Join(tempDir, "log.fifo")
 		metricsFile := filepath.Join(tempDir, "metrics.fifo")
@@ -2220,7 +2218,7 @@ func TestCreateVM_Isolated(t *testing.T) {
 			// Ensure the response fields are populated correctly
 			assert.Equal(t, request.VMID, resp.VMID)
 
-			_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: request.VMID})
+			_, err := fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: request.VMID})
 			require.Equal(t, status.Code(err), codes.OK)
 		}
 	}
@@ -2318,9 +2316,7 @@ func TestPauseResume_Isolated(t *testing.T) {
 	runTest := func(t *testing.T, request *proto.CreateVMRequest, state func(ctx context.Context, resp *proto.CreateVMResponse)) {
 		vmID := testNameToVMID(t.Name())
 
-		tempDir, err := ioutil.TempDir("", vmID)
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
+		tempDir := t.TempDir()
 
 		logFile := filepath.Join(tempDir, "log.fifo")
 		metricsFile := filepath.Join(tempDir, "metrics.fifo")
@@ -2347,7 +2343,7 @@ func TestPauseResume_Isolated(t *testing.T) {
 		assert.Equal(t, request.VMID, resp.VMID)
 
 		// Resume the VM since state() may pause the VM.
-		_, err = fcClient.ResumeVM(ctx, &proto.ResumeVMRequest{VMID: vmID})
+		_, err := fcClient.ResumeVM(ctx, &proto.ResumeVMRequest{VMID: vmID})
 		require.NoError(t, err)
 
 		_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: vmID})

--- a/runtime/service_test.go
+++ b/runtime/service_test.go
@@ -16,7 +16,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -234,9 +233,7 @@ func TestBuildVMConfiguration(t *testing.T) {
 				config:    tc.config,
 			}
 
-			tempDir, err := ioutil.TempDir(os.TempDir(), namespace)
-			assert.NoError(t, err)
-			defer os.RemoveAll(tempDir)
+			tempDir := t.TempDir()
 
 			svc.shimDir = vm.Dir(tempDir)
 			svc.jailer = newNoopJailer(context.Background(), svc.logger, svc.shimDir)
@@ -304,13 +301,7 @@ func TestDebugConfig(t *testing.T) {
 		},
 	}
 
-	cwd, err := os.Getwd()
-	require.NoError(t, err, "failed to get working dir")
-
-	path, err := ioutil.TempDir(cwd, "TestDebugConfig")
-	assert.NoError(t, err, "failed to create temp directory")
-
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	for i, c := range cases {
 		c := c


### PR DESCRIPTION
*Description of changes:*
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
