### PR TITLE
Makefile: replace the 'arch' command with 'uname -m'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ export FIRECRACKER_CONTAINERD_TEST_IMAGE?=localhost/firecracker-containerd-test
 export GO_CACHE_VOLUME_NAME?=gocache
 
 # This Makefile uses Firecracker's pre-build Linux kernels for x86_64 and aarch64.
-host_arch=$(shell arch)
+host_arch=$(shell uname -m)
 ifeq ($(host_arch),x86_64)
 	kernel_sha256sum="ea5e7d5cf494a8c4ba043259812fc018b44880d70bcbbfc4d57d2760631b1cd6"
 else ifeq ($(host_arch),aarch64)


### PR DESCRIPTION
*Description of changes:*

**tl;dr**
I'm using Arch linux and ironically can't build this because
I don't have the "arch" command. I dug a bit and found it's a
wrapper to 'uname -m' so I just replaced it.

**Longer version**
`arch` is a wrapper for `uname -m` in GNU coreutils [0]
However, unlikely the `uname` command, the `arch` command
is not as available.

It also looks like the arch command is being carried on in
UNIX history as a mechanism for retrocompatibility, here's a
manpace for solaris [1] saying:

> This command is provided for compatibility with previous releases and its use is discouraged. Instead, the uname command is recommended. See uname(1) for usage information.


[0] https://github.com/coreutils/coreutils/blob/00ea4bacf6063ccc125209d5186f8f2382c6f0d4/src/coreutils-arch.c
[1] https://docs.oracle.com/cd/E88353_01/html/E37839/arch-1.html

Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>

*Issue #, if available:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
