### PR TITLE
Revert "Fix lint"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ distclean: clean
 
 lint:
 	$(BINPATH)/ltag -t ./.headers -excludes "tools $(SUBMODULES)" -check -v
-	$(BINPATH)/git-validation -run DCO,short-subject -range 78381c382b17ac8c8ef6ffbfae27f65db8b186a7..HEAD
+	$(BINPATH)/git-validation -run DCO,short-subject -range HEAD~20..HEAD
 	$(BINPATH)/golangci-lint run
 
 tidy:


### PR DESCRIPTION
This reverts commit 9b5912e368802ba1cf19fd3aaa250c9fee9b5a40.

Signed-off-by: Swagat Bora <swagatbora90@gmail.com>

*Issue #, if available:*

*Description of changes:*

This reverts the changes as mentioned in #619. A fix for the same issue has been merged with https://github.com/vbatts/git-validation/pull/55.

`make lint` is now passing
```
[ec2-user@ip-172-31-9-211 firecracker-containerd]$ make lint

/home/ec2-user/firecracker-containerd/bin/git-validation -run DCO,short-subject -range HEAD~20..HEAD
 * e646a57 "Revert \"Fix lint\"" ... PASS
 * d99a632 "Merge pull request #620 from Kern--/lint" ... PASS
 * 9b5912e "Fix lint" ... PASS
 * 78381c3 "Allow configuration of block_device cache strategy in firecracker (#615)" ... PASS
 * b88e16e "Merge pull request #604 from ginglis13/upgrade-imgcrypt" ... PASS
 * 5f6efb9 "Merge pull request #616 from kzys/client-dead-lock" ... PASS
 * 4e4bf2b "Make TestMultipleVMs_Isolated stable by not sharing its ttrpc client" ... PASS
 * 601bf1f "Upgrade containerd/1.6.3 (CVE-2022-24778)" ... PASS
 * 3af01d8 "Merge pull request #612 from Kern--/remote-snapshotter-minor" ... PASS
 * 786f02c "Fix minor demux snapshotter issues" ... PASS
 * 5b7fa79 "Merge pull request #565 from kzys/fix-thinpool" ... PASS
 * 06cf6ee "Use \"fc-test-thinpool\" as a thinpool for testing" ... PASS
 * ae05892 "Merge pull request #611 from kzys/runtime-test-timeout" ... PASS
 * 92039cd "Allow each test under runtime/ to run for an hour at maximum" ... PASS
 * 6396bb0 "Merge pull request #609 from kzys/remove-mongo-replace" ... PASS
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
