### PR TITLE
Make TestMultipleVMs_Isolated less painful to run

### DIFF
--- a/.buildkite/al2_pipeline.yml
+++ b/.buildkite/al2_pipeline.yml
@@ -34,7 +34,7 @@ steps:
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
     env:
-      NUMBER_OF_VMS: "100"
+      NUMBER_OF_VMS: "10"
       EXTRAGOARGS: "-v -count=1 -timeout=1h"
     artifact_paths:
       - "runtime/logs/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,8 +97,8 @@ steps:
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
     env:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
-      NUMBER_OF_VMS: 100
-      EXTRAGOARGS: "-v -count=1 -race -timeout=1h"
+      NUMBER_OF_VMS: 50
+      EXTRAGOARGS: "-v -count=1 -race"
       FICD_DM_VOLUME_GROUP: fcci-vg
     artifact_paths:
       - "runtime/logs/*"


### PR DESCRIPTION
This commit makes the test less painful to run
- By reducing the number of VMs from 100 to 50
- By reducing the timeout to fail sooner


Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
