### PR TITLE
add: integration test for remote snapshotter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,6 +73,20 @@ steps:
       - make test-in-docker
     timeout_in_minutes: 10
 
+  - label: ":running: snapshotter isolated tests"
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
+      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
+    env:
+      DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
+      NUMBER_OF_VMS: 10
+      EXTRAGOARGS: "-v -count=1 -race"
+    artifact_paths:
+      - "snapshotter/logs/*"
+    command:
+      - make -C snapshotter integ-test
+
   - label: ":running: runtime isolated tests"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 bin/
+tmp/
 runtime/logs
 *stamp
 default-vmlinux.bin

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ $(INTEG_TEST_SUBDIRS): test-images
 
 test-images: test-images-stamp
 
-test-images-stamp: | image firecracker-containerd-test-image
+test-images-stamp: | image image-stargz firecracker-containerd-test-image
 	touch $@
 
 firecracker-containerd-test-image: all-in-docker firecracker runc test-cni-bins cni-bins default-vmlinux kernel

--- a/internal/integtest/runtime.go
+++ b/internal/integtest/runtime.go
@@ -15,6 +15,7 @@ package integtest
 
 import (
 	"os"
+	"strconv"
 )
 
 const (
@@ -22,15 +23,23 @@ const (
 	FirecrackerRuntime = "aws.firecracker"
 
 	containerdSockPathEnvVar = "CONTAINERD_SOCKET"
+	numberOfVmsEnvVar        = "NUMBER_OF_VMS"
 )
 
 var (
 	// ContainerdSockPath is the default Firecracker-containerd socket path
 	ContainerdSockPath = "/run/firecracker-containerd/containerd.sock"
+
+	// NumberOfVms is the number of VMs used in integration testing set
+	// by either environment variable read or defaults to 5 VMs.
+	NumberOfVms = 5
 )
 
 func init() {
 	if v := os.Getenv(containerdSockPathEnvVar); v != "" {
 		ContainerdSockPath = v
+	}
+	if v := os.Getenv(numberOfVmsEnvVar); v != "" {
+		NumberOfVms, _ = strconv.Atoi(v)
 	}
 }

--- a/snapshotter/.gitignore
+++ b/snapshotter/.gitignore
@@ -1,2 +1,3 @@
 demux-snapshotter
 http-address-resolver
+logs/

--- a/snapshotter/Makefile
+++ b/snapshotter/Makefile
@@ -12,14 +12,28 @@
 # permissions and limitations under the License.
 
 EXTRAGOARGS?=
+NUMBER_OF_VMS?=
 
 SOURCES := $(shell find . -name '*.go')
 GOMOD := $(shell go env GOMOD)
 GOSUM := $(GOMOD:.mod=.sum)
+DOCKER_IMAGE_TAG?=latest
+GO_CACHE_VOLUME_NAME?=gocache
+FIRECRACKER_CONTAINERD_TEST_IMAGE?=localhost/firecracker-containerd-test
 
 REVISION := $(shell git rev-parse HEAD)
 
-all: demux-snapshotter
+INTEG_TEST_SUFFIX := _Isolated
+INTEG_TESTNAMES=$(shell docker run --rm \
+	--network=none \
+	--volume $(CURDIR)/..:/src \
+	--volume $(GO_CACHE_VOLUME_NAME):/go \
+	--entrypoint=/bin/bash \
+	--workdir=/src/snapshotter \
+	$(FIRECRACKER_CONTAINERD_TEST_IMAGE):$(DOCKER_IMAGE_TAG) \
+	-c "go test -list . | sed '$$d' | grep $(INTEG_TEST_SUFFIX)")
+
+all: demux-snapshotter http-address-resolver
 
 demux-snapshotter: $(SOURCES) $(GOMOD) $(GOSUM)
 	go build $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)" -o $@
@@ -27,18 +41,43 @@ demux-snapshotter: $(SOURCES) $(GOMOD) $(GOSUM)
 http-address-resolver: $(SOURCES) $(GOMOD) $(GOSUM)
 	go build $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)" -o $@ internal/http_address_resolver.go
 
+install: demux-snapshotter http-address-resolver
+	install -D -o root -g root -m755 -t $(INSTALLROOT)/bin $^
+
 test:
 	go test ./... $(EXTRAGOARGS)
 
 integ-test:
+	$(MAKE) $(addprefix integ-test-,$(INTEG_TESTNAMES))
+
+integ-test-%: logs
+	docker run --rm -it \
+		--privileged \
+		--ipc=host \
+		--network=bridge \
+		--volume /dev:/dev \
+		--volume /run/udev/control:/run/udev/control \
+		--volume $(CURDIR)/logs:/var/log/firecracker-containerd-test \
+		--volume $(CURDIR)/..:/src \
+		--volume $(GO_CACHE_VOLUME_NAME):/go \
+		--env ENABLE_ISOLATED_TESTS=1 \
+		--env GOPROXY=direct \
+		--env GOSUMDB=off \
+		--env GO111MODULE=on \
+		--env NUMBER_OF_VMS=$(NUMBER_OF_VMS) \
+		--workdir="/src/snapshotter" \
+		--init \
+		$(FIRECRACKER_CONTAINERD_TEST_IMAGE):$(DOCKER_IMAGE_TAG) \
+		"go test $(EXTRAGOARGS) -run '^$(subst integ-test-,,$@)$$'"
+
+logs:
+	mkdir logs
 
 clean:
 	- rm -f demux-snapshotter
-	- rm -f http-resolver
+	- rm -f http-address-resolver
 
 distclean: clean
+	- rm -rf logs
 
-# Install is a noop here, for now.
-install:
-
-.PHONY: all install test clean distclean
+.PHONY: all clean distclean install test integ-test

--- a/snapshotter/internal/integtest/stargz/fs/config/config.go
+++ b/snapshotter/internal/integtest/stargz/fs/config/config.go
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Copied from https://github.com/containerd/stargz-snapshotter/blob/v0.11.4/fs/config/config.go
+//
+// Taking Stargz as a code dependency required dropping support for Go 1.16.
+// Used to add Stargz annotations to pull requests.
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package config
+
+const (
+	// TargetSkipVerifyLabel is a snapshot label key that indicates to skip content
+	// verification for the layer.
+	TargetSkipVerifyLabel = "containerd.io/snapshot/remote/stargz.skipverify"
+
+	// TargetPrefetchSizeLabel is a snapshot label key that indicates size to prefetch
+	// the layer. If the layer is eStargz and contains prefetch landmarks, these config
+	// will be respeced.
+	TargetPrefetchSizeLabel = "containerd.io/snapshot/remote/stargz.prefetch"
+)

--- a/snapshotter/internal/integtest/stargz/fs/source/source.go
+++ b/snapshotter/internal/integtest/stargz/fs/source/source.go
@@ -1,0 +1,128 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Copied from https://github.com/containerd/stargz-snapshotter/blob/v0.11.4/fs/source/source.go
+//
+// Taking Stargz as a code dependency required dropping support for Go 1.16.
+// Used to add Stargz annotations to pull requests.
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/labels"
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/internal/integtest/stargz/fs/config"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	// targetRefLabel is a label which contains image reference.
+	targetRefLabel = "containerd.io/snapshot/remote/stargz.reference"
+
+	// targetDigestLabel is a label which contains layer digest.
+	targetDigestLabel = "containerd.io/snapshot/remote/stargz.digest"
+
+	// targetImageLayersLabel is a label which contains layer digests contained in
+	// the target image.
+	targetImageLayersLabel = "containerd.io/snapshot/remote/stargz.layers"
+
+	// targetImageURLsLabelPrefix is a label prefix which constructs a map from the layer index to
+	// urls of the layer descriptor.
+	targetImageURLsLabelPrefix = "containerd.io/snapshot/remote/urls."
+
+	// targetURsLLabel is a label which contains layer URL. This is only used to pass URL from containerd
+	// to snapshotter.
+	targetURLsLabel = "containerd.io/snapshot/remote/urls"
+)
+
+// AppendDefaultLabelsHandlerWrapper makes a handler which appends image's basic
+// information to each layer descriptor as annotations during unpack. These
+// annotations will be passed to this remote snapshotter as labels and used to
+// construct source information.
+func AppendDefaultLabelsHandlerWrapper(ref string, prefetchSize int64) func(f images.Handler) images.Handler {
+	return func(f images.Handler) images.Handler {
+		return images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+			children, err := f.Handle(ctx, desc)
+			if err != nil {
+				return nil, err
+			}
+			switch desc.MediaType {
+			case ocispec.MediaTypeImageManifest, images.MediaTypeDockerSchema2Manifest:
+				for i := range children {
+					c := &children[i]
+					if images.IsLayerType(c.MediaType) {
+						if c.Annotations == nil {
+							c.Annotations = make(map[string]string)
+						}
+						c.Annotations[targetRefLabel] = ref
+						c.Annotations[targetDigestLabel] = c.Digest.String()
+						var layers string
+						for i, l := range children[i:] {
+							if images.IsLayerType(l.MediaType) {
+								ls := fmt.Sprintf("%s,", l.Digest.String())
+								// This avoids the label hits the size limitation.
+								// Skipping layers is allowed here and only affects performance.
+								if err := labels.Validate(targetImageLayersLabel, layers+ls); err != nil {
+									break
+								}
+								layers += ls
+
+								// Store URLs of the neighbouring layer as well.
+								urlsKey := targetImageURLsLabelPrefix + fmt.Sprintf("%d", i)
+								c.Annotations[urlsKey] = appendWithValidation(urlsKey, l.URLs)
+							}
+						}
+						c.Annotations[targetImageLayersLabel] = strings.TrimSuffix(layers, ",")
+						c.Annotations[config.TargetPrefetchSizeLabel] = fmt.Sprintf("%d", prefetchSize)
+
+						// store URL in annotation to let containerd to pass it to the snapshotter
+						c.Annotations[targetURLsLabel] = appendWithValidation(targetURLsLabel, c.URLs)
+					}
+				}
+			}
+			return children, nil
+		})
+	}
+}
+
+func appendWithValidation(key string, values []string) string {
+	var v string
+	for _, u := range values {
+		s := fmt.Sprintf("%s,", u)
+		if err := labels.Validate(key, v+s); err != nil {
+			break
+		}
+		v += s
+	}
+	return strings.TrimSuffix(v, ",")
+}

--- a/snapshotter/service_integ_test.go
+++ b/snapshotter/service_integ_test.go
@@ -1,0 +1,149 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+	"github.com/firecracker-microvm/firecracker-containerd/internal/integtest"
+	"github.com/firecracker-microvm/firecracker-containerd/proto"
+	"github.com/firecracker-microvm/firecracker-containerd/runtime/firecrackeroci"
+	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/internal/integtest/stargz/fs/source"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	snapshotterName = "demux"
+
+	imageRef = "ghcr.io/firecracker-microvm/firecracker-containerd/amazonlinux:latest-esgz"
+
+	noAuth = ""
+
+	dockerMetadataTemplate = `
+        {
+            "docker-credentials": {
+                "%s": {
+                    "username": "%s",
+                    "password": "%s"
+                }
+            }
+        }`
+)
+
+func TestLaunchContainerWithRemoteSnapshotter_Isolated(t *testing.T) {
+	integtest.Prepare(t, integtest.WithDefaultNetwork())
+
+	vmID := 0
+
+	testTimeout := 300 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	launchContainerWithRemoteSnapshotterInVM(ctx, t, strconv.Itoa(vmID))
+}
+
+func TestLaunchMultipleContainersWithRemoteSnapshotter_Isolated(t *testing.T) {
+	integtest.Prepare(t, integtest.WithDefaultNetwork())
+
+	testTimeout := 600 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	numberOfVms := integtest.NumberOfVms
+	for vmID := 0; vmID < numberOfVms; vmID++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			launchContainerWithRemoteSnapshotterInVM(ctx, t, strconv.Itoa(id))
+		}(vmID)
+	}
+	wg.Wait()
+}
+
+func launchContainerWithRemoteSnapshotterInVM(ctx context.Context, t *testing.T, vmID string) {
+	// For integration testing, assume the namespace is same as the VM ID.
+	namespace := vmID
+
+	ctx = namespaces.WithNamespace(ctx, namespace)
+
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(integtest.FirecrackerRuntime))
+	require.NoError(t, err, "Unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
+
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
+	require.NoError(t, err, "Failed to create fccontrol client")
+
+	_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{
+		VMID: vmID,
+		RootDrive: &proto.FirecrackerRootDrive{
+			HostPath: "/var/lib/firecracker-containerd/runtime/rootfs-stargz.img",
+		},
+		NetworkInterfaces: []*proto.FirecrackerNetworkInterface{
+			{
+				AllowMMDS: true,
+				CNIConfig: &proto.CNIConfiguration{
+					NetworkName:   "fcnet",
+					InterfaceName: "veth0",
+				},
+			},
+		},
+		MachineCfg: &proto.FirecrackerMachineConfiguration{
+			VcpuCount:  1,
+			MemSizeMib: 1024,
+		},
+		ContainerCount: 1,
+	})
+	require.NoErrorf(t, err, "Failed to create microVM[%s]", vmID)
+	defer fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: vmID})
+
+	_, err = fcClient.SetVMMetadata(ctx, &proto.SetVMMetadataRequest{
+		VMID:     vmID,
+		Metadata: fmt.Sprintf(dockerMetadataTemplate, "ghcr.io", noAuth, noAuth),
+	})
+	require.NoError(t, err, "Failed to configure VM metadata for registry resolution")
+
+	image, err := client.Pull(ctx, imageRef,
+		containerd.WithPullUnpack,
+		containerd.WithPullSnapshotter(snapshotterName),
+		containerd.WithImageHandlerWrapper(source.AppendDefaultLabelsHandlerWrapper(imageRef, 10*1024*1024)),
+	)
+	require.NoError(t, err, "Failed to pull image for VM: %s", vmID)
+	defer client.ImageService().Delete(ctx, image.Name())
+
+	container, err := client.NewContainer(ctx, fmt.Sprintf("container-%s", vmID),
+		containerd.WithSnapshotter(snapshotterName),
+		containerd.WithNewSnapshot("snapshot", image),
+		containerd.WithNewSpec(
+			oci.WithProcessArgs("echo", "hello"),
+			oci.WithDefaultPathEnv,
+			firecrackeroci.WithVMLocalImageConfig(image),
+			firecrackeroci.WithVMID(vmID),
+			firecrackeroci.WithVMNetwork,
+		),
+	)
+	require.NoError(t, err, "Failed to create container in VM: %s", vmID)
+	defer container.Delete(ctx, containerd.WithSnapshotCleanup)
+
+	_, err = integtest.RunTask(ctx, container)
+	require.NoError(t, err, "Failed to run task in VM: %s", vmID)
+}

--- a/tools/docker/Dockerfile.integ-test
+++ b/tools/docker/Dockerfile.integ-test
@@ -11,22 +11,23 @@ ENV FICD_LOG_DIR="/var/log/firecracker-containerd-test"
 ENV FICD_CONTAINERD_OUTFILE="${FICD_LOG_DIR}/containerd.out"
 
 RUN apt-get update && apt-get install --yes --no-install-recommends \
-		build-essential \
-		ca-certificates \
-		curl \
-		git \
-		iptables \
-		iperf3 \
-		libdevmapper-dev \
-		libseccomp-dev \
-		rng-tools # used for rngtest
+  build-essential \
+  ca-certificates \
+  curl \
+  git \
+  iptables \
+  iperf3 \
+  libdevmapper-dev \
+  libseccomp-dev \
+  tcpdump \
+  rng-tools # used for rngtest
 
 RUN mkdir -p \
-    /var/run/firecracker-containerd \
-    /src \
-    /srv/firecracker_containerd_tests \
-    ${FICD_LOG_DIR} \
-    /etc/cni/net.d
+  /var/run/firecracker-containerd \
+  /src \
+  /srv/firecracker_containerd_tests \
+  ${FICD_LOG_DIR} \
+  /etc/cni/net.d
 
 RUN wget https://github.com/containerd/containerd/releases/download/v1.6.4/containerd-1.6.4-linux-amd64.tar.gz && \
   tar zxvf containerd-1.6.4-linux-amd64.tar.gz -C /tmp/ && \
@@ -68,7 +69,10 @@ RUN --mount=type=bind,target=/src make -C /src \
   install-default-runc-jailer-config \
   install-test-cni-bins \
   install-test-rootfs \
+  install-stargz-rootfs \
   demo-network
+
+RUN --mount=type=bind,target=/src make -C /src/snapshotter install
 
 COPY tools/docker/entrypoint.sh /entrypoint
 ENTRYPOINT ["/entrypoint"]

--- a/tools/docker/config.toml
+++ b/tools/docker/config.toml
@@ -1,3 +1,8 @@
 imports = ["/etc/containerd/snapshotter/*.toml", "/etc/containerd/cri/*.toml"]
 [grpc]
   address = "/run/firecracker-containerd/containerd.sock"
+
+[proxy_plugins]
+  [proxy_plugins.demux]
+    type = "snapshot"
+    address = "/var/lib/demux-snapshotter/snapshotter.sock"

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -40,8 +40,21 @@ version = 2
   level = "debug"
 EOF
 
+mkdir -p /etc/demux-snapshotter /var/lib/demux-snapshotter
+cat > /etc/demux-snapshotter/config.toml <<EOF
+[snapshotter.proxy.address.resolver]
+  type = "http"
+  address = "http://127.0.0.1:10001"
+
+[debug]
+  logLevel = "debug"
+EOF
+
 touch ${FICD_CONTAINERD_OUTFILE}
 chmod a+rw ${FICD_CONTAINERD_OUTFILE}
 /usr/local/bin/containerd --log-level debug &>> ${FICD_CONTAINERD_OUTFILE} &
+
+/usr/local/bin/http-address-resolver &>> ${FICD_LOG_DIR}/http-address-resolver.out &
+/usr/local/bin/demux-snapshotter &>> ${FICD_LOG_DIR}/demux-snapshotter.out &
 
 exec /bin/bash -c "$@"

--- a/tools/image-builder/files_stargz/etc/systemd/system/stargz-snapshotter.service
+++ b/tools/image-builder/files_stargz/etc/systemd/system/stargz-snapshotter.service
@@ -20,4 +20,4 @@ Requires=local-fs.target
 Type=simple
 ExecStartPre=/bin/mkdir -p /var/lib/containerd-stargz-grpc
 ExecStartPre=/bin/mount -t tmpfs -o noatime,mode=0755 stargz /var/lib/containerd-stargz-grpc
-ExecStart=/usr/local/bin/containerd-stargz-grpc
+ExecStart=/usr/local/bin/containerd-stargz-grpc --log-level=debug


### PR DESCRIPTION
*Issue #, if available:*
#595 

*Description of changes:*
Adds integration test to launch a task in using a remote snapshotter running inside the microVM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>