### PR TITLE
Make fcnet targets depend on source file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,12 +294,12 @@ install-test-cni-bins: test-cni-bins $(CNI_BIN_ROOT)
 	install -D -o root -g root -m755 -t $(CNI_BIN_ROOT) $(TEST_BRIDGED_TAP_BIN)
 
 FCNET_CONFIG?=/etc/cni/conf.d/fcnet.conflist
-$(FCNET_CONFIG):
+$(FCNET_CONFIG): tools/demo/fcnet.conflist
 	mkdir -p $(dir $(FCNET_CONFIG))
 	install -o root -g root -m644 tools/demo/fcnet.conflist $(FCNET_CONFIG)
 
 FCNET_BRIDGE_CONFIG?=/etc/network/interfaces.d/fc-br0
-$(FCNET_BRIDGE_CONFIG):
+$(FCNET_BRIDGE_CONFIG): tools/demo/fc-br0.interface
 	mkdir -p $(dir $(FCNET_BRIDGE_CONFIG))
 	install -o root -g root -m644 tools/demo/fc-br0.interface $(FCNET_BRIDGE_CONFIG)
 


### PR DESCRIPTION
Previously, make demo-network only worked the first time
because the target did not depend on the soruce file. With
this change, make demo-network will reinstall the CNI configs
every time the source file changes

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
