### PR TITLE
refactor: integ test common code into internal package

### DIFF
--- a/internal/integtest/containerd.go
+++ b/internal/integtest/containerd.go
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integtest
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+)
+
+// CommandResult encapsulates the stdout, stderr, and exit code returned
+// from a task.
+type CommandResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode uint32
+}
+
+// RunTask is a utility function for running a task and returning the result.
+func RunTask(ctx context.Context, c containerd.Container) (*CommandResult, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	task, err := c.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, &stdout, &stderr)))
+	if err != nil {
+		return nil, err
+	}
+
+	exitCh, err := task.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = task.Start(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	select {
+	case exitStatus := <-exitCh:
+		if err := exitStatus.Error(); err != nil {
+			return nil, err
+		}
+
+		_, err := task.Delete(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return &CommandResult{
+			Stdout:   stdout.String(),
+			Stderr:   stderr.String(),
+			ExitCode: exitStatus.ExitCode(),
+		}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/internal/integtest/firecracker.go
+++ b/internal/integtest/firecracker.go
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integtest
+
+import "github.com/firecracker-microvm/firecracker-containerd/firecracker-control/client"
+
+// NewFCControlClient returns a Firecracker control client for the given socket.
+func NewFCControlClient(socket string) (*client.Client, error) {
+	return client.New(socket + ".ttrpc")
+}

--- a/internal/integtest/network.go
+++ b/internal/integtest/network.go
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integtest
+
+import (
+	"github.com/firecracker-microvm/firecracker-containerd/config"
+	"github.com/firecracker-microvm/firecracker-containerd/proto"
+)
+
+// WithDefaultNetwork is an option to use the default network configuration
+// in the runtime configuration for integration testing
+func WithDefaultNetwork() func(c *config.Config) {
+	return func(c *config.Config) {
+		c.DefaultNetworkInterfaces = []proto.FirecrackerNetworkInterface{
+			{
+				CNIConfig: &proto.CNIConfiguration{
+					NetworkName:   "fcnet",
+					InterfaceName: "veth0",
+				},
+			},
+		}
+	}
+}

--- a/internal/integtest/runtime.go
+++ b/internal/integtest/runtime.go
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integtest
+
+import (
+	"os"
+)
+
+const (
+	// FirecrackerRuntime is the Firecracker-containerd runtime
+	FirecrackerRuntime = "aws.firecracker"
+
+	containerdSockPathEnvVar = "CONTAINERD_SOCKET"
+)
+
+var (
+	// ContainerdSockPath is the default Firecracker-containerd socket path
+	ContainerdSockPath = "/run/firecracker-containerd/containerd.sock"
+)
+
+func init() {
+	if v := os.Getenv(containerdSockPathEnvVar); v != "" {
+		ContainerdSockPath = v
+	}
+}

--- a/runtime/benchmark_test.go
+++ b/runtime/benchmark_test.go
@@ -57,13 +57,13 @@ func createAndStopVM(
 }
 
 func benchmarkCreateAndStopVM(t *testing.T, vcpuCount uint32, kernelArgs string) {
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create fccontrol client")
 
 	request := proto.CreateVMRequest{

--- a/runtime/jailer_integ_test.go
+++ b/runtime/jailer_integ_test.go
@@ -94,8 +94,8 @@ func fsSafeTestName(tb testing.TB) string {
 func testJailer(t *testing.T, jailerConfig *proto.JailerConfig) {
 	require := require.New(t)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
@@ -140,7 +140,7 @@ func testJailer(t *testing.T, jailerConfig *proto.JailerConfig) {
 		require.NoError(err, "failed to chown %q", additionalDrive)
 	}
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(err)
 
 	_, err = fcClient.CreateVM(ctx, &request)
@@ -202,8 +202,8 @@ func TestJailerCPUSet_Isolated(t *testing.T) {
 
 func testAttachBlockDevice(t *testing.T, jailerConfig *proto.JailerConfig) {
 	require := require.New(t)
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
@@ -211,7 +211,7 @@ func testAttachBlockDevice(t *testing.T, jailerConfig *proto.JailerConfig) {
 	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(err, "failed to get alpine image")
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(err)
 
 	vmID := testNameToVMID(t.Name())

--- a/runtime/limits_integ_test.go
+++ b/runtime/limits_integ_test.go
@@ -32,8 +32,8 @@ func TestDiskLimit_Isolated(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	image, err := alpineImage(ctx, client, defaultSnapshotterName)
@@ -57,11 +57,11 @@ func TestDiskLimit_Isolated(t *testing.T) {
 		require.NoError(err, "failed to delete a container")
 	}()
 
-	result, err := runTask(ctx, container)
+	result, err := integtest.RunTask(ctx, container)
 	require.NoError(err, "failed to create a container")
 
-	assert.Equal(uint32(1), result.exitCode, "writing 2GB must fail")
+	assert.Equal(uint32(1), result.ExitCode, "writing 2GB must fail")
 	assert.Equal(`952+0 records in
 951+0 records out
-`, result.stderr, "but it must be able to write ~1024MB")
+`, result.Stderr, "but it must be able to write ~1024MB")
 }

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -76,22 +76,12 @@ const (
 
 	defaultBalloonMemory         = int64(66)
 	defaultStatsPollingIntervals = int64(1)
-
-	containerdSockPathEnvVar = "CONTAINERD_SOCKET"
 )
 
 var (
 	findShim        = findProcWithName(shimProcessName)
 	findFirecracker = findProcWithName(firecrackerProcessName)
-
-	containerdSockPath = "/run/firecracker-containerd/containerd.sock"
 )
-
-func init() {
-	if v := os.Getenv(containerdSockPathEnvVar); v != "" {
-		containerdSockPath = v
-	}
-}
 
 // Images are presumed by the isolated tests to have already been pulled
 // into the content store. This will just unpack the layers into an
@@ -123,8 +113,8 @@ func TestShimExitsUponContainerDelete_Isolated(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), defaultNamespace)
 
-	client, err := containerd.New(containerdSockPath)
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath)
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	image, err := alpineImage(ctx, client, defaultSnapshotterName)
@@ -299,8 +289,8 @@ func TestMultipleVMs_Isolated(t *testing.T) {
 
 	testCtx := namespaces.WithNamespace(context.Background(), defaultNamespace)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	image, err := alpineImage(testCtx, client, defaultSnapshotterName)
@@ -355,7 +345,7 @@ func TestMultipleVMs_Isolated(t *testing.T) {
 				MachineCfg: &proto.FirecrackerMachineConfiguration{MemSizeMib: 1024},
 			}
 
-			fcClient, err := newFCControlClient(containerdSockPath)
+			fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 			if err != nil {
 				return err
 			}
@@ -679,7 +669,7 @@ func TestLongUnixSocketPath_Isolated(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), namespace)
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create fccontrol client")
 
 	subtests := []struct {
@@ -771,8 +761,8 @@ func TestStubBlockDevices_Isolated(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	image, err := alpineImage(ctx, client, defaultSnapshotterName)
@@ -785,7 +775,7 @@ func TestStubBlockDevices_Isolated(t *testing.T) {
 	containerName := fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano())
 	snapshotName := fmt.Sprintf("%s-snapshot", containerName)
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create fccontrol client")
 
 	_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{
@@ -909,7 +899,7 @@ func testCreateContainerWithSameName(t *testing.T, vmID string) {
 
 	// Explicitly specify Container Count = 2 to workaround #230
 	if len(vmID) != 0 {
-		fcClient, err := newFCControlClient(containerdSockPath)
+		fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 		require.NoError(t, err, "failed to create fccontrol client")
 
 		_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{
@@ -921,8 +911,8 @@ func testCreateContainerWithSameName(t *testing.T, vmID string) {
 
 	withNewSpec := containerd.WithNewSpec(oci.WithProcessArgs("echo", "hello"), firecrackeroci.WithVMID(vmID), oci.WithDefaultPathEnv)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	image, err := alpineImage(ctx, client, defaultSnapshotterName)
@@ -997,8 +987,8 @@ func TestStubDriveReserveAndReleaseByContainers_Isolated(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	image, err := alpineImage(ctx, client, defaultSnapshotterName)
@@ -1047,10 +1037,10 @@ func TestDriveMount_Isolated(t *testing.T) {
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), testTimeout)
 	defer cancel()
 
-	ctrdClient, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	ctrdClient, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create fccontrol client")
 
 	image, err := alpineImage(ctx, ctrdClient, defaultSnapshotterName)
@@ -1221,7 +1211,7 @@ func TestDriveMountFails_Isolated(t *testing.T) {
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), testTimeout)
 	defer cancel()
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create fccontrol client")
 
 	testImgHostPath := internal.CreateFSImg(ctx, t, "ext4", internal.FSImgFile{
@@ -1286,11 +1276,11 @@ func TestUpdateVMMetadata_Isolated(t *testing.T) {
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), testTimeout)
 	defer cancel()
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create fccontrol client")
 
 	cniNetworkName := "fcnet-test"
@@ -1403,7 +1393,7 @@ func TestMemoryBalloon_Isolated(t *testing.T) {
 			defer deleteTapDevice(ctx, tapName)
 			require.NoError(t, err, "failed to create tap device for vm %d", vmID)
 
-			fcClient, err := newFCControlClient(containerdSockPath)
+			fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 			require.NoError(t, err, "failed to create fccontrol client")
 
 			_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{
@@ -1485,8 +1475,8 @@ func TestRandomness_Isolated(t *testing.T) {
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), defaultNamespace), 60*time.Second)
 	defer cancel()
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	image, err := alpineImage(ctx, client, defaultSnapshotterName)
@@ -1622,8 +1612,8 @@ func TestStopVM_Isolated(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
@@ -1760,7 +1750,7 @@ func TestStopVM_Isolated(t *testing.T) {
 		},
 	}
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(err)
 
 	for _, test := range tests {
@@ -1840,8 +1830,8 @@ func TestStopVM_Isolated(t *testing.T) {
 func TestExec_Isolated(t *testing.T) {
 	integtest.Prepare(t)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
@@ -1849,7 +1839,7 @@ func TestExec_Isolated(t *testing.T) {
 	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create ttrpc client")
 
 	vmID := testNameToVMID(t.Name())
@@ -1954,8 +1944,8 @@ func TestEvents_Isolated(t *testing.T) {
 	integtest.Prepare(t)
 	require := require.New(t)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
@@ -1970,7 +1960,7 @@ func TestEvents_Isolated(t *testing.T) {
 
 	vmID := testNameToVMID(t.Name())
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(err, "failed to create ttrpc client")
 
 	_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{VMID: vmID})
@@ -2037,8 +2027,8 @@ func findProcWithName(name string) func(context.Context, *process.Process) (bool
 func TestOOM_Isolated(t *testing.T) {
 	integtest.Prepare(t)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
@@ -2053,7 +2043,7 @@ func TestOOM_Isolated(t *testing.T) {
 
 	vmID := testNameToVMID(t.Name())
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create ttrpc client")
 
 	_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{VMID: vmID})
@@ -2128,13 +2118,13 @@ func requireNonEmptyFifo(t testing.TB, path string) {
 
 func TestCreateVM_Isolated(t *testing.T) {
 	integtest.Prepare(t)
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create ttrpc client")
 
 	type subtest struct {
@@ -2258,13 +2248,13 @@ func TestCreateVM_Isolated(t *testing.T) {
 func TestPauseResume_Isolated(t *testing.T) {
 	integtest.Prepare(t)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create ttrpc client")
 
 	subtests := []struct {
@@ -2380,8 +2370,8 @@ func TestPauseResume_Isolated(t *testing.T) {
 func TestAttach_Isolated(t *testing.T) {
 	integtest.Prepare(t)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
@@ -2483,8 +2473,8 @@ func (errorBuffer) Write(b []byte) (int, error) {
 func TestBrokenPipe_Isolated(t *testing.T) {
 	integtest.Prepare(t)
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(firecrackerRuntime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")

--- a/runtime/volume_integ_test.go
+++ b/runtime/volume_integ_test.go
@@ -55,14 +55,14 @@ func testVolumes(t *testing.T, runtime string) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
-	client, err := containerd.New(containerdSockPath, containerd.WithDefaultRuntime(runtime))
-	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", containerdSockPath)
+	client, err := containerd.New(integtest.ContainerdSockPath, containerd.WithDefaultRuntime(runtime))
+	require.NoError(t, err, "unable to create client to containerd service at %s, is containerd running?", integtest.ContainerdSockPath)
 	defer client.Close()
 
 	image, err := alpineImage(ctx, client, defaultSnapshotterName)
 	require.NoError(t, err, "failed to get alpine image")
 
-	fcClient, err := newFCControlClient(containerdSockPath)
+	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err, "failed to create fccontrol client")
 
 	// Make volumes.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactor common integ test functions to internal integtest package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>