### PR TITLE
Add volume.FromImage

### DIFF
--- a/tools/docker/Dockerfile.integ-test
+++ b/tools/docker/Dockerfile.integ-test
@@ -46,7 +46,8 @@ RUN --mount=type=bind,target=/src \
   ln -sv /usr/local/bin/firecracker-ctr /usr/local/bin/ctr
 RUN containerd 2>/dev/null & \
   ctr --address /run/firecracker-containerd/containerd.sock content fetch docker.io/library/alpine:3.10.1 >/dev/null && \
-  ctr --address /run/firecracker-containerd/containerd.sock content fetch docker.io/mlabbe/iperf3:3.6-r0 >/dev/null
+  ctr --address /run/firecracker-containerd/containerd.sock content fetch docker.io/mlabbe/iperf3:3.6-r0 >/dev/null && \
+  ctr --address /run/firecracker-containerd/containerd.sock content fetch docker.io/library/postgres:14.3 >/dev/null
 
 # Install critest
 ENV VERSION="v1.23.0"

--- a/volume/image.go
+++ b/volume/image.go
@@ -1,0 +1,188 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/continuity/fs"
+	"github.com/hashicorp/go-multierror"
+	"github.com/opencontainers/image-spec/identity"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type imageVolumeProvider struct {
+	client      *containerd.Client
+	image       string
+	target      string
+	snapshotter string
+	snapshot    string
+}
+
+// ImageOpt allows setting optional properties of the provider.
+type ImageOpt func(*imageVolumeProvider)
+
+// WithSnapshotter sets the snapshotter to pull images.
+func WithSnapshotter(ss string) ImageOpt {
+	return func(p *imageVolumeProvider) {
+		p.snapshotter = ss
+	}
+}
+
+func getV1ImageConfig(ctx context.Context, image containerd.Image) (*v1.Image, error) {
+	var result v1.Image
+
+	ic, err := image.Config(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	switch ic.MediaType {
+	case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
+		p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(p, &result); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unknown type: %s", ic.MediaType)
+	}
+	return &result, nil
+}
+
+// FromImage returns a new provider to that expose the volumes on the given image.
+func FromImage(client *containerd.Client, image, snapshot string, opts ...ImageOpt) Provider {
+	p := imageVolumeProvider{
+		snapshotter: containerd.DefaultSnapshotter,
+		client:      client,
+		image:       image,
+		snapshot:    snapshot,
+	}
+
+	for _, opt := range opts {
+		opt(&p)
+	}
+
+	return &p
+}
+
+func (p *imageVolumeProvider) Name() string {
+	return p.image
+}
+
+func (p *imageVolumeProvider) Delete(ctx context.Context) error {
+	var retErr error
+
+	if p.target != "" {
+		retErr = mount.UnmountAll(p.target, 0)
+	}
+
+	ss := p.client.SnapshotService(p.snapshotter)
+	err := ss.Remove(ctx, p.snapshot)
+	if err != nil {
+		retErr = multierror.Append(retErr, err)
+	}
+	defer ss.Close()
+
+	return retErr
+}
+
+func (p *imageVolumeProvider) CreateVolumesUnder(ctx context.Context, tempDir string) ([]*Volume, error) {
+	image, err := p.client.GetImage(ctx, p.image)
+	if err != nil {
+		return nil, err
+	}
+
+	unpacked, err := image.IsUnpacked(ctx, p.snapshotter)
+	if err != nil {
+		return nil, err
+	}
+
+	if !unpacked {
+		err := image.Unpack(ctx, p.snapshotter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	config, err := getV1ImageConfig(ctx, image)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(config.Config.Volumes) == 0 {
+		return nil, nil
+	}
+
+	root, err := p.mountImage(ctx, tempDir)
+	if err != nil {
+		return nil, err
+	}
+	p.target = root
+
+	result := make([]*Volume, 0, len(config.Config.Volumes))
+	for path := range config.Config.Volumes {
+		hostPath, err := fs.RootPath(root, path)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, &Volume{hostPath: hostPath, containerPath: path})
+	}
+	return result, nil
+}
+
+func (p *imageVolumeProvider) mountImage(ctx context.Context, tempDir string) (string, error) {
+	image, err := p.client.GetImage(ctx, p.image)
+	if err != nil {
+		return "", err
+	}
+
+	ids, err := image.RootFS(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	parent := identity.ChainID(ids).String()
+
+	ss := p.client.SnapshotService(p.snapshotter)
+	mounts, err := ss.View(ctx, p.snapshot, parent, snapshots.WithLabels(map[string]string{
+		"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
+	}))
+	if err != nil {
+		return "", err
+	}
+	defer ss.Close()
+
+	target, err := os.MkdirTemp(tempDir, "mount")
+	if err != nil {
+		return "", err
+	}
+	err = mount.All(mounts, target)
+	if err != nil {
+		return "", err
+	}
+
+	return target, nil
+}

--- a/volume/set_test.go
+++ b/volume/set_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testProvider struct {
+	name string
+}
+
+func (p *testProvider) CreateVolumesUnder(ctx context.Context, path string) ([]*Volume, error) {
+	return nil, nil
+}
+func (p *testProvider) Delete(ctx context.Context) error {
+	return nil
+}
+func (p *testProvider) Name() string {
+	return p.name
+}
+
+func TestNewSet(t *testing.T) {
+	provider := &testProvider{name: "foobar"}
+
+	ctx := context.Background()
+	vs := NewSet("")
+	err := vs.AddFrom(ctx, provider)
+	require.NoError(t, err)
+}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -19,8 +19,9 @@ package volume
 
 // Volume is a special directory that could be shared between containers.
 type Volume struct {
-	name     string
-	hostPath string
+	name          string
+	hostPath      string
+	containerPath string
 }
 
 // New returns an empty volume.


### PR DESCRIPTION
OCI images can have multiple volumes. Orchestrators such as ECS import
the volumes from the images in addition to.

volume.FromImage() will be used to implement such a feature.

https://github.com/opencontainers/image-spec/blob/v1.0.2/config.md#properties
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html#bind-mount-examples

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
