### PR TITLE
Support volumes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,10 @@ jobs:
       - run: make deps
       - run: make
       - run: make lint
-      - run: make test
+      - name: make test
+        run: DISABLE_ROOT_TESTS=1 make test
+      - name: make test as root
+        run: EXTRAGOARGS='-exec sudo' make test
       - run: |
           make tidy
           git diff --exit-code

--- a/runtime/volume_integ_test.go
+++ b/runtime/volume_integ_test.go
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+	"github.com/firecracker-microvm/firecracker-containerd/proto"
+	"github.com/firecracker-microvm/firecracker-containerd/runtime/firecrackeroci"
+	"github.com/firecracker-microvm/firecracker-containerd/volume"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const mib = 1024 * 1024
+
+func TestVolumes_Isolated(t *testing.T) {
+	prepareIntegTest(t)
+
+	const vmID = 0
+
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+
+	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	defer client.Close()
+
+	image, err := alpineImage(ctx, client, defaultSnapshotterName)
+	require.NoError(t, err, "failed to get alpine image")
+
+	fcClient, err := newFCControlClient(containerdSockPath)
+	require.NoError(t, err, "failed to create fccontrol client")
+
+	// Make volumes.
+	path, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+
+	f, err := os.Create(filepath.Join(path, "hello.txt"))
+	require.NoError(t, err)
+
+	_, err = f.Write([]byte("hello from host\n"))
+	require.NoError(t, err)
+
+	const volName = "volume1"
+	vs := volume.NewSet()
+	vs.Add(volume.FromHost(volName, path))
+
+	// Since CreateVM doesn't take functional options, we need to explicitly create
+	// a FirecrackerDriveMount
+	mount, err := vs.PrepareDriveMount(ctx, 10*mib)
+	require.NoError(t, err)
+
+	containers := []string{"c1", "c2"}
+
+	_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{
+		VMID:           strconv.Itoa(vmID),
+		ContainerCount: int32(len(containers)),
+		DriveMounts:    []*proto.FirecrackerDriveMount{mount},
+	})
+	require.NoError(t, err, "failed to create VM")
+
+	// Make containers with the volume.
+	dir := "/path/in/container"
+	mpOpt, err := vs.WithMounts([]volume.Mount{{Source: volName, Destination: dir, ReadOnly: false}})
+	require.NoError(t, err)
+
+	for _, name := range containers {
+		snapshotName := fmt.Sprintf("%s-snapshot", name)
+
+		sh := fmt.Sprintf("echo hello from %s >> %s/hello.txt", name, dir)
+		container, err := client.NewContainer(ctx,
+			name,
+			containerd.WithSnapshotter(defaultSnapshotterName),
+			containerd.WithNewSnapshot(snapshotName, image),
+			containerd.WithNewSpec(
+				firecrackeroci.WithVMID(strconv.Itoa(vmID)),
+				oci.WithProcessArgs("sh", "-c", sh),
+				oci.WithDefaultPathEnv,
+				mpOpt,
+			),
+		)
+		require.NoError(t, err, "failed to create container %s", name)
+
+		var stdout, stderr bytes.Buffer
+
+		task, err := container.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, &stdout, &stderr)))
+		require.NoError(t, err, "failed to create task for container %s", name)
+
+		exitCh, err := task.Wait(ctx)
+		require.NoError(t, err, "failed to wait on task for container %s", name)
+
+		err = task.Start(ctx)
+		require.NoError(t, err, "failed to start task for container %s", name)
+
+		exit := <-exitCh
+		_, err = task.Delete(ctx)
+		require.NoError(t, err)
+
+		assert.Equalf(t, uint32(0), exit.ExitCode(), "stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	name := "cat"
+	snapshotName := fmt.Sprintf("%s-snapshot", name)
+	container, err := client.NewContainer(ctx,
+		name,
+		containerd.WithSnapshotter(defaultSnapshotterName),
+		containerd.WithNewSnapshot(snapshotName, image),
+		containerd.WithNewSpec(
+			firecrackeroci.WithVMID(strconv.Itoa(vmID)),
+			oci.WithProcessArgs("cat", fmt.Sprintf("%s/hello.txt", dir)),
+			oci.WithDefaultPathEnv,
+			mpOpt,
+		),
+	)
+	require.NoError(t, err, "failed to create container %s", name)
+
+	var stdout, stderr bytes.Buffer
+	task, err := container.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, &stdout, &stderr)))
+	require.NoError(t, err, "failed to create task for container %s", name)
+
+	exitCh, err := task.Wait(ctx)
+	require.NoError(t, err, "failed to wait on task for container %s", name)
+
+	err = task.Start(ctx)
+	require.NoError(t, err, "failed to start task for container %s", name)
+
+	exit := <-exitCh
+	_, err = task.Delete(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint32(0), exit.ExitCode())
+	assert.Equal(t, "hello from host\nhello from c1\nhello from c2\n", stdout.String())
+	assert.Equal(t, "", stderr.String())
+}

--- a/volume/set.go
+++ b/volume/set.go
@@ -1,0 +1,200 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/continuity/fs"
+	"github.com/firecracker-microvm/firecracker-containerd/proto"
+	"github.com/hashicorp/go-multierror"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const (
+	vmVolumePath = "/vmv"
+	fsType       = "ext4"
+)
+
+// Set is a set of volumes.
+type Set struct {
+	volumes map[string]*Volume
+	tempDir string
+}
+
+// NewSet returns a new volume set.
+func NewSet() *Set {
+	return NewSetWithTempDir(os.TempDir())
+}
+
+// NewSetWithTempDir returns a new volume set and creates all temporary files under the tempDir.
+func NewSetWithTempDir(tempDir string) *Set {
+	return &Set{volumes: make(map[string]*Volume), tempDir: tempDir}
+}
+
+// Add a volume to the set.
+func (vs *Set) Add(v *Volume) {
+	vs.volumes[v.name] = v
+}
+
+func (vs *Set) createDiskImage(ctx context.Context, size int64) (path string, retErr error) {
+	f, err := os.CreateTemp(vs.tempDir, "createDiskImage")
+	if err != nil {
+		retErr = err
+		return
+	}
+	defer func() {
+		// The file must be closed even in the success case.
+		err := f.Close()
+		if err != nil {
+			retErr = multierror.Append(retErr, err)
+		}
+		// But the file must not be deleted in the success case.
+		if retErr != nil {
+			err = os.Remove(path)
+			if err != nil {
+				retErr = multierror.Append(retErr, err)
+			}
+		}
+	}()
+
+	err = f.Truncate(size)
+	if err != nil {
+		retErr = err
+		return
+	}
+
+	out, err := exec.CommandContext(ctx, "mkfs."+fsType, "-F", f.Name()).CombinedOutput()
+	if err != nil {
+		retErr = fmt.Errorf("failed to execute mkfs.%s: %s: %w", fsType, out, err)
+		return
+	}
+
+	path = f.Name()
+	return
+}
+
+func mountDiskImage(source, target string) error {
+	return mount.All([]mount.Mount{{Type: fsType, Source: source, Options: []string{"loop"}}}, target)
+}
+
+// PrepareDriveMount returns a FirecrackerDriveMount that could be used with CreateVM.
+func (vs *Set) PrepareDriveMount(ctx context.Context, size int64) (dm *proto.FirecrackerDriveMount, retErr error) {
+	path, err := vs.createDiskImage(ctx, size)
+	if err != nil {
+		retErr = err
+		return
+	}
+	defer func() {
+		// The file must not be deleted in the success case.
+		if retErr != nil {
+			err := os.Remove(path)
+			if err != nil {
+				retErr = multierror.Append(retErr, err)
+			}
+		}
+	}()
+
+	dir, err := os.MkdirTemp(vs.tempDir, "PrepareDriveMount")
+	if err != nil {
+		retErr = err
+		return
+	}
+	defer func() {
+		err := os.Remove(dir)
+		if err != nil {
+			retErr = multierror.Append(retErr, err)
+		}
+	}()
+
+	err = mountDiskImage(path, dir)
+	if err != nil {
+		retErr = err
+		return
+	}
+	defer func() {
+		err := mount.Unmount(dir, 0)
+		if err != nil {
+			retErr = multierror.Append(retErr, err)
+		}
+	}()
+
+	for _, v := range vs.volumes {
+		path := filepath.Join(dir, v.name)
+		if v.hostPath == "" {
+			continue
+		}
+		err := fs.CopyDir(path, v.hostPath)
+		if err != nil {
+			retErr = fmt.Errorf("failed to copy volume %q: %w", v.name, err)
+			return
+		}
+	}
+
+	dm = &proto.FirecrackerDriveMount{
+		HostPath:       path,
+		VMPath:         vmVolumePath,
+		FilesystemType: fsType,
+		IsWritable:     true,
+	}
+	return
+}
+
+// Mount is used to expose volumes to containers.
+type Mount struct {
+	// Source is the name of a volume.
+	Source string
+	// Destination is the path inside the container where the volume is mounted.
+	Destination string
+	// ReadOnly is true if the volume is mounted as read-only.
+	ReadOnly bool
+}
+
+// WithMounts expose given volumes to the container.
+func (vs *Set) WithMounts(mountpoints []Mount) (oci.SpecOpts, error) {
+	mounts := []specs.Mount{}
+
+	for _, mp := range mountpoints {
+		v, ok := vs.volumes[mp.Source]
+		if !ok {
+			return nil, fmt.Errorf("failed to find volume %q", mp.Source)
+		}
+
+		options := []string{"bind"}
+		if mp.ReadOnly {
+			options = append(options, "ro")
+		}
+
+		mounts = append(mounts, specs.Mount{
+			// TODO: for volumes that are provided by the guest (e.g. in-VM snapshotters)
+			// We may be able to have bind-mounts from in-VM snapshotters' mount points.
+			Source:      filepath.Join(vmVolumePath, v.name),
+			Destination: mp.Destination,
+			Type:        "bind",
+			Options:     options,
+		})
+	}
+
+	return func(ctx context.Context, client oci.Client, container *containers.Container, s *oci.Spec) error {
+		s.Mounts = append(s.Mounts, mounts...)
+		return nil
+	}, nil
+}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package volume provides volumes like Docker and Amazon ECS.
+// Volumes are specicial directories that could be shared by multiple containers.
+//
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#volumes
+package volume
+
+// Volume is a special directory that could be shared between containers.
+type Volume struct {
+	name     string
+	hostPath string
+}
+
+// New returns an empty volume.
+func New(name string) *Volume {
+	return &Volume{name: name}
+}
+
+// FromHost returns a volume which has the files from the given path.
+func FromHost(name, path string) *Volume {
+	return &Volume{name: name, hostPath: path}
+}

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/stretchr/testify/require"
+)
+
+const mib = 1024 * 1024
+
+func TestCreateDiskImage(t *testing.T) {
+	ctx := context.Background()
+
+	vs := &Set{}
+
+	_, err := vs.createDiskImage(ctx, 10)
+	require.Errorf(t, err, "10 bytes is too small to have a valid %s image", fsType)
+
+	path, err := vs.createDiskImage(ctx, 100*mib)
+	require.NoError(t, err)
+
+	defer os.Remove(path)
+
+	uid := os.Getuid()
+	if uid != 0 {
+		t.Logf("skip mounting %s since uid=%d", path, uid)
+		return
+	}
+
+	// Make sure that the disk image is valid.
+	target := t.TempDir()
+	err = mountDiskImage(path, target)
+	require.NoError(t, err)
+
+	err = mount.Unmount(target, 0)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Since firecracker-containerd puts containers in VMs, mounting the host's
directories is not straightforward.

This commit adds "volume" package that makes an empty ext4 image to pack
and create helper functions around to make the image usable from
containers.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
