### PR TITLE
Fix minor demux snapshotter issues

### DIFF
--- a/snapshotter/app/service.go
+++ b/snapshotter/app/service.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -153,11 +152,7 @@ func initSnapshotter(ctx context.Context, config config.Config, cache cache.Cach
 		if err != nil {
 			return nil, err
 		}
-		u, err := url.Parse(response.Address)
-		if err != nil {
-			return nil, err
-		}
-		host := u.Hostname()
+		host := response.Address
 		port, err := strconv.ParseUint(response.SnapshotterPort, base10, bits32)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
http-address-resolver:
* Call GetVMInfo with namespace set
* Return SnapshotterPort

demux-snapshotter:
* Dial the returned address verbatim without
  trying to parse it into a URL

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
