### PR TITLE
add monitoring of metrics proxy servers

### DIFF
--- a/snapshotter/app/service.go
+++ b/snapshotter/app/service.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -56,7 +55,29 @@ func Run(config config.Config) error {
 	group, ctx := errgroup.WithContext(ctx)
 
 	cache := cache.NewSnapshotterCache()
-	snapshotter, err := initSnapshotter(ctx, config, cache)
+
+	var (
+		monitor          *metrics.Monitor
+		serviceDiscovery *discovery.ServiceDiscovery
+	)
+	if config.Snapshotter.Metrics.Enable {
+		sdHost := config.Snapshotter.Metrics.Host
+		sdPort := config.Snapshotter.Metrics.ServiceDiscoveryPort
+		serviceDiscovery := discovery.NewServiceDiscovery(sdHost, sdPort, cache)
+		monitor, err := initMetricsProxyMonitor(config.Snapshotter.Metrics.PortRange)
+		if err != nil {
+			log.G(ctx).WithError(err).Fatal("failed creating metrics proxy monitor")
+			return err
+		}
+		group.Go(func() error {
+			return serviceDiscovery.Serve()
+		})
+		group.Go(func() error {
+			return monitor.Start()
+		})
+	}
+
+	snapshotter, err := initSnapshotter(ctx, config, cache, monitor)
 	if err != nil {
 		log.G(ctx).WithFields(
 			logrus.Fields{"resolver": config.Snapshotter.Proxy.Address.Resolver.Type},
@@ -80,15 +101,6 @@ func Run(config config.Config) error {
 		return err
 	}
 
-	var serviceDiscovery *discovery.ServiceDiscovery
-	if config.Snapshotter.Metrics.Enable {
-		sdPort := config.Snapshotter.Metrics.ServiceDiscoveryPort
-		serviceDiscovery = discovery.NewServiceDiscovery(config.Snapshotter.Metrics.Host, sdPort, cache)
-		group.Go(func() error {
-			return serviceDiscovery.Serve()
-		})
-	}
-
 	group.Go(func() error {
 		return grpcServer.Serve(listener)
 	})
@@ -101,10 +113,13 @@ func Run(config config.Config) error {
 			if err := snapshotter.Close(); err != nil {
 				log.G(ctx).WithError(err).Error("failed to close snapshotter")
 			}
-			if serviceDiscovery != nil {
+			if config.Snapshotter.Metrics.Enable {
 				if err := serviceDiscovery.Shutdown(ctx); err != nil {
 					log.G(ctx).WithError(err).Error("failed to shutdown service discovery server")
 				}
+				// Senders to this channel would panic if it is closed. However snapshotter.Close() will
+				// shutdown all metrics proxies and ensure there are no more senders over the channel.
+				monitor.Stop()
 			}
 		}()
 
@@ -141,23 +156,19 @@ func initResolver(config config.Config) (proxyaddress.Resolver, error) {
 const base10 = 10
 const bits32 = 32
 
-func initSnapshotter(ctx context.Context, config config.Config, cache cache.Cache) (snapshots.Snapshotter, error) {
+func initSnapshotter(ctx context.Context, config config.Config, cache cache.Cache, monitor *metrics.Monitor) (snapshots.Snapshotter, error) {
 	resolver, err := initResolver(config)
 	if err != nil {
 		return nil, err
 	}
 
-	newProxySnapshotterFunc := func(ctx context.Context, namespace string) (*proxy.RemoteSnapshotter, error) {
+	newRemoteSnapshotterFunc := func(ctx context.Context, namespace string) (*proxy.RemoteSnapshotter, error) {
 		r := resolver
 		response, err := r.Get(namespace)
 		if err != nil {
 			return nil, err
 		}
-		u, err := url.Parse(response.Address)
-		if err != nil {
-			return nil, err
-		}
-		host := u.Hostname()
+		host := response.Address
 		port, err := strconv.ParseUint(response.SnapshotterPort, base10, bits32)
 		if err != nil {
 			return nil, err
@@ -167,57 +178,48 @@ func initSnapshotter(ctx context.Context, config config.Config, cache cache.Cach
 		}
 
 		var metricsProxy *metrics.Proxy
-		// TODO (ginglis13): port management and lifecycle ties in to overall metrics proxy
-		// server lifecycle. tracked here: https://github.com/firecracker-microvm/firecracker-containerd/issues/607
-		portMap := make(map[int]bool)
 		if config.Snapshotter.Metrics.Enable {
-			metricsPort, err := strconv.ParseUint(response.MetricsPort, base10, bits32)
+			metricsProxy, err = initMetricsProxy(config, monitor, host, response.MetricsPort, response.Labels)
 			if err != nil {
 				return nil, err
 			}
-
-			metricsDialer := func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return vsock.DialContext(ctx, host, uint32(metricsPort), vsock.WithLogger(log.G(ctx)))
-			}
-
-			portRange := config.Snapshotter.Metrics.PortRange
-			metricsHost := config.Snapshotter.Metrics.Host
-
-			// Assign a port for metrics proxy server.
-			ports := strings.Split(portRange, "-")
-			portRangeError := fmt.Errorf("invalid port range %s", portRange)
-			if len(ports) < 2 {
-				return nil, portRangeError
-			}
-			lower, err := strconv.Atoi(ports[0])
-			if err != nil {
-				return nil, portRangeError
-			}
-			upper, err := strconv.Atoi(ports[1])
-			if err != nil {
-				return nil, portRangeError
-			}
-			port := -1
-			for p := lower; p <= upper; p++ {
-				if _, ok := portMap[p]; !ok {
-					port = p
-					portMap[p] = true
-					break
-				}
-			}
-			if port < 0 {
-				return nil, fmt.Errorf("invalid port: %d", port)
-			}
-
-			metricsProxy, err = metrics.NewProxy(metricsHost, port, response.Labels, metricsDialer)
-			if err != nil {
-				return nil, err
-			}
-
 		}
 
-		return proxy.NewProxySnapshotter(ctx, host, snapshotterDialer, metricsProxy)
+		return proxy.NewRemoteSnapshotter(ctx, host, snapshotterDialer, metricsProxy)
 	}
 
-	return demux.NewSnapshotter(cache, newProxySnapshotterFunc), nil
+	return demux.NewSnapshotter(cache, newRemoteSnapshotterFunc), nil
+}
+
+func initMetricsProxyMonitor(portRange string) (*metrics.Monitor, error) {
+	ports := strings.Split(portRange, "-")
+	portRangeError := fmt.Errorf("invalid port range %s", portRange)
+	if len(ports) < 2 {
+		return nil, portRangeError
+	}
+	lower, err := strconv.Atoi(ports[0])
+	if err != nil {
+		return nil, portRangeError
+	}
+	upper, err := strconv.Atoi(ports[1])
+	if err != nil {
+		return nil, portRangeError
+	}
+
+	return metrics.NewMonitor(lower, upper)
+}
+
+func initMetricsProxy(config config.Config, monitor *metrics.Monitor, host, port string, labels map[string]string) (*metrics.Proxy, error) {
+	metricsPort, err := strconv.ParseUint(port, base10, bits32)
+	if err != nil {
+		return nil, err
+	}
+
+	metricsDialer := func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return vsock.DialContext(ctx, host, uint32(metricsPort), vsock.WithLogger(log.G(ctx)))
+	}
+
+	metricsHost := config.Snapshotter.Metrics.Host
+
+	return metrics.NewProxy(metricsHost, monitor, labels, metricsDialer)
 }

--- a/snapshotter/demux/metrics/proxy.go
+++ b/snapshotter/demux/metrics/proxy.go
@@ -15,10 +15,12 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"strconv"
+	"sync"
 
 	"github.com/containerd/containerd/log"
 )
@@ -30,10 +32,76 @@ const (
 	MaxMetricsResponseSize = 32768 // 32 KB
 )
 
+// Monitor is used for port and lifecycle management of metrics proxies.
+type Monitor struct {
+	// ch is used for communicating when a metrics proxy and its port are no longer in use
+	// so that the Monitor can mark the port as free.
+	ch chan int
+	// portsInUse is a set that tracks used and unused metrics proxy server ports.
+	portsInUse map[int]bool
+	// startPort is first port in the configurable range of ports to serve metrics proxies from.
+	startPort int
+	// endPort is last port in the configurable range of ports to serve metrics proxies from.
+	endPort int
+	// mu is the lock used for threadsafe reading and writing of the metrics proxy port map.
+	mu *sync.Mutex
+}
+
+// NewMonitor returns a new metrics proxy monitor.
+func NewMonitor(startPort, endPort int) (*Monitor, error) {
+	if startPort <= 0 || endPort <= 0 || startPort > endPort {
+		return nil, fmt.Errorf("invalid port range %d-%d", startPort, endPort)
+	}
+	return &Monitor{make(chan int), make(map[int]bool), startPort, endPort, &sync.Mutex{}}, nil
+}
+
+// Start receives messages from the proxy server channel indiciating a server has closed or terminated.
+// It marks the metrics proxy server's port as available by removing it from the portsInUse set.
+func (m *Monitor) Start() error {
+	for freePort := range m.ch {
+		m.mu.Lock()
+		delete(m.portsInUse, freePort)
+		m.mu.Unlock()
+	}
+
+	return nil
+}
+
+// Stop closes the metrics proxy monitoring channel.
+func (m *Monitor) Stop() {
+	close(m.ch)
+}
+
+// findOpenPort returns a port for use by a metrics proxy server.
+func (m *Monitor) findOpenPort() (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	metricsProxyPort := -1
+	for p := m.startPort; p <= m.endPort; p++ {
+		if _, ok := m.portsInUse[p]; !ok {
+			// Mark the port as in use in the set
+			metricsProxyPort = p
+			m.portsInUse[p] = true
+			break
+		}
+	}
+
+	if metricsProxyPort < 0 {
+		return 0, fmt.Errorf("unable to find port in range %d-%d", m.startPort, m.endPort)
+	}
+
+	return metricsProxyPort, nil
+}
+
+// HTTPClient defines the interface for the client getting metrics.
+type HTTPClient interface {
+	Get(string) (*http.Response, error)
+}
+
 // Proxy represents a metrics proxy server for getting and serving remote snapshotter metrics.
 type Proxy struct {
 	// client is the HTTP client used to send metrics requests to a remote snapshotter.
-	client *http.Client
+	client HTTPClient
 	// server is the proxy server on host for serving remote snapshotter metrics.
 	server *http.Server
 	// host is the nonroutable address listening for metrics requests.
@@ -42,13 +110,19 @@ type Proxy struct {
 	Port int
 	// Labels are labels used to apply to metrics.
 	Labels map[string]string
+	// monitor is the metrics proxy monitor
+	monitor *Monitor
 }
 
 // NewProxy creates a new Proxy with initialized HTTP client and port.
 // dialer is used as the DialContext underlying the metrics HTTP client's RoundTripper.
 //
 // Reference: https://pkg.go.dev/net/http#Transport
-func NewProxy(host string, port int, labels map[string]string, dialer func(context.Context, string, string) (net.Conn, error)) (*Proxy, error) {
+func NewProxy(host string, monitor *Monitor, labels map[string]string, dialer func(context.Context, string, string) (net.Conn, error)) (*Proxy, error) {
+	port, err := monitor.findOpenPort()
+	if err != nil {
+		return nil, err
+	}
 	return &Proxy{
 		client: &http.Client{
 			Transport: &http.Transport{
@@ -74,9 +148,12 @@ func (mp *Proxy) Serve(ctx context.Context) error {
 
 	err := mp.server.ListenAndServe()
 	if err != http.ErrServerClosed {
+		log.G(ctx).Errorf("metrics proxy server: %v\n", err)
+		mp.monitor.ch <- mp.Port
 		return err
 	}
 
+	mp.monitor.ch <- mp.Port
 	return nil
 }
 
@@ -92,7 +169,7 @@ func (mp *Proxy) metrics(w http.ResponseWriter, req *http.Request) {
 	// Pull metrics and copy to HTTP response.
 	res, err := mp.client.Get(RequestPath)
 	if err != nil {
-		log.G(ctx).Errorf("error reading response body: %v\n", err)
+		log.G(ctx).Errorf("error reading response body: %v", err)
 		w.WriteHeader(500)
 		return
 	}
@@ -100,5 +177,10 @@ func (mp *Proxy) metrics(w http.ResponseWriter, req *http.Request) {
 	defer res.Body.Close()
 	response := io.LimitReader(res.Body, MaxMetricsResponseSize)
 
-	io.Copy(w, response)
+	_, err = io.Copy(w, response)
+	if err != nil {
+		log.G(ctx).Errorf("error writing response body: %v", err)
+		w.WriteHeader(500)
+		return
+	}
 }

--- a/snapshotter/demux/metrics/proxy_test.go
+++ b/snapshotter/demux/metrics/proxy_test.go
@@ -1,0 +1,240 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func okPortRange(startPort, endPort int) error {
+	m, err := NewMonitor(startPort, endPort)
+	errMsg := errors.New("valid port range should not result in error")
+	if err != nil {
+		return errMsg
+	}
+	p, err := m.findOpenPort()
+	if err != nil && p == 0 {
+		return errMsg
+	}
+
+	return nil
+}
+
+func invalidPortRange(startPort, endPort int) error {
+	_, err := NewMonitor(startPort, endPort)
+	if err == nil {
+		return errors.New("invalid port range should result in error")
+	}
+
+	return nil
+}
+
+func noPortsAvailable(startPort, endPort int) error {
+	m, err := NewMonitor(startPort, endPort)
+	if err != nil {
+		return errors.New("initialization of monitor should not result in error")
+	}
+	m.portsInUse[startPort] = true
+	m.portsInUse[endPort] = true
+	p, err := m.findOpenPort()
+	if err == nil && p != 0 {
+		return errors.New("no port should be available")
+	}
+
+	return nil
+}
+
+func TestFindOpenPort(t *testing.T) {
+	tests := []struct {
+		name      string
+		startPort int
+		endPort   int
+		run       func(int, int) error
+	}{
+		{"Valid Port Range", 9000, 9999, okPortRange},
+		{"Invalid Port Range", 9999, 9000, invalidPortRange},
+		{"No Ports Available", 9999, 9999, noPortsAvailable},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.run(test.startPort, test.endPort); err != nil {
+				t.Fatal(test.name + ": " + err.Error())
+			}
+		})
+	}
+}
+
+const metricsResponse = `
+		# A histogram, which has a pretty complex representation in the text format:
+		# HELP http_request_duration_seconds A histogram of the request duration.
+		# TYPE http_request_duration_seconds histogram
+		http_request_duration_seconds_bucket{le="0.05"} 24054
+		http_request_duration_seconds_bucket{le="0.1"} 33444
+		http_request_duration_seconds_bucket{le="0.2"} 100392
+		http_request_duration_seconds_bucket{le="0.5"} 129389
+		http_request_duration_seconds_bucket{le="1"} 133988
+		http_request_duration_seconds_bucket{le="+Inf"} 144320
+		http_request_duration_seconds_sum 53423
+		http_request_duration_seconds_count 144320
+		`
+
+func happyPath() error {
+	reader := mockReader{response: []byte(metricsResponse), err: io.EOF}
+	client := mockClient{getError: nil, getResponse: http.Response{Body: &reader}}
+	uut := Proxy{client: &client}
+
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", RequestPath, nil)
+	if err != nil {
+		return errors.New("expected no error from metrics request")
+	}
+	uut.metrics(rr, req)
+	if status := rr.Code; status != http.StatusOK {
+		return fmt.Errorf("metrics handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	if rr.Body.String() != metricsResponse {
+		return fmt.Errorf("metrics handler returned unexpected body: got %v want %v",
+			rr.Body.String(), metricsResponse)
+	}
+
+	return nil
+}
+
+func exceedBufferSize() error {
+	b := make([]byte, 1<<16)
+	largeResponse := string(b)
+
+	reader := mockReader{response: []byte(largeResponse), err: io.EOF}
+	client := mockClient{getError: nil, getResponse: http.Response{Body: &reader}}
+	uut := Proxy{client: &client}
+
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", RequestPath, nil)
+	if err != nil {
+		return errors.New("expected no error from metrics request")
+	}
+	uut.metrics(rr, req)
+	if status := rr.Code; status != http.StatusOK {
+		return fmt.Errorf("metrics handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check that body does not match since it should be truncated.
+	if rr.Body.String() == largeResponse {
+		// Do not output large body to keep testing logs clean.
+		return fmt.Errorf("metrics handler returned unexpected body")
+	}
+
+	responseLen := len(rr.Body.String())
+	if len(rr.Body.String()) > MaxMetricsResponseSize {
+		return fmt.Errorf("metrics handler body too large: got %v want %v", responseLen, MaxMetricsResponseSize)
+
+	}
+
+	return nil
+}
+
+func returnErrorOnRequest() error {
+	reader := mockReader{response: []byte(""), err: nil}
+	client := mockClient{getError: http.ErrHandlerTimeout, getResponse: http.Response{Body: &reader}}
+	uut := Proxy{client: &client}
+
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", RequestPath, nil)
+	if err != nil {
+		return errors.New("expected no error from metrics request")
+	}
+	uut.metrics(rr, req)
+
+	if status := rr.Code; status != http.StatusInternalServerError {
+		return fmt.Errorf("metrics handler returned wrong status code: got %v want %v",
+			status, http.StatusInternalServerError)
+	}
+
+	return nil
+}
+
+func returnErrorOnResponse() error {
+	reader := mockReader{response: []byte(""), err: io.ErrClosedPipe}
+	client := mockClient{getError: nil, getResponse: http.Response{Body: &reader}}
+	uut := Proxy{client: &client}
+
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", RequestPath, nil)
+	if err != nil {
+		return errors.New("expected no error from metrics request")
+	}
+	uut.metrics(rr, req)
+
+	if status := rr.Code; status != http.StatusInternalServerError {
+		return fmt.Errorf("metrics handler returned wrong status code: got %v want %v",
+			status, http.StatusInternalServerError)
+	}
+
+	return nil
+}
+
+func TestMetricsGet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"HappyPath", happyPath},
+		{"ExceedBufferSize", exceedBufferSize},
+		{"ReturnErrorOnRequest", returnErrorOnRequest},
+		{"ReturnErrorOnResponse", returnErrorOnResponse},
+	}
+
+	for _, test := range tests {
+		if err := test.run(); err != nil {
+			t.Fatalf(test.name+" test failed: %s", err)
+		}
+	}
+}
+
+type mockClient struct {
+	getResponse http.Response
+	getError    error
+}
+
+func (c *mockClient) Get(url string) (*http.Response, error) {
+	if c.getError != nil {
+		return nil, c.getError
+	}
+	return &c.getResponse, nil
+}
+
+type mockReader struct {
+	response []byte
+	err      error
+}
+
+func (r *mockReader) Read(p []byte) (int, error) {
+	return copy(p, r.response), r.err
+}
+
+func (r *mockReader) Close() error {
+	return nil
+}

--- a/snapshotter/demux/proxy/snapshotter.go
+++ b/snapshotter/demux/proxy/snapshotter.go
@@ -51,8 +51,8 @@ func (rs *RemoteSnapshotter) Close() error {
 	return compiledErr
 }
 
-// NewProxySnapshotter creates a proxy snapshotter using gRPC over vsock connection.
-func NewProxySnapshotter(ctx context.Context, address string,
+// NewRemoteSnapshotter creates a proxy snapshotter using gRPC over vsock connection.
+func NewRemoteSnapshotter(ctx context.Context, address string,
 	dialer func(context.Context, string) (net.Conn, error), metricsProxy *metrics.Proxy) (*RemoteSnapshotter, error) {
 
 	opts := []grpc.DialOption{
@@ -65,9 +65,7 @@ func NewProxySnapshotter(ctx context.Context, address string,
 		return nil, err
 	}
 
-	// TODO (ginglis13)
-	// we should be monitoring this goroutine's status.
-	// https://github.com/firecracker-microvm/firecracker-containerd/issues/607
+	// Treat metrics proxy errors as operational errors, logged by the server itself.
 	if metricsProxy != nil {
 		go metricsProxy.Serve(ctx)
 	}


### PR DESCRIPTION
This change introduces a Monitor type which is made aware of a metrics
proxy's closure via a channel. It contains the logic for port selection
for a new metrics proxy and port freeing for a metrics proxy that has
been shut down.

For maintainability, open to discussions around moving Monitor implementation to its own file in the metrics package.

refactoring done to move metrics proxy server initialization to its own function, as well as removal of `enable` configuration option for metrics. Included some unit tests for the `metrics` HTTPResponseHandler

resolves #607

Signed-off-by: Gavin Inglis <giinglis@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
