### PR TITLE
refactor: integration test common code into internal module

### DIFF
--- a/internal/integtest/config.go
+++ b/internal/integtest/config.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integtest
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/firecracker-microvm/firecracker-containerd/config"
+)
+
+const runtimeConfigPath = "/etc/containerd/firecracker-runtime.json"
+
+// DefaultRuntimeConfig represents a simple firecracker-containerd configuration.
+var DefaultRuntimeConfig = config.Config{
+	FirecrackerBinaryPath: "/usr/local/bin/firecracker",
+	KernelImagePath:       "/var/lib/firecracker-containerd/runtime/default-vmlinux.bin",
+	KernelArgs:            "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules systemd.unified_cgroup_hierarchy=0 systemd.journald.forward_to_console systemd.log_color=false systemd.unit=firecracker.target init=/sbin/overlay-init",
+	RootDrive:             "/var/lib/firecracker-containerd/runtime/default-rootfs.img",
+	LogLevels:             []string{"debug"},
+	ShimBaseDir:           ShimBaseDir(),
+	JailerConfig: config.JailerConfig{
+		RuncBinaryPath: "/usr/local/bin/runc",
+		RuncConfigPath: "/etc/containerd/firecracker-runc-config.json",
+	},
+}
+
+func writeRuntimeConfig(options ...func(*config.Config)) error {
+	config := DefaultRuntimeConfig
+	for _, option := range options {
+		option(&config)
+	}
+
+	file, err := os.OpenFile(runtimeConfigPath, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	bytes, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	_, err = file.Write(bytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/integtest/prepare.go
+++ b/internal/integtest/prepare.go
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integtest
+
+import (
+	"testing"
+
+	"github.com/firecracker-microvm/firecracker-containerd/config"
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
+)
+
+// Prepare is a common integration test setup function which ensures
+// isolation and prepares the runtime configuration for firecracker-containerd
+func Prepare(t testing.TB, options ...func(*config.Config)) {
+	t.Helper()
+
+	internal.RequiresIsolation(t)
+
+	err := writeRuntimeConfig(options...)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/integtest/shim.go
+++ b/internal/integtest/shim.go
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integtest
+
+import "os"
+
+const shimBaseDirEnvVar = "SHIM_BASE_DIR"
+const defaultShimBaseDir = "/srv/firecracker_containerd_tests"
+
+// ShimBaseDir checks the "SHIM_BASE_DIR" environment variable and returns its value
+// if it exists, else returns the default value
+func ShimBaseDir() string {
+	if v := os.Getenv(shimBaseDirEnvVar); v != "" {
+		return v
+	}
+
+	return defaultShimBaseDir
+}

--- a/runtime/benchmark_test.go
+++ b/runtime/benchmark_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/integtest"
 	"github.com/firecracker-microvm/firecracker-containerd/proto"
 	fccontrol "github.com/firecracker-microvm/firecracker-containerd/proto/service/fccontrol/ttrpc"
 	"github.com/gofrs/uuid"
@@ -94,13 +95,13 @@ func benchmarkCreateAndStopVM(t *testing.T, vcpuCount uint32, kernelArgs string)
 }
 
 func TestPerf_CreateVM(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	t.Run("vcpu=1", func(subtest *testing.T) {
-		benchmarkCreateAndStopVM(subtest, 1, defaultRuntimeConfig.KernelArgs)
+		benchmarkCreateAndStopVM(subtest, 1, integtest.DefaultRuntimeConfig.KernelArgs)
 	})
 	t.Run("vcpu=5", func(subtest *testing.T) {
-		benchmarkCreateAndStopVM(subtest, 1, defaultRuntimeConfig.KernelArgs)
+		benchmarkCreateAndStopVM(subtest, 1, integtest.DefaultRuntimeConfig.KernelArgs)
 	})
 	t.Run("firecracker-demo", func(subtest *testing.T) {
 		benchmarkCreateAndStopVM(

--- a/runtime/cni_integ_test.go
+++ b/runtime/cni_integ_test.go
@@ -34,12 +34,13 @@ import (
 
 	"github.com/firecracker-microvm/firecracker-containerd/config"
 	"github.com/firecracker-microvm/firecracker-containerd/internal"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/integtest"
 	"github.com/firecracker-microvm/firecracker-containerd/proto"
 	"github.com/firecracker-microvm/firecracker-containerd/runtime/firecrackeroci"
 )
 
 func TestCNISupport_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 	testTimeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), testTimeout)
 	defer cancel()
@@ -147,7 +148,7 @@ func TestCNISupport_Isolated(t *testing.T) {
 }
 
 func TestAutomaticCNISupport_Isolated(t *testing.T) {
-	prepareIntegTest(t, withDefaultNetwork())
+	integtest.Prepare(t, withDefaultNetwork())
 
 	testTimeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), testTimeout)
@@ -213,7 +214,7 @@ func TestAutomaticCNISupport_Isolated(t *testing.T) {
 }
 
 func TestCNIPlugin_Performance(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	numVMs := perfTestVMCount(t)
 	runtimeDuration := perfTestRuntime(t)

--- a/runtime/jailer_test.go
+++ b/runtime/jailer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/firecracker-microvm/firecracker-containerd/config"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/integtest"
 	"github.com/firecracker-microvm/firecracker-containerd/internal/vm"
 	"github.com/firecracker-microvm/firecracker-containerd/proto"
 )
@@ -99,7 +100,7 @@ func TestJailer_invalidUIDGID(t *testing.T) {
 }
 
 func TestNewJailer_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	ociBundlePath := t.TempDir()
 	b, err := exec.Command(

--- a/runtime/limits_integ_test.go
+++ b/runtime/limits_integ_test.go
@@ -19,12 +19,13 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/integtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDiskLimit_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	assert := assert.New(t)
 	require := require.New(t)

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/firecracker-microvm/firecracker-containerd/config"
 	_ "github.com/firecracker-microvm/firecracker-containerd/firecracker-control"
 	"github.com/firecracker-microvm/firecracker-containerd/internal"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/integtest"
 	"github.com/firecracker-microvm/firecracker-containerd/internal/vm"
 	"github.com/firecracker-microvm/firecracker-containerd/proto"
 	fccontrol "github.com/firecracker-microvm/firecracker-containerd/proto/service/fccontrol/ttrpc"
@@ -118,7 +119,7 @@ func iperf3Image(ctx context.Context, client *containerd.Client, snapshotterName
 }
 
 func TestShimExitsUponContainerDelete_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	ctx := namespaces.WithNamespace(context.Background(), defaultNamespace)
 
@@ -249,7 +250,7 @@ func createTapDevice(ctx context.Context, tapName string) error {
 }
 
 func TestMultipleVMs_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	// This test starts multiple VMs and some may hit firecracker-containerd's
 	// default timeout. So overriding the timeout to wait longer.
@@ -538,7 +539,7 @@ func testMultipleExecs(
 	close(execStdouts)
 
 	if jailerConfig != nil {
-		dir, err := vm.ShimDir(shimBaseDir(), "default", vmIDStr)
+		dir, err := vm.ShimDir(integtest.ShimBaseDir(), "default", vmIDStr)
 		if err != nil {
 			return err
 		}
@@ -661,7 +662,7 @@ func getMountNamespace(ctx context.Context, client *containerd.Client, container
 }
 
 func TestLongUnixSocketPath_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	cfg, err := config.LoadConfig("")
 	require.NoError(t, err, "failed to load config")
@@ -764,7 +765,7 @@ func allowDeviceAccess(_ context.Context, _ oci.Client, _ *containers.Container,
 }
 
 func TestStubBlockDevices_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	const vmID = 0
 
@@ -981,7 +982,7 @@ func testCreateContainerWithSameName(t *testing.T, vmID string) {
 }
 
 func TestCreateContainerWithSameName_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	testCreateContainerWithSameName(t, "")
 
@@ -990,7 +991,7 @@ func TestCreateContainerWithSameName_Isolated(t *testing.T) {
 }
 
 func TestStubDriveReserveAndReleaseByContainers_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	assert := assert.New(t)
 
@@ -1038,7 +1039,7 @@ func TestStubDriveReserveAndReleaseByContainers_Isolated(t *testing.T) {
 }
 
 func TestDriveMount_Isolated(t *testing.T) {
-	prepareIntegTest(t, func(cfg *config.Config) {
+	integtest.Prepare(t, func(cfg *config.Config) {
 		cfg.JailerConfig.RuncBinaryPath = "/usr/local/bin/runc"
 	})
 
@@ -1214,7 +1215,7 @@ func TestDriveMount_Isolated(t *testing.T) {
 }
 
 func TestDriveMountFails_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	testTimeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), testTimeout)
@@ -1279,7 +1280,7 @@ func TestDriveMountFails_Isolated(t *testing.T) {
 }
 
 func TestUpdateVMMetadata_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	testTimeout := 60 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), testTimeout)
@@ -1381,7 +1382,7 @@ func TestUpdateVMMetadata_Isolated(t *testing.T) {
 }
 
 func TestMemoryBalloon_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 	ctx := namespaces.WithNamespace(context.Background(), defaultNamespace)
 
 	numberOfVms := defaultNumberOfVms
@@ -1479,7 +1480,7 @@ func exitCode(err *exec.ExitError) int {
 // timeout of 60 seconds). It also validates that the quality of the randomness passes the rngtest
 // utility's suite.
 func TestRandomness_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), 60*time.Second)
 	defer cancel()
@@ -1617,7 +1618,7 @@ func pidExists(pid int) bool {
 }
 
 func TestStopVM_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -1837,7 +1838,7 @@ func TestStopVM_Isolated(t *testing.T) {
 }
 
 func TestExec_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
@@ -1950,7 +1951,7 @@ func TestExec_Isolated(t *testing.T) {
 }
 
 func TestEvents_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 	require := require.New(t)
 
 	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
@@ -2034,7 +2035,7 @@ func findProcWithName(name string) func(context.Context, *process.Process) (bool
 }
 
 func TestOOM_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
@@ -2126,7 +2127,7 @@ func requireNonEmptyFifo(t testing.TB, path string) {
 }
 
 func TestCreateVM_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
 	defer client.Close()
@@ -2255,7 +2256,7 @@ func TestCreateVM_Isolated(t *testing.T) {
 }
 
 func TestPauseResume_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
@@ -2377,7 +2378,7 @@ func TestPauseResume_Isolated(t *testing.T) {
 	}
 }
 func TestAttach_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
@@ -2480,7 +2481,7 @@ func (errorBuffer) Write(b []byte) (int, error) {
 }
 
 func TestBrokenPipe_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
 	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)

--- a/runtime/volume_integ_test.go
+++ b/runtime/volume_integ_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/integtest"
 	"github.com/firecracker-microvm/firecracker-containerd/proto"
 	"github.com/firecracker-microvm/firecracker-containerd/runtime/firecrackeroci"
 	"github.com/firecracker-microvm/firecracker-containerd/volume"
@@ -36,7 +37,7 @@ import (
 const mib = 1024 * 1024
 
 func TestVolumes_Isolated(t *testing.T) {
-	prepareIntegTest(t)
+	integtest.Prepare(t)
 
 	const vmID = 0
 


### PR DESCRIPTION
*Issue #, if available:*
Prep for #595 

*Description of changes:*
Refactor some of the common integration test setup code into a reusable module for integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>