### PR TITLE
Add List interface to snapshotter cache

### DIFF
--- a/snapshotter/demux/cache/cache.go
+++ b/snapshotter/demux/cache/cache.go
@@ -33,4 +33,7 @@ type Cache interface {
 
 	// Releases the cache's internal resources and closes any cached snapshotters.
 	Close() error
+
+	// Lists keys present in the cache.
+	List() []string
 }


### PR DESCRIPTION
*Description of changes:*

Add a List interface to Cache and implement it for SnapshotterCache. The
List interface returns keys existing in a cache.

These changes also modify the SnapshotterCache to use a RWMutex rather
than a vanilla Mutex https://pkg.go.dev/sync#RWMutex . This way any
number of readers can read from cache, but only one writer may acquire
the lock at a time.

Signed-off-by: Gavin Inglis <giinglis@amazon.com>

*Issue #, if available:*



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
