### PR TITLE
Fix unsafe map access in snapshotter cache

### DIFF
--- a/snapshotter/demux/cache/snapshotter_cache.go
+++ b/snapshotter/demux/cache/snapshotter_cache.go
@@ -37,7 +37,9 @@ func NewSnapshotterCache() *SnapshotterCache {
 
 // Get fetches and caches the snapshotter for a given key.
 func (cache *SnapshotterCache) Get(ctx context.Context, key string, fetch SnapshotterProvider) (*proxy.RemoteSnapshotter, error) {
+	cache.mutex.RLock()
 	snapshotter, ok := cache.snapshotters[key]
+	cache.mutex.RUnlock()
 
 	if !ok {
 		cache.mutex.Lock()
@@ -92,6 +94,8 @@ func (cache *SnapshotterCache) Evict(key string) error {
 // Close calls Close on all cached remote snapshotters.
 func (cache *SnapshotterCache) Close() error {
 	var compiledErr error
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
 	for _, remoteSnapshotter := range cache.snapshotters {
 		if err := remoteSnapshotter.Close(); err != nil {
 			compiledErr = multierror.Append(compiledErr, err)


### PR DESCRIPTION
I have been giving bad advice and suggesting that we don't use read locks in the snapshotter cache. Turns out this is unsafe and can cause runtime panics if we concurrently read and write the map.

https://go.dev/doc/faq#atomic_maps

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
