### PR TITLE
fix: cleanup of network devices for CNI tests

### DIFF
--- a/runtime/cni_integ_test.go
+++ b/runtime/cni_integ_test.go
@@ -64,7 +64,7 @@ func TestCNISupport_Isolated(t *testing.T) {
 		webpages[vmID] = fmt.Sprintf("Hello, my virtual machine %s\n", vmID)
 	}
 
-	localServices, err := internal.NewLocalNetworkServices(webpages)
+	localServices, err := internal.NewLocalNetworkServices(t, webpages)
 	require.NoError(t, err, "failed to create local network test services")
 
 	cniNetworkName := "fcnet-test"
@@ -170,7 +170,7 @@ func TestAutomaticCNISupport_Isolated(t *testing.T) {
 		webpages[taskID] = fmt.Sprintf("Hello, my task %s\n", taskID)
 	}
 
-	localServices, err := internal.NewLocalNetworkServices(webpages)
+	localServices, err := internal.NewLocalNetworkServices(t, webpages)
 	require.NoError(t, err, "failed to create local network test services")
 
 	cniNetworkName := "fcnet"


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
While running integration tests, I ran into issues with tests not cleaning up the devices on failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>