### PR TITLE
Fix lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ distclean: clean
 
 lint:
 	$(BINPATH)/ltag -t ./.headers -excludes "tools $(SUBMODULES)" -check -v
-	$(BINPATH)/git-validation -run DCO,short-subject -range HEAD~20..HEAD
+	$(BINPATH)/git-validation -run DCO,short-subject -range 78381c382b17ac8c8ef6ffbfae27f65db8b186a7..HEAD
 	$(BINPATH)/golangci-lint run
 
 tidy:


### PR DESCRIPTION
78381c382b17ac8c8ef6ffbfae27f65db8b186a7 has a CRLF in the DCO which
git-validation doesn't like. Update lint target to start after that
commit.

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
