### PR TITLE
Disable cgroups v2 in our getting started guides

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -247,7 +247,7 @@ configuration file has the following fields:
 {
   "firecracker_binary_path": "/usr/local/bin/firecracker",
   "kernel_image_path": "/var/lib/firecracker-containerd/runtime/hello-vmlinux.bin",
-  "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules ro systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
+  "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules ro systemd.unified_cgroup_hierarchy=0 systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
   "root_drive": "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
   "cpu_template": "T2",
   "log_fifo": "fc-logs.fifo",

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -9,7 +9,7 @@ firecracker-runtime.json file.
 {
   "firecracker_binary_path": "/usr/local/bin/firecracker",
   "kernel_image_path": "/var/lib/firecracker-containerd/runtime/default-vmlinux.bin",
-  "kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
+  "kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.unified_cgroup_hierarchy=0 systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
   "root_drive": "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
   "cpu_template": "T2",
   "log_levels": ["debug"],
@@ -48,7 +48,7 @@ info, error, warning, and debug are mutually exclusive and only one can be set a
 {
   "firecracker_binary_path": "/usr/local/bin/firecracker",
   "kernel_image_path": "/var/lib/firecracker-containerd/runtime/default-vmlinux.bin",
-  "kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
+  "kernel_args": "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.unified_cgroup_hierarchy=0 systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
   "root_drive": "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
   "cpu_template": "T2",
   "log:levels": ["info","firecracker:debug","firecracker-containerd:error"],

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -214,7 +214,7 @@ sudo tee /etc/containerd/firecracker-runtime.json <<EOF
   "log_fifo": "fc-logs.fifo",
   "log_levels": ["debug"],
   "metrics_fifo": "fc-metrics.fifo",
-  "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules ro systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
+  "kernel_args": "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules ro systemd.unified_cgroup_hierarchy=0 systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init",
   "default_network_interfaces": [{
     "CNIConfig": {
       "NetworkName": "fcnet",


### PR DESCRIPTION
Our getting started guides recommend a pre-built kernel at version 4.14.
Cgroups v2 require kernel 4.15 and our image builder scripts now use
Debian 11 which enabled cgroups v2 by default.

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
