### PR TITLE
Allow each test under runtime/ to run for an hour at maximum

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,13 +85,12 @@ steps:
     env:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
       NUMBER_OF_VMS: 100
-      EXTRAGOARGS: "-v -count=1 -race"
+      EXTRAGOARGS: "-v -count=1 -race -timeout=1h"
       FICD_DM_VOLUME_GROUP: fcci-vg
     artifact_paths:
       - "runtime/logs/*"
     command:
       - make -C runtime integ-test FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_runtime
-    timeout_in_minutes: 30
 
   - label: ":rotating_light: :exclamation: example tests"
     agents:
@@ -100,7 +99,7 @@ steps:
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
     env:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
-      EXTRAGOARGS: "-v -count=1 -timeout=1h"
+      EXTRAGOARGS: "-v -count=1 -race"
       FICD_DM_VOLUME_GROUP: fcci-vg
     artifact_paths:
       - "examples/logs/*"


### PR DESCRIPTION
Previously 746fc78 (#593) changed examples/ and Amazon Linux 2's tests.
However runtime/ is still having 10 minutes timeout from Go's default,
30 minutes timeout from BuildKite.

This commit removes them and adding much longer timeout.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
