### PR TITLE
refactor: internal HTTP address resolver

### DIFF
--- a/snapshotter/.gitignore
+++ b/snapshotter/.gitignore
@@ -1,2 +1,2 @@
 demux-snapshotter
-http-resolver
+http-address-resolver

--- a/snapshotter/Makefile
+++ b/snapshotter/Makefile
@@ -24,7 +24,7 @@ all: demux-snapshotter
 demux-snapshotter: $(SOURCES) $(GOMOD) $(GOSUM)
 	go build $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)" -o $@
 
-http-resolver: $(SOURCES) $(GOMOD) $(GOSUM)
+http-address-resolver: $(SOURCES) $(GOMOD) $(GOSUM)
 	go build $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)" -o $@ internal/http_address_resolver.go
 
 test:


### PR DESCRIPTION
Requires #594 

*Issue #, if available:*

*Description of changes:*
Change the internal mechanics to query firecracker-containerd
instead of using the requests namespace as the VM ID.

This internal mechanism will be used for integration testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
