### PR TITLE
feat: add demultiplexing snapshotter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-SUBDIRS:=agent runtime examples firecracker-control/cmd/containerd
+SUBDIRS:=agent runtime examples firecracker-control/cmd/containerd snapshotter
 TEST_SUBDIRS:=$(addprefix test-,$(SUBDIRS))
 INTEG_TEST_SUBDIRS:=$(addprefix integ-test-,$(SUBDIRS))
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5
 	github.com/opencontainers/runc v1.1.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210910115017-0d6cc581aeea
+	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect

--- a/snapshotter/.gitignore
+++ b/snapshotter/.gitignore
@@ -1,0 +1,2 @@
+demux-snapshotter
+http-resolver

--- a/snapshotter/Makefile
+++ b/snapshotter/Makefile
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+EXTRAGOARGS?=
+
+SOURCES := $(shell find . -name '*.go')
+GOMOD := $(shell go env GOMOD)
+GOSUM := $(GOMOD:.mod=.sum)
+
+REVISION := $(shell git rev-parse HEAD)
+
+all: demux-snapshotter
+
+demux-snapshotter: $(SOURCES) $(GOMOD) $(GOSUM)
+	go build $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)" -o $@
+
+http-resolver: $(SOURCES) $(GOMOD) $(GOSUM)
+	go build $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)" -o $@ internal/http_address_resolver.go
+
+test:
+	go test ./... $(EXTRAGOARGS)
+
+clean:
+	- rm -f demux-snapshotter
+	- rm -f http-resolver
+
+distclean: clean
+
+# Install is a noop here, for now.
+install:
+
+.PHONY: all install test clean distclean

--- a/snapshotter/app/service.go
+++ b/snapshotter/app/service.go
@@ -1,0 +1,152 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
+	"github.com/containerd/containerd/contrib/snapshotservice"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/firecracker-microvm/firecracker-go-sdk/vsock"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/config"
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux"
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/cache"
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/proxy"
+	proxyaddress "github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/proxy/address"
+)
+
+// Run the demultiplexing snapshotter service.
+//
+// The snapshotter server will be running on the
+// network address and port specified in listener config.
+func Run(config config.Config) error {
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE, syscall.SIGHUP, syscall.SIGQUIT)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	group, ctx := errgroup.WithContext(ctx)
+
+	snapshotter, err := initSnapshotter(ctx, config)
+	if err != nil {
+		log.G(ctx).WithFields(
+			logrus.Fields{"resolver": config.Snapshotter.Proxy.Address.Resolver.Type},
+		).WithError(err).Fatal("failed creating socket resolver")
+		return err
+	}
+
+	grpcServer := grpc.NewServer()
+	service := snapshotservice.FromSnapshotter(snapshotter)
+	snapshotsapi.RegisterSnapshotsServer(grpcServer, service)
+
+	listenerConfig := config.Snapshotter.Listener
+	listener, err := net.Listen(listenerConfig.Network, listenerConfig.Address)
+	if err != nil {
+		log.G(ctx).WithFields(
+			logrus.Fields{
+				"network": listenerConfig.Network,
+				"address": listenerConfig.Address,
+			},
+		).WithError(err).Fatal("failed creating listener")
+		return err
+	}
+
+	group.Go(func() error {
+		return grpcServer.Serve(listener)
+	})
+
+	group.Go(func() error {
+		defer func() {
+			log.G(ctx).Info("stopping server")
+			grpcServer.Stop()
+
+			if err := snapshotter.Close(); err != nil {
+				log.G(ctx).WithError(err).Error("failed to close snapshotter")
+			}
+		}()
+
+		for {
+			select {
+			case <-stop:
+				cancel()
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+
+	if err := group.Wait(); err != nil {
+		log.G(ctx).WithError(err).Error("demux snapshotter error")
+		return err
+	}
+
+	log.G(ctx).Info("done")
+	return nil
+}
+
+func initResolver(config config.Config) (proxyaddress.Resolver, error) {
+	resolverConfig := config.Snapshotter.Proxy.Address.Resolver
+	switch resolverConfig.Type {
+	case "http":
+		return proxyaddress.NewHTTPResolver(resolverConfig.Address), nil
+	default:
+		return nil, fmt.Errorf("invalid resolver type: %s", resolverConfig.Type)
+	}
+}
+
+const base10 = 10
+const bits32 = 32
+
+func initSnapshotter(ctx context.Context, config config.Config) (snapshots.Snapshotter, error) {
+	resolver, err := initResolver(config)
+	if err != nil {
+		return nil, err
+	}
+
+	newProxySnapshotterFunc := func(ctx context.Context, namespace string) (snapshots.Snapshotter, error) {
+		r := resolver
+		response, err := r.Get(namespace)
+		if err != nil {
+			return nil, err
+		}
+		host, portstr, err := net.SplitHostPort(response.Address)
+		if err != nil {
+			return nil, err
+		}
+		port, err := strconv.ParseUint(portstr, base10, bits32)
+		if err != nil {
+			return nil, err
+		}
+		snapshotterDialer := func(ctx context.Context, namespace string) (net.Conn, error) {
+			return vsock.DialContext(ctx, host, uint32(port), vsock.WithLogger(log.G(ctx)))
+		}
+		return proxy.NewProxySnapshotter(ctx, host, snapshotterDialer)
+	}
+
+	return demux.NewSnapshotter(cache.NewSnapshotterCache(), newProxySnapshotterFunc), nil
+}

--- a/snapshotter/config/config.go
+++ b/snapshotter/config/config.go
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"io"
+	"os"
+
+	"github.com/pelletier/go-toml"
+)
+
+// Config contains metadata necessary to forward snapshotter requests
+// to the destined remote snapshotter.
+//
+// The default location for the configuration file is '/etc/demux-snapshotter/config.toml'
+type Config struct {
+	Snapshotter snapshotter `toml:"snapshotter"`
+
+	Debug debug `toml:"debug"`
+}
+
+type snapshotter struct {
+	Listener listener `toml:"listener"`
+	Proxy    proxy    `toml:"proxy"`
+}
+
+type listener struct {
+	Network string `toml:"network" default:"unix"`
+	Address string `toml:"address" default:"/var/lib/demux-snapshotter/snapshotter.sock"`
+}
+
+type proxy struct {
+	Address address `toml:"address"`
+}
+
+type address struct {
+	Resolver resolver `toml:"resolver"`
+}
+
+type resolver struct {
+	Type    string `toml:"type"`
+	Address string `toml:"address"`
+}
+
+type debug struct {
+	LogLevel string `toml:"logLevel" default:"info"`
+}
+
+// Load parses application configuration from a specified file path.
+func Load(filePath string) (Config, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return Config{}, err
+	}
+	defer file.Close()
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return Config{}, err
+	}
+
+	return load(file, fileInfo.Size())
+}
+
+func load(reader io.Reader, readSize int64) (Config, error) {
+	buffer := make([]byte, readSize)
+	readBytes, err := reader.Read(buffer)
+	if int64(readBytes) != readSize || err != nil {
+		return Config{}, err
+	}
+
+	config := Config{}
+	if err = toml.Unmarshal(buffer, &config); err != nil {
+		return Config{}, err
+	}
+	return config, nil
+}

--- a/snapshotter/config/config.toml.example
+++ b/snapshotter/config/config.toml.example
@@ -1,0 +1,10 @@
+[snapshotter.listener]
+  type = "unix"
+  address = "/var/lib/demux-snapshotter/snapshotter.sock"
+
+[snapshotter.proxy.address.resolver]
+  type = "http"
+  address = "127.0.0.1:10001"
+
+[debug]
+  logLevel = "info"

--- a/snapshotter/config/config_test.go
+++ b/snapshotter/config/config_test.go
@@ -1,0 +1,142 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type fakeReader struct {
+	buffer    []byte
+	bytesRead int
+	err       error
+}
+
+func (fr fakeReader) Read(p []byte) (int, error) {
+	copy(p, fr.buffer)
+	return fr.bytesRead, fr.err
+}
+
+func errorOnRead() error {
+	reader := fakeReader{
+		buffer:    nil,
+		bytesRead: 0,
+		err:       errors.New("mock read error"),
+	}
+	if _, err := load(reader, 10); err == nil {
+		return errors.New("expected error on read")
+	}
+	return nil
+}
+
+func errorOnParse() error {
+	fileContents := []byte(`[snapshotter`)
+	reader := fakeReader{
+		buffer:    fileContents,
+		bytesRead: len(fileContents),
+		err:       nil,
+	}
+	if _, err := load(reader, int64(len(fileContents))); err == nil {
+		return errors.New("expected error on parse")
+	}
+	return nil
+}
+
+func defaultConfig() error {
+	expected := Config{
+		Snapshotter: snapshotter{
+			Listener: listener{
+				Network: "unix",
+				Address: "/var/lib/demux-snapshotter/snapshotter.sock",
+			},
+		},
+		Debug: debug{
+			LogLevel: "info",
+		},
+	}
+	return parseConfig([]byte(``), expected)
+}
+
+func parseExampleConfig() error {
+	fileContents := []byte(`
+	[snapshotter]
+	  [snapshotter.listener]
+	    network = "unix"
+	    address = "/var/lib/demux-snapshotter/non-default-snapshotter.vsock"
+	  [snapshotter.proxy.address.resolver]
+	    type = "http"
+	    address = "localhost:10001"
+
+	[debug]
+	  logLevel = "debug"
+	`)
+	expected := Config{
+		Snapshotter: snapshotter{
+			Listener: listener{
+				Network: "unix",
+				Address: "/var/lib/demux-snapshotter/non-default-snapshotter.vsock",
+			},
+			Proxy: proxy{
+				Address: address{
+					Resolver: resolver{
+						Type:    "http",
+						Address: "localhost:10001",
+					},
+				},
+			},
+		},
+		Debug: debug{
+			LogLevel: "debug",
+		},
+	}
+	return parseConfig(fileContents, expected)
+}
+
+func parseConfig(input []byte, expected Config) error {
+	reader := fakeReader{
+		buffer:    input,
+		bytesRead: len(input),
+		err:       nil,
+	}
+	actual, err := load(reader, int64(len(input)))
+	if err != nil {
+		return errors.New("expected no error on parse")
+	}
+	if actual != expected {
+		return fmt.Errorf("expected %s actual %s", expected, actual)
+	}
+	return nil
+}
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"ReadError", errorOnRead},
+		{"ParseError", errorOnParse},
+		{"DefaultConfig", defaultConfig},
+		{"ParseFullConfig", parseExampleConfig},
+	}
+
+	for _, test := range tests {
+		if err := test.run(); err != nil {
+			t.Fatalf("%s: %s", test.name, err.Error())
+		}
+	}
+}

--- a/snapshotter/demux/cache/cache.go
+++ b/snapshotter/demux/cache/cache.go
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/snapshots"
+)
+
+// SnapshotterProvider defines a snapshotter fetch function.
+type SnapshotterProvider = func(context.Context, string) (snapshots.Snapshotter, error)
+
+// Cache defines the interface for a snapshotter caching mechanism.
+type Cache interface {
+	// Retrieves the snapshotter from the underlying cache using the provided
+	// fetch function if the snapshotter is not currently cached.
+	Get(ctx context.Context, key string, fetch SnapshotterProvider) (snapshots.Snapshotter, error)
+
+	// Closes the snapshotter and removes it from the cache.
+	Evict(key string) error
+
+	// Releases the cache's internal resources and closes any cached snapshotters.
+	Close() error
+}

--- a/snapshotter/demux/cache/snapshotter_cache.go
+++ b/snapshotter/demux/cache/snapshotter_cache.go
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/containerd/containerd/snapshots"
+	"github.com/hashicorp/go-multierror"
+)
+
+// SnapshotterCache implements a read, write protected cache mechanism
+// for keyed snapshotters.
+type SnapshotterCache struct {
+	mutex        *sync.Mutex
+	snapshotters map[string]snapshots.Snapshotter
+}
+
+// NewSnapshotterCache creates a new instance with an empty cache.
+func NewSnapshotterCache() *SnapshotterCache {
+	return &SnapshotterCache{&sync.Mutex{}, make(map[string]snapshots.Snapshotter)}
+}
+
+// Get fetches and caches the snapshotter for a given key.
+func (cache *SnapshotterCache) Get(ctx context.Context, key string, fetch SnapshotterProvider) (snapshots.Snapshotter, error) {
+	snapshotter, ok := cache.snapshotters[key]
+
+	if !ok {
+		cache.mutex.Lock()
+		defer cache.mutex.Unlock()
+
+		snapshotter, ok = cache.snapshotters[key]
+		if !ok {
+			newSnapshotter, err := fetch(ctx, key)
+			if err != nil {
+				return nil, err
+			}
+
+			cache.snapshotters[key] = newSnapshotter
+			snapshotter = newSnapshotter
+		}
+	}
+	return snapshotter, nil
+}
+
+// Evict removes a cached snapshotter for a given key.
+func (cache *SnapshotterCache) Evict(key string) error {
+	snapshotter, ok := cache.snapshotters[key]
+
+	if !ok {
+		return fmt.Errorf("snapshotter %s not found in cache", key)
+	}
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	err := snapshotter.Close()
+	delete(cache.snapshotters, key)
+	return err
+}
+
+// Close calls Close on all cached remote snapshotters.
+func (cache *SnapshotterCache) Close() error {
+	var compiledErr error
+	for _, snapshotter := range cache.snapshotters {
+		if err := snapshotter.Close(); err != nil {
+			compiledErr = multierror.Append(compiledErr, err)
+		}
+	}
+	return compiledErr
+}

--- a/snapshotter/demux/cache/snapshotter_cache_test.go
+++ b/snapshotter/demux/cache/snapshotter_cache_test.go
@@ -1,0 +1,191 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/snapshots"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/internal"
+)
+
+func getSnapshotterOkFunction(ctx context.Context, key string) (snapshots.Snapshotter, error) {
+	return &internal.SuccessfulSnapshotter{}, nil
+}
+
+func getSnapshotterErrorFunction(ctx context.Context, key string) (snapshots.Snapshotter, error) {
+	return &internal.SuccessfulSnapshotter{}, errors.New("MOCK ERROR")
+}
+
+func getFailingSnapshotterOkFunction(ctx context.Context, key string) (snapshots.Snapshotter, error) {
+	return &internal.FailingSnapshotter{}, nil
+}
+
+func getSnapshotterFromEmptyCache(uut *SnapshotterCache) error {
+	_, err := uut.Get(context.Background(), "SnapshotterKey", getSnapshotterOkFunction)
+	if err != nil {
+		return errors.Wrap(err, "Fetch from empty cache incorrectly resulted in error")
+	}
+	return nil
+}
+
+func getCachedSnapshotter(uut *SnapshotterCache) error {
+	if _, err := uut.Get(context.Background(), "SnapshotterKey", getSnapshotterOkFunction); err != nil {
+		return errors.Wrap(err, "Adding snapshotter to empty cache incorrectly resulted in error")
+	}
+
+	if _, err := uut.Get(context.Background(), "SnapshotterKey", getSnapshotterOkFunction); err != nil {
+		return errors.Wrap(err, "Fetching cached snapshotter resulted in error")
+	}
+	return nil
+}
+
+func getSnapshotterPropogatesErrors(uut *SnapshotterCache) error {
+	if _, err := uut.Get(context.Background(), "SnapshotterKey", getSnapshotterErrorFunction); err == nil {
+		return errors.New("Get function did not propagate errors from snapshotter generator function")
+	}
+	return nil
+}
+
+func evictSnapshotterFromEmptyCache(uut *SnapshotterCache) error {
+	if err := uut.Evict("SnapshotterKey"); err == nil {
+		return errors.New("Evict function did not return error on call on empty cache")
+	}
+	return nil
+}
+
+func evictSnapshotterFromCache(uut *SnapshotterCache) error {
+	if _, err := uut.Get(context.Background(), "SnapshotterKey", getSnapshotterOkFunction); err != nil {
+		return errors.Wrap(err, "Adding snapshotter to empty cache incorrectly resulted in error")
+	}
+
+	if err := uut.Evict("SnapshotterKey"); err != nil {
+		return errors.Wrap(err, "Evicting snapshotter incorrectly resulted in error")
+	}
+	return nil
+}
+
+func evictSnapshotterFromCachePropogatesCloseError(uut *SnapshotterCache) error {
+	if _, err := uut.Get(context.Background(), "SnapshotterKey", getFailingSnapshotterOkFunction); err != nil {
+		return errors.Wrap(err, "Adding snapshotter to empty cache incorrectly resulted in error")
+	}
+
+	if err := uut.Evict("SnapshotterKey"); err == nil {
+		return errors.Wrap(err, "Evicting snapshotter did not propagate closure error")
+	}
+	return nil
+}
+
+func closeCacheWithEmptyCache(uut *SnapshotterCache) error {
+	if err := uut.Close(); err != nil {
+		return errors.Wrap(err, "Close on empty cache resulted in error")
+	}
+	return nil
+}
+
+func closeCacheWithNonEmptyCache(uut *SnapshotterCache) error {
+	uut.Get(context.Background(), "SnapshotterKey", getSnapshotterOkFunction)
+
+	if err := uut.Close(); err != nil {
+		return errors.Wrap(err, "Close on non empty cache resulted in error")
+	}
+	return nil
+}
+
+func closeCacheReturnsAllOccurringErrors(uut *SnapshotterCache) error {
+	uut.Get(context.Background(), "OkSnapshotterKey", getSnapshotterOkFunction)
+	uut.Get(context.Background(), "FailingSnapshotterKey", getFailingSnapshotterOkFunction)
+	uut.Get(context.Background(), "AnotherFailingSnapshotterKey", getFailingSnapshotterOkFunction)
+
+	err := uut.Close()
+	if err == nil {
+		return errors.New("Close did not propagate the last close snapshotter error")
+	}
+	if merr, ok := err.(*multierror.Error); ok {
+		if merr.Len() != 2 {
+			return errors.Errorf("Expected 2 errors; actual %d", merr.Len())
+		}
+	}
+	return nil
+}
+
+func TestGetSnapshotterFromCache(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(*SnapshotterCache) error
+	}{
+		{"AddSnapshotterToCache", getSnapshotterFromEmptyCache},
+		{"GetCachedSnapshotter", getCachedSnapshotter},
+		{"PropogateFetchSnapshotterErrors", getSnapshotterPropogatesErrors},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			uut := NewSnapshotterCache()
+			if err := test.run(uut); err != nil {
+				t.Fatal(test.name + ": " + err.Error())
+			}
+		})
+	}
+}
+
+func TestEvictSnapshotterFromCache(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(*SnapshotterCache) error
+	}{
+		{"EvictSnapshotterFromEmptyCache", evictSnapshotterFromEmptyCache},
+		{"EvictSnapshotterFromCache", evictSnapshotterFromCache},
+		{"PropogateEvictSnapshotterCloseErrors", evictSnapshotterFromCachePropogatesCloseError},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			uut := NewSnapshotterCache()
+			if err := test.run(uut); err != nil {
+				t.Fatal(test.name + ": " + err.Error())
+			}
+		})
+	}
+}
+
+func TestCloseCache(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(*SnapshotterCache) error
+	}{
+		{"CloseCacheWithEmptyCache", closeCacheWithEmptyCache},
+		{"CloseCacheWithNonEmptyCache", closeCacheWithNonEmptyCache},
+		{"CloseCacheReturnsAllOccurringErrors", closeCacheReturnsAllOccurringErrors},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			uut := NewSnapshotterCache()
+			if err := test.run(uut); err != nil {
+				t.Fatal(test.name + ": " + err.Error())
+			}
+		})
+	}
+}

--- a/snapshotter/demux/internal/failing_snapshotter.go
+++ b/snapshotter/demux/internal/failing_snapshotter.go
@@ -1,0 +1,76 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+)
+
+// FailingSnapshotter mocks containerd snapshots.Snapshotter interface
+// return non-nil errors on calls.
+type FailingSnapshotter struct{}
+
+// Stat mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) Stat(ctx context.Context, key string) (snapshots.Info, error) {
+	return snapshots.Info{}, errors.New("mock Stat error from remote snapshotter")
+}
+
+// Update mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	return snapshots.Info{}, errors.New("mock Update error from remote snapshotter")
+}
+
+// Usage mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
+	return snapshots.Usage{}, errors.New("mock Usage error from remote snapshotter")
+}
+
+// Mounts mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	return []mount.Mount{}, errors.New("mock Mounts error from remote snapshotter")
+}
+
+// Prepare mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) Prepare(ctx context.Context, key string, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return []mount.Mount{}, errors.New("mock Prepare error from remote snapshotter")
+}
+
+// View mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) View(ctx context.Context, key string, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return []mount.Mount{}, errors.New("mock View error from remote snapshotter")
+}
+
+// Commit mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) Commit(ctx context.Context, name string, key string, opts ...snapshots.Opt) error {
+	return errors.New("mock Commit error from remote snapshotter")
+}
+
+// Remove mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) Remove(ctx context.Context, key string) error {
+	return errors.New("mock Remove error from remote snapshotter")
+}
+
+// Walk mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error {
+	return errors.New("mock Walk error from remote snapshotter")
+}
+
+// Close mocks a failing remote call with a non-nil error.
+func (s *FailingSnapshotter) Close() error {
+	return errors.New("mock Close error from remote snapshotter")
+}

--- a/snapshotter/demux/internal/successful_snapshotter.go
+++ b/snapshotter/demux/internal/successful_snapshotter.go
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package internal
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+)
+
+// SuccessfulSnapshotter mocks containerd snapshots.Snapshotter interface
+// returning nil errors on calls.
+type SuccessfulSnapshotter struct{}
+
+// Stat mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) Stat(ctx context.Context, key string) (snapshots.Info, error) {
+	return snapshots.Info{}, nil
+}
+
+// Update mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	return snapshots.Info{}, nil
+}
+
+// Usage mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
+	return snapshots.Usage{}, nil
+}
+
+// Mounts mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	return []mount.Mount{}, nil
+}
+
+// Prepare mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) Prepare(ctx context.Context, key string, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return []mount.Mount{}, nil
+}
+
+// View mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) View(ctx context.Context, key string, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return []mount.Mount{}, nil
+}
+
+// Commit mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) Commit(ctx context.Context, name string, key string, opts ...snapshots.Opt) error {
+	return nil
+}
+
+// Remove mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) Remove(ctx context.Context, key string) error {
+	return nil
+}
+
+// Walk mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error {
+	return nil
+}
+
+// Close mocks a successful remote call with a nil error.
+func (s *SuccessfulSnapshotter) Close() error {
+	return nil
+}

--- a/snapshotter/demux/proxy/address/http_resolver.go
+++ b/snapshotter/demux/proxy/address/http_resolver.go
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package address
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// HTTPClient defines the interface for the client used
+// for HTTP communications in the resolver.
+type HTTPClient interface {
+	Get(string) (*http.Response, error)
+}
+
+// ResponseReader defines the reading function interface.
+type ResponseReader func(io.Reader) ([]byte, error)
+
+// HTTPResolver implements a proxy address resolver via HTTP.
+type HTTPResolver struct {
+	url    string
+	client HTTPClient
+}
+
+// NewHTTPResolver creates a new instance of HttpResolver with specified the URL.
+func NewHTTPResolver(url string) HTTPResolver {
+	return HTTPResolver{url: url, client: http.DefaultClient}
+}
+
+func requestURL(url string, namespace string) string {
+	return fmt.Sprintf("%s/address?namespace=%s", url, namespace)
+}
+
+// Get queries the proxy network type and address for the specified namespace.
+func (h HTTPResolver) Get(namespace string) (Response, error) {
+	httpResponse, err := h.client.Get(requestURL(h.url, namespace))
+	if err != nil {
+		return Response{}, err
+	}
+	defer httpResponse.Body.Close()
+
+	body, err := ioutil.ReadAll(httpResponse.Body)
+	if err != nil {
+		return Response{}, err
+	}
+
+	var response Response
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return Response{}, err
+	}
+
+	return response, nil
+}

--- a/snapshotter/demux/proxy/address/http_resolver_test.go
+++ b/snapshotter/demux/proxy/address/http_resolver_test.go
@@ -1,0 +1,142 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package address
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func returnErrorOnHTTPClientError() error {
+	client := mockClient{}
+	client.getError = errors.New("error on HTTP GET")
+	uut := HTTPResolver{url: "localhost:10001", client: &client}
+
+	if _, err := uut.Get("namespace"); err == nil {
+		return errors.New("expected error on HTTP client GET")
+	}
+
+	return nil
+}
+
+func returnErrorOnResponseReadError() error {
+	reader := mockReader{response: nil, err: errors.New("mock error on read")}
+	client := mockClient{getError: nil, getResponse: http.Response{Body: &reader}}
+	uut := HTTPResolver{url: "localhost:10001", client: &client}
+
+	if _, err := uut.Get("namespace"); err == nil {
+		return errors.New("expected error on body read")
+	}
+
+	return nil
+}
+
+func returnErrorOnJSONParserError() error {
+	reader := mockReader{response: []byte(`{"network": "unix"`), err: io.EOF}
+	client := mockClient{getError: nil, getResponse: http.Response{Body: &reader}}
+	uut := HTTPResolver{url: "localhost:10001", client: &client}
+
+	if _, err := uut.Get("namespace"); err == nil {
+		return errors.New("expected error on JSON parsing")
+	}
+
+	return nil
+}
+
+func happyPath() error {
+	reader := mockReader{response: []byte(`{"network": "unix", "address": "/path/to/snapshotter.vsock"}`), err: io.EOF}
+	client := mockClient{getError: nil, getResponse: http.Response{Body: &reader}}
+	uut := HTTPResolver{url: "localhost:10001", client: &client}
+
+	actual, err := uut.Get("namespace")
+	if err != nil {
+		return errors.New("expected no error from HTTP resolver")
+	}
+
+	if actual.Network != "unix" {
+		return fmt.Errorf("Expected network 'unix' but actual %s", actual.Address)
+	}
+	if actual.Address != "/path/to/snapshotter.vsock" {
+		return fmt.Errorf("Expected address '/path/to/snapshotter.vsock' but actual %s", actual.Address)
+	}
+	return nil
+}
+
+func TestHttpResolverGet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"HttpClientError", returnErrorOnHTTPClientError},
+		{"ResponseReaderError", returnErrorOnResponseReadError},
+		{"JsonParserError", returnErrorOnJSONParserError},
+		{"HappyPath", happyPath},
+	}
+
+	for _, test := range tests {
+		if err := test.run(); err != nil {
+			t.Fatalf(test.name+" test failed: %s", err)
+		}
+	}
+}
+
+func TestRequestUrlFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		url       string
+		namespace string
+		expected  string
+	}{
+		{"NS-1", "http://127.0.0.1:10001", "ns-1", "http://127.0.0.1:10001/address?namespace=ns-1"},
+		{"NS-2", "http://localhost:10001", "ns-2", "http://localhost:10001/address?namespace=ns-2"},
+	}
+
+	for _, test := range tests {
+		if actual := requestURL(test.url, test.namespace); actual != test.expected {
+			t.Fatalf("%s failed: expected %s actual %s", test.name, test.expected, actual)
+		}
+	}
+}
+
+type mockClient struct {
+	getResponse http.Response
+	getError    error
+}
+
+func (c *mockClient) Get(url string) (*http.Response, error) {
+	if c.getError != nil {
+		return nil, c.getError
+	}
+	return &c.getResponse, nil
+}
+
+type mockReader struct {
+	response []byte
+	err      error
+}
+
+func (r *mockReader) Read(p []byte) (int, error) {
+	return copy(p, r.response), r.err
+}
+
+func (r *mockReader) Close() error {
+	return nil
+}

--- a/snapshotter/demux/proxy/address/resolver.go
+++ b/snapshotter/demux/proxy/address/resolver.go
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package address
+
+// Response to the proxy network address resolver.
+type Response struct {
+	// Network type used in net.Dial.
+	//
+	// Reference: https://pkg.go.dev/net#Dial
+	Network string `json:"network"`
+
+	// Network address used in net.Dial.
+	// Assumes the host port forms documented in net.SplitHostPort.
+	//
+	// Reference: https://pkg.go.dev/net#SplitHostPort
+	Address string `json:"address"`
+}
+
+// Resolver for the proxy network address.
+type Resolver interface {
+	// Fetch the network address used to forward snapshotter
+	// requests by namespace lookup from a remote service call.
+	Get(namespace string) (Response, error)
+}

--- a/snapshotter/demux/proxy/snapshotter.go
+++ b/snapshotter/demux/proxy/snapshotter.go
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"net"
+
+	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/proxy"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// SnapshotterDialer defines an interface for establishing a network connection.
+type SnapshotterDialer = func(context.Context, *logrus.Entry, string, uint32)
+
+// NewProxySnapshotter creates a proxy snapshotter using gRPC over vsock connection.
+func NewProxySnapshotter(ctx context.Context, address string, dialer func(context.Context, string) (net.Conn, error)) (snapshots.Snapshotter, error) {
+	opts := []grpc.DialOption{
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	}
+	gRPCConn, err := grpc.DialContext(ctx, address, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return proxy.NewSnapshotter(snapshotsapi.NewSnapshotsClient(gRPCConn), address), nil
+}

--- a/snapshotter/demux/snapshotter.go
+++ b/snapshotter/demux/snapshotter.go
@@ -1,0 +1,290 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package demux
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/sirupsen/logrus"
+
+	"github.com/firecracker-microvm/firecracker-containerd/internal/vm"
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/cache"
+	mountutil "github.com/firecracker-microvm/firecracker-containerd/snapshotter/internal/mount"
+)
+
+const proxiedFunctionCallErrorString = "Proxied function call failed"
+
+// Snapshotter routes snapshotter requests to their destined
+// remote snapshotter via their snapshotter namespace.
+//
+// Proxy snapshotters are cached for subsequent snapshotter requests.
+type Snapshotter struct {
+	cache            cache.Cache
+	fetchSnapshotter cache.SnapshotterProvider
+}
+
+// NewSnapshotter creates instance of Snapshotter with cache and
+// proxy snapshotter creation function.
+func NewSnapshotter(cache cache.Cache, fetchSnapshotter cache.SnapshotterProvider) snapshots.Snapshotter {
+	return &Snapshotter{cache, fetchSnapshotter}
+}
+
+// Stat proxies remote snapshotter stat request.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) Stat(ctx context.Context, key string) (snapshots.Info, error) {
+	contextLogger := log.G(ctx).WithField("function", "Stat")
+	namespace, err := getNamespaceFromContext(ctx, contextLogger)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+	logger := contextLogger.WithField("namespace", namespace)
+
+	snapshotter, err := s.getSnapshotterFromCache(ctx, namespace, logger)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	info, err := snapshotter.Stat(ctx, key)
+	if err != nil {
+		contextLogger.WithError(err).Error(proxiedFunctionCallErrorString)
+		return snapshots.Info{}, err
+	}
+	return info, nil
+}
+
+// Update proxies remote snapshotter update request.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	contextLogger := log.G(ctx).WithField("function", "Update")
+	namespace, err := getNamespaceFromContext(ctx, contextLogger)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+	logger := contextLogger.WithField("namespace", namespace)
+
+	snapshotter, err := s.getSnapshotterFromCache(ctx, namespace, logger)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	updatedInfo, err := snapshotter.Update(ctx, info, fieldpaths...)
+	if err != nil {
+		contextLogger.WithError(err).Error(proxiedFunctionCallErrorString)
+		return snapshots.Info{}, err
+	}
+	return updatedInfo, nil
+}
+
+// Usage proxies remote snapshotter usage request.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
+	contextLogger := log.G(ctx).WithField("function", "Usage")
+	namespace, err := getNamespaceFromContext(ctx, contextLogger)
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+	logger := contextLogger.WithField("namespace", namespace)
+
+	snapshotter, err := s.getSnapshotterFromCache(ctx, namespace, logger)
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+
+	usage, err := snapshotter.Usage(ctx, key)
+	if err != nil {
+		contextLogger.WithError(err).Error(proxiedFunctionCallErrorString)
+		return snapshots.Usage{}, err
+	}
+	return usage, nil
+}
+
+// Mounts proxies remote snapshotter mounts request.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	contextLogger := log.G(ctx).WithField("function", "Mounts")
+	namespace, err := getNamespaceFromContext(ctx, contextLogger)
+	if err != nil {
+		return []mount.Mount{}, err
+	}
+	logger := contextLogger.WithField("namespace", namespace)
+
+	snapshotter, err := s.getSnapshotterFromCache(ctx, namespace, logger)
+	if err != nil {
+		return []mount.Mount{}, err
+	}
+
+	mounts, err := snapshotter.Mounts(ctx, key)
+	if err != nil {
+		contextLogger.WithError(err).Error(proxiedFunctionCallErrorString)
+		return []mount.Mount{}, err
+	}
+	return mountutil.Map(mounts, vm.AddLocalMountIdentifier), nil
+}
+
+// Prepare proxies remote snapshotter prepare request.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) Prepare(ctx context.Context, key string, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	contextLogger := log.G(ctx).WithField("function", "Prepare")
+	namespace, err := getNamespaceFromContext(ctx, contextLogger)
+	if err != nil {
+		return []mount.Mount{}, err
+	}
+	logger := contextLogger.WithField("namespace", namespace)
+
+	snapshotter, err := s.getSnapshotterFromCache(ctx, namespace, logger)
+	if err != nil {
+		return []mount.Mount{}, err
+	}
+
+	mounts, err := snapshotter.Prepare(ctx, key, parent, opts...)
+	if err != nil {
+		contextLogger.WithError(err).Error(proxiedFunctionCallErrorString)
+		return []mount.Mount{}, err
+	}
+	return mountutil.Map(mounts, vm.AddLocalMountIdentifier), nil
+}
+
+// View proxies remote snapshotter view request.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) View(ctx context.Context, key string, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	contextLogger := log.G(ctx).WithField("function", "View")
+	namespace, err := getNamespaceFromContext(ctx, contextLogger)
+	if err != nil {
+		return []mount.Mount{}, err
+	}
+	logger := contextLogger.WithField("namespace", namespace)
+
+	snapshotter, err := s.getSnapshotterFromCache(ctx, namespace, logger)
+	if err != nil {
+		return []mount.Mount{}, err
+	}
+
+	mounts, err := snapshotter.View(ctx, key, parent, opts...)
+	if err != nil {
+		contextLogger.WithError(err).Error(proxiedFunctionCallErrorString)
+		return []mount.Mount{}, err
+	}
+	return mountutil.Map(mounts, vm.AddLocalMountIdentifier), nil
+}
+
+// Commit proxies remote snapshotter commit request.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) Commit(ctx context.Context, name string, key string, opts ...snapshots.Opt) error {
+	contextLogger := log.G(ctx).WithField("function", "Commit")
+	namespace, err := getNamespaceFromContext(ctx, contextLogger)
+	if err != nil {
+		return err
+	}
+	logger := contextLogger.WithField("namespace", namespace)
+
+	snapshotter, err := s.getSnapshotterFromCache(ctx, namespace, logger)
+	if err != nil {
+		return err
+	}
+
+	err = snapshotter.Commit(ctx, name, key, opts...)
+	if err != nil {
+		contextLogger.WithError(err).Error(proxiedFunctionCallErrorString)
+		return err
+	}
+	return nil
+}
+
+// Remove proxies remote snapshotter remove request.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) Remove(ctx context.Context, key string) error {
+	contextLogger := log.G(ctx).WithField("function", "Remove")
+	namespace, err := getNamespaceFromContext(ctx, contextLogger)
+	if err != nil {
+		return err
+	}
+	logger := contextLogger.WithField("namespace", namespace)
+
+	snapshotter, err := s.getSnapshotterFromCache(ctx, namespace, logger)
+	if err != nil {
+		return err
+	}
+
+	err = snapshotter.Remove(ctx, key)
+	if err != nil {
+		contextLogger.WithError(err).Error(proxiedFunctionCallErrorString)
+		return err
+	}
+	return nil
+}
+
+// Walk proxies remote snapshotter walk request.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error {
+	contextLogger := log.G(ctx).WithField("function", "Walk")
+	namespace, err := getNamespaceFromContext(ctx, contextLogger)
+	if err != nil {
+		return err
+	}
+	logger := contextLogger.WithField("namespace", namespace)
+
+	snapshotter, err := s.getSnapshotterFromCache(ctx, namespace, logger)
+	if err != nil {
+		return err
+	}
+
+	err = snapshotter.Walk(ctx, fn, filters...)
+	if err != nil {
+		contextLogger.WithError(err).Error(proxiedFunctionCallErrorString)
+		return err
+	}
+	return nil
+}
+
+// Close calls close on all cached remote snapshotters.
+//
+// See https://github.com/containerd/containerd/blob/main/snapshots/snapshotter.go
+func (s *Snapshotter) Close() error {
+	return s.cache.Close()
+}
+
+const snapshotterNotFoundErrorString = "Snapshotter not found in cache"
+
+func (s *Snapshotter) getSnapshotterFromCache(ctx context.Context, namespace string, log *logrus.Entry) (snapshots.Snapshotter, error) {
+	snapshotter, err := s.cache.Get(ctx, namespace, s.fetchSnapshotter)
+	if err != nil {
+		log.WithError(err).Error(snapshotterNotFoundErrorString)
+		return nil, err
+	}
+	return snapshotter, nil
+}
+
+const missingNamespaceErrorString = "Function called without namespaced context"
+
+func getNamespaceFromContext(ctx context.Context, log *logrus.Entry) (string, error) {
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		log.WithError(err).Error(missingNamespaceErrorString)
+		return "", err
+	}
+	return namespace, nil
+}

--- a/snapshotter/demux/snapshotter_test.go
+++ b/snapshotter/demux/snapshotter_test.go
@@ -1,0 +1,197 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package demux
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/containerd/containerd/log/logtest"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshots"
+
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/cache"
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/internal"
+)
+
+func fetchOkSnapshotter(ctx context.Context, key string) (snapshots.Snapshotter, error) {
+	var snapshotter internal.SuccessfulSnapshotter = internal.SuccessfulSnapshotter{}
+	return &snapshotter, nil
+}
+
+func fetchSnapshotterNotFound(ctx context.Context, key string) (snapshots.Snapshotter, error) {
+	return nil, errors.New("mock snapshotter not found")
+}
+
+func createSnapshotterCacheWithSuccessfulSnapshotter(namespace string) cache.Cache {
+	cache := cache.NewSnapshotterCache()
+	cache.Get(context.Background(), namespace, fetchOkSnapshotter)
+	return cache
+}
+
+func fetchFailingSnapshotter(ctx context.Context, key string) (snapshots.Snapshotter, error) {
+	var snapshotter internal.FailingSnapshotter = internal.FailingSnapshotter{}
+	return &snapshotter, nil
+}
+
+func createSnapshotterCacheWithFailingSnapshotter(namespace string) cache.Cache {
+	cache := cache.NewSnapshotterCache()
+	cache.Get(context.Background(), namespace, fetchFailingSnapshotter)
+	return cache
+}
+
+func TestReturnErrorWhenCalledWithoutNamespacedContext(t *testing.T) {
+	t.Parallel()
+
+	cache := cache.NewSnapshotterCache()
+	ctx := logtest.WithT(context.Background(), t)
+
+	uut := NewSnapshotter(cache, fetchOkSnapshotter)
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"Stat", func() error { _, err := uut.Stat(ctx, "layerKey"); return err }},
+		{"Update", func() error { _, err := uut.Update(ctx, snapshots.Info{}); return err }},
+		{"Usage", func() error { _, err := uut.Usage(ctx, "layerKey"); return err }},
+		{"Mounts", func() error { _, err := uut.Mounts(ctx, "layerKey"); return err }},
+		{"Prepare", func() error { _, err := uut.Prepare(ctx, "layerKey", ""); return err }},
+		{"View", func() error { _, err := uut.View(ctx, "layerKey", ""); return err }},
+		{"Commit", func() error { return uut.Commit(ctx, "layer1", "layerKey") }},
+		{"Remove", func() error { return uut.Remove(ctx, "layerKey") }},
+		{"Walk", func() error {
+			var callback = func(c context.Context, i snapshots.Info) error { return nil }
+			return uut.Walk(ctx, callback)
+		}},
+	}
+
+	for _, test := range tests {
+		if err := test.run(); err == nil {
+			t.Fatal(test.name + " call did not return error")
+		}
+	}
+}
+
+func TestReturnErrorWhenSnapshotterNotFound(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "testing"
+	cache := cache.NewSnapshotterCache()
+	ctx := namespaces.WithNamespace(context.TODO(), namespace)
+	ctx = logtest.WithT(ctx, t)
+
+	uut := NewSnapshotter(cache, fetchSnapshotterNotFound)
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"Stat", func() error { _, err := uut.Stat(ctx, "layerKey"); return err }},
+		{"Update", func() error { _, err := uut.Update(ctx, snapshots.Info{}); return err }},
+		{"Usage", func() error { _, err := uut.Usage(ctx, "layerKey"); return err }},
+		{"Mounts", func() error { _, err := uut.Mounts(ctx, "layerKey"); return err }},
+		{"Prepare", func() error { _, err := uut.Prepare(ctx, "layerKey", ""); return err }},
+		{"View", func() error { _, err := uut.View(ctx, "layerKey", ""); return err }},
+		{"Commit", func() error { return uut.Commit(ctx, "layer1", "layerKey") }},
+		{"Remove", func() error { return uut.Remove(ctx, "layerKey") }},
+		{"Walk", func() error {
+			var callback = func(c context.Context, i snapshots.Info) error { return nil }
+			return uut.Walk(ctx, callback)
+		}},
+	}
+
+	for _, test := range tests {
+		if err := test.run(); err == nil {
+			t.Fatal(test.name + " call did not return error")
+		}
+	}
+}
+
+func TestReturnErrorAfterProxyFunctionFailure(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "testing"
+	cache := createSnapshotterCacheWithFailingSnapshotter(namespace)
+	ctx := namespaces.WithNamespace(context.Background(), namespace)
+	ctx = logtest.WithT(ctx, t)
+
+	uut := NewSnapshotter(cache, fetchOkSnapshotter)
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"Stat", func() error { _, err := uut.Stat(ctx, "layerKey"); return err }},
+		{"Update", func() error { _, err := uut.Update(ctx, snapshots.Info{}); return err }},
+		{"Usage", func() error { _, err := uut.Usage(ctx, "layerKey"); return err }},
+		{"Mounts", func() error { _, err := uut.Mounts(ctx, "layerKey"); return err }},
+		{"Prepare", func() error { _, err := uut.Prepare(ctx, "layerKey", ""); return err }},
+		{"View", func() error { _, err := uut.View(ctx, "layerKey", ""); return err }},
+		{"Commit", func() error { return uut.Commit(ctx, "layer1", "layerKey") }},
+		{"Remove", func() error { return uut.Remove(ctx, "layerKey") }},
+		{"Walk", func() error {
+			var callback = func(c context.Context, i snapshots.Info) error { return nil }
+			return uut.Walk(ctx, callback)
+		}},
+		{"Close", func() error { return uut.Close() }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+"ProxyFailure", func(t *testing.T) {
+			if err := test.run(); err == nil {
+				t.Fatal(test.name + " call did not return error")
+			}
+		})
+	}
+}
+
+func TestNoErrorIsReturnedOnSuccessfulProxyExecution(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "testing"
+	cache := createSnapshotterCacheWithSuccessfulSnapshotter(namespace)
+	ctx := namespaces.WithNamespace(context.Background(), namespace)
+	ctx = logtest.WithT(ctx, t)
+
+	uut := NewSnapshotter(cache, fetchOkSnapshotter)
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"Stat", func() error { _, err := uut.Stat(ctx, "layerKey"); return err }},
+		{"Update", func() error { _, err := uut.Update(ctx, snapshots.Info{}); return err }},
+		{"Usage", func() error { _, err := uut.Usage(ctx, "layerKey"); return err }},
+		{"Mounts", func() error { _, err := uut.Mounts(ctx, "layerKey"); return err }},
+		{"Prepare", func() error { _, err := uut.Prepare(ctx, "layerKey", ""); return err }},
+		{"View", func() error { _, err := uut.View(ctx, "layerKey", ""); return err }},
+		{"Commit", func() error { return uut.Commit(ctx, "layer1", "layerKey") }},
+		{"Remove", func() error { return uut.Remove(ctx, "layerKey") }},
+		{"Walk", func() error {
+			var callback = func(c context.Context, i snapshots.Info) error { return nil }
+			return uut.Walk(ctx, callback)
+		}},
+		{"Close", func() error { return uut.Close() }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+"SuccessfulProxyCall", func(t *testing.T) {
+			if err := test.run(); err != nil {
+				t.Fatal(test.name + " call incorrectly returned an error")
+			}
+		})
+	}
+}

--- a/snapshotter/internal/http_address_resolver.go
+++ b/snapshotter/internal/http_address_resolver.go
@@ -1,0 +1,153 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	proxyaddress "github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/proxy/address"
+)
+
+var (
+	port     int
+	filepath string
+	logger   *logrus.Logger
+	store    map[string]networkAddress
+)
+
+type networkAddress struct {
+	Network string `json:"network"`
+	Address string `json:"address"`
+}
+
+func init() {
+	flag.IntVar(&port, "port", 10001, "port to be used in the network address")
+	flag.StringVar(&filepath, "map", "map.json", "filepath to map configuration")
+	logger = logrus.New()
+}
+
+// Simple example of an HTTP service to resolve snapshotter namespace
+// to a forwarding address for the demultiplexing snapshotter.
+//
+// Example:
+// curl -X GET "http://localhost:10001/address?namespace=ns-1"
+//
+// Response:
+// {
+//     "network": "tcp",
+//     "address": "192.168.0.1:80"
+// }
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+		<-c
+		cancel()
+	}()
+
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
+	if err := loadStoreFromFile(filepath); err != nil {
+		logger.WithError(err).Error()
+		os.Exit(1)
+	}
+
+	http.HandleFunc("/address", queryAddress)
+	httpServer := &http.Server{
+		Addr: fmt.Sprintf(":%d", port),
+	}
+
+	logger.Info(fmt.Sprintf("http server serving at port %d", port))
+	g, gCtx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return httpServer.ListenAndServe()
+	})
+	g.Go(func() error {
+		<-gCtx.Done()
+		return httpServer.Shutdown(context.Background())
+	})
+
+	if err := g.Wait(); err != http.ErrServerClosed {
+		logger.WithError(err).Error()
+		os.Exit(1)
+	}
+
+	logger.Info("http: server closed")
+}
+
+func loadStoreFromFile(filepath string) error {
+	store = make(map[string]networkAddress)
+	contextLogger := logger.WithField("filepath", filepath)
+	contextLogger.Info("opening file for read...")
+
+	fileStream, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return err
+	}
+
+	contextLogger.Info("reading JSON from file...")
+	return json.Unmarshal(fileStream, &store)
+}
+
+func queryAddress(writ http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(writ, fmt.Sprintf("%s method not allowed", req.Method), http.StatusForbidden)
+		return
+	}
+
+	writ.Header().Set("Content-Type", "application/json")
+
+	keys, ok := req.URL.Query()["namespace"]
+
+	if !ok {
+		http.Error(writ, "Missing 'namespace' query", http.StatusBadRequest)
+		return
+	}
+
+	namespace := keys[0]
+	networkAddress, ok := store[namespace]
+	if !ok {
+		http.Error(writ, "Socket path not found", http.StatusNotFound)
+		return
+	}
+
+	writ.WriteHeader(http.StatusOK)
+
+	response, err := json.Marshal(proxyaddress.Response{
+		Network: networkAddress.Network,
+		Address: networkAddress.Address,
+	})
+	if err != nil {
+		http.Error(writ, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	writ.Write(response)
+}

--- a/snapshotter/internal/mount/collection.go
+++ b/snapshotter/internal/mount/collection.go
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mount
+
+import "github.com/containerd/containerd/mount"
+
+// Map returns the slice of results after applying the given function
+// to each item of a given slice.
+func Map(mounts []mount.Mount, f func(mount.Mount) mount.Mount) []mount.Mount {
+	fms := make([]mount.Mount, len(mounts))
+	for i, mount := range mounts {
+		fms[i] = f(mount)
+	}
+	return fms
+}

--- a/snapshotter/internal/mount/collection_test.go
+++ b/snapshotter/internal/mount/collection_test.go
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mount
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/containerd/containerd/mount"
+)
+
+func assertEqual(actual, expected []mount.Mount) error {
+	if len(actual) != len(expected) {
+		return fmt.Errorf("expected %s actual %s", expected, actual)
+	}
+	for k, v := range actual {
+		if v.Type != expected[k].Type && v.Source != expected[k].Source {
+			return fmt.Errorf("expected %s actual %s at index %d", expected[k], v, k)
+		}
+	}
+	return nil
+}
+
+func okOnEmptySlice() error {
+	expected := []mount.Mount{}
+	actual := Map([]mount.Mount{}, nil)
+	return assertEqual(actual, expected)
+}
+
+func applyFunctionToSlice() error {
+	pre := []mount.Mount{
+		{Type: "pre-type-1", Source: "pre-source-1"},
+		{Type: "pre-type-2", Source: "pre-source-2"},
+	}
+	transform := func(m mount.Mount) mount.Mount {
+		switch m.Type {
+		case "pre-type-1":
+			return mount.Mount{Type: "post-type-1", Source: "post-source-1"}
+		case "pre-type-2":
+			return mount.Mount{Type: "post-type-2", Source: "post-source-2"}
+		default:
+			return mount.Mount{}
+		}
+	}
+
+	expected := []mount.Mount{
+		{Type: "post-type-1", Source: "post-source-1"},
+		{Type: "post-type-2", Source: "post-source-2"},
+	}
+	actual := Map(pre, transform)
+	return assertEqual(actual, expected)
+}
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"EmptySlice", okOnEmptySlice},
+		{"ApplyFoo", applyFunctionToSlice},
+	}
+
+	for _, test := range tests {
+		if err := test.run(); err != nil {
+			t.Fatalf("%s: %s", test.name, err.Error())
+		}
+	}
+}

--- a/snapshotter/main.go
+++ b/snapshotter/main.go
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/app"
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/config"
+)
+
+func main() {
+	var filepath string
+	flag.StringVar(&filepath, "config", "/etc/demux-snapshotter/config.toml", "Configuration filepath")
+
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
+	config, err := config.Load(filepath)
+	if err != nil {
+		logger := logrus.New().WithField("config", filepath)
+		logger.WithError(err).Error("error reading config")
+		return
+	}
+
+	logLevel, err := logrus.ParseLevel(config.Debug.LogLevel)
+	if err != nil {
+		logLevel = logrus.InfoLevel
+		logrus.New().WithError(err).Warn("Fallback to default log level")
+	}
+	logrus.SetLevel(logLevel)
+
+	if err := app.Run(config); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds a demultiplexing snapshotter application which allows
for proxying remote snapshotter requests across the microVM threshold.

The snapshotter includes a vsock lookup mechanism via namespace
specified via configuration file. Also includes a cache mechanism
for vsock lookup results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
