### PR TITLE
add metrics config to remote snapshotter rootfs

### DIFF
--- a/tools/image-builder/files_stargz/etc/containerd-stargz-grpc/config.toml
+++ b/tools/image-builder/files_stargz/etc/containerd-stargz-grpc/config.toml
@@ -1,0 +1,2 @@
+metrics_address = "localhost:8234"
+no_prometheus = false

--- a/tools/image-builder/files_stargz/etc/systemd/system/firecracker.target.wants/metrics-socat.service
+++ b/tools/image-builder/files_stargz/etc/systemd/system/firecracker.target.wants/metrics-socat.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/metrics-socat.service

--- a/tools/image-builder/files_stargz/etc/systemd/system/metrics-socat.service
+++ b/tools/image-builder/files_stargz/etc/systemd/system/metrics-socat.service
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+[Unit]
+Description=Metrics Socat
+StartLimitIntervalSec=2
+After=stargz-snapshotter.service
+Requires=stargz-snapshotter.service
+SuccessAction=reboot
+
+[Service]
+Type=simple
+ExecStart=socat VSOCK-LISTEN:10001,reuseaddr,fork TCP:localhost:8234


### PR DESCRIPTION
configure socat to forward requests to in-Vm metrics server being hosted by remote snapshotter, and configure remote snapshotter to emit metrics. 

Tested locally with `firectl` and `socat`, my relative paths to kernel and remote snapshotter rootfs used here:


```
$ make image-stargz
$ sudo ./firectl -d -t  \
    --kernel=./hello-vmlinux.bin \ 
    --root-drive=./tools/image-builder/rootfs-stargz.img  \
    --kernel-opts="console=ttyS0 noapic reboot=k panic=1 pci=off nomodules ro systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init"   \
    --vsock-device=./test.sock:1
```
in another shell:
```
$ sudo socat - UNIX-CONNECT:test.sock
CONNECT 10001
OK 1073741824
GET /metrics HTTP/1.1
Host:localhost

....(metrics)....
```

Signed-off-by: Gavin Inglis <giinglis@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
