### PR TITLE
Update HTTP resolver to return metrics port

### DIFF
--- a/snapshotter/config/config.go
+++ b/snapshotter/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 type snapshotter struct {
 	Listener listener `toml:"listener"`
 	Proxy    proxy    `toml:"proxy"`
+	Metrics  metrics  `toml:"metrics"`
 }
 
 type listener struct {
@@ -55,6 +56,10 @@ type resolver struct {
 
 type debug struct {
 	LogLevel string `toml:"logLevel" default:"info"`
+}
+
+type metrics struct {
+	Enable bool `toml:"enable" default:"false"`
 }
 
 // Load parses application configuration from a specified file path.

--- a/snapshotter/config/config.toml.example
+++ b/snapshotter/config/config.toml.example
@@ -6,5 +6,8 @@
   type = "http"
   address = "127.0.0.1:10001"
 
+[snapshotter.metrics]
+  enable = true
+
 [debug]
   logLevel = "info"

--- a/snapshotter/config/config_test.go
+++ b/snapshotter/config/config_test.go
@@ -62,6 +62,9 @@ func defaultConfig() error {
 				Network: "unix",
 				Address: "/var/lib/demux-snapshotter/snapshotter.sock",
 			},
+			Metrics: metrics{
+				Enable: false,
+			},
 		},
 		Debug: debug{
 			LogLevel: "info",
@@ -79,6 +82,8 @@ func parseExampleConfig() error {
 	  [snapshotter.proxy.address.resolver]
 	    type = "http"
 	    address = "localhost:10001"
+	  [snapshotter.metrics]
+        enable = true
 
 	[debug]
 	  logLevel = "debug"
@@ -96,6 +101,9 @@ func parseExampleConfig() error {
 						Address: "localhost:10001",
 					},
 				},
+			},
+			Metrics: metrics{
+				Enable: true,
 			},
 		},
 		Debug: debug{
@@ -116,7 +124,7 @@ func parseConfig(input []byte, expected Config) error {
 		return errors.New("expected no error on parse")
 	}
 	if actual != expected {
-		return fmt.Errorf("expected %s actual %s", expected, actual)
+		return fmt.Errorf("expected %v actual %v", expected, actual)
 	}
 	return nil
 }

--- a/snapshotter/demux/proxy/address/http_resolver_test.go
+++ b/snapshotter/demux/proxy/address/http_resolver_test.go
@@ -58,7 +58,7 @@ func returnErrorOnJSONParserError() error {
 }
 
 func happyPath() error {
-	reader := mockReader{response: []byte(`{"network": "unix", "address": "/path/to/snapshotter.vsock"}`), err: io.EOF}
+	reader := mockReader{response: []byte(`{"network": "unix", "address": "/path/to/snapshotter.vsock", "snapshotter_port": "10000", "metrics_port": "10001"}`), err: io.EOF}
 	client := mockClient{getError: nil, getResponse: http.Response{Body: &reader}}
 	uut := HTTPResolver{url: "localhost:10001", client: &client}
 
@@ -72,6 +72,12 @@ func happyPath() error {
 	}
 	if actual.Address != "/path/to/snapshotter.vsock" {
 		return fmt.Errorf("Expected address '/path/to/snapshotter.vsock' but actual %s", actual.Address)
+	}
+	if actual.SnapshotterPort != "10000" {
+		return fmt.Errorf("Expected metrics port '10000' but actual %s", actual.MetricsPort)
+	}
+	if actual.MetricsPort != "10001" {
+		return fmt.Errorf("Expected metrics port '10001' but actual %s", actual.MetricsPort)
 	}
 	return nil
 }

--- a/snapshotter/demux/proxy/address/resolver.go
+++ b/snapshotter/demux/proxy/address/resolver.go
@@ -21,10 +21,13 @@ type Response struct {
 	Network string `json:"network"`
 
 	// Network address used in net.Dial.
-	// Assumes the host port forms documented in net.SplitHostPort.
-	//
-	// Reference: https://pkg.go.dev/net#SplitHostPort
 	Address string `json:"address"`
+
+	// SnapshotterPort is the port used in vsock.DialContext for sending snapshotter API requests to the remote snapshotter.
+	SnapshotterPort string `json:"snapshotter_port"`
+
+	// MetricsPort is the port used in vsock.DialContext for sending metrics requests to the remote snapshotter.
+	MetricsPort string `json:"metrics_port"`
 }
 
 // Resolver for the proxy network address.


### PR DESCRIPTION
Signed-off-by: Gavin Inglis <giinglis@amazon.com>

*Issue #, if available:*

#602 task 1

*Description of changes:*

These changes update the Response of the HTTP resolver to include the
port for pulling metrics from a remote snapshotter. They also include initial update to configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
