### PR TITLE
add: no namespace walk support to demux snapshotter

### DIFF
--- a/snapshotter/demux/cache/cache.go
+++ b/snapshotter/demux/cache/cache.go
@@ -16,6 +16,7 @@ package cache
 import (
 	"context"
 
+	"github.com/containerd/containerd/snapshots"
 	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/proxy"
 )
 
@@ -27,6 +28,9 @@ type Cache interface {
 	// Retrieves the snapshotter from the underlying cache using the provided
 	// fetch function if the snapshotter is not currently cached.
 	Get(ctx context.Context, key string, fetch SnapshotterProvider) (*proxy.RemoteSnapshotter, error)
+
+	// WalkAll applies the provided function across all cached snapshotters.
+	WalkAll(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error
 
 	// Closes the snapshotter and removes it from the cache.
 	Evict(key string) error

--- a/snapshotter/demux/cache/snapshotter_cache.go
+++ b/snapshotter/demux/cache/snapshotter_cache.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/containerd/containerd/snapshots"
 	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/proxy"
 	"github.com/hashicorp/go-multierror"
 )
@@ -54,6 +55,21 @@ func (cache *SnapshotterCache) Get(ctx context.Context, key string, fetch Snapsh
 		}
 	}
 	return snapshotter, nil
+}
+
+// WalkAll applies the provided function to all cached snapshotters.
+func (cache *SnapshotterCache) WalkAll(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error {
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
+
+	var allErr error
+
+	for namespace, snapshotter := range cache.snapshotters {
+		if err := snapshotter.Walk(ctx, fn, filters...); err != nil {
+			allErr = multierror.Append(allErr, fmt.Errorf("failed to walk function on snapshotter[%s]: %w", namespace, err))
+		}
+	}
+	return allErr
 }
 
 // Evict removes a cached snapshotter for a given key.

--- a/snapshotter/demux/snapshotter.go
+++ b/snapshotter/demux/snapshotter.go
@@ -243,7 +243,8 @@ func (s *Snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, filters .
 	contextLogger := log.G(ctx).WithField("function", "Walk")
 	namespace, err := getNamespaceFromContext(ctx, contextLogger)
 	if err != nil {
-		return err
+		contextLogger.Debug("no namespace found, proxying walk function to all cached snapshotters")
+		return s.cache.WalkAll(ctx, fn, filters...)
 	}
 	logger := contextLogger.WithField("namespace", namespace)
 

--- a/snapshotter/demux/snapshotter_test.go
+++ b/snapshotter/demux/snapshotter_test.go
@@ -73,6 +73,27 @@ func TestReturnErrorWhenCalledWithoutNamespacedContext(t *testing.T) {
 		{"View", func() error { _, err := uut.View(ctx, "layerKey", ""); return err }},
 		{"Commit", func() error { return uut.Commit(ctx, "layer1", "layerKey") }},
 		{"Remove", func() error { return uut.Remove(ctx, "layerKey") }},
+	}
+
+	for _, test := range tests {
+		if err := test.run(); err == nil {
+			t.Fatalf("%s call did not return error", test.name)
+		}
+	}
+}
+
+func TestNoErrorWhenCalledWithoutNamespacedContext(t *testing.T) {
+	t.Parallel()
+
+	cache := cache.NewSnapshotterCache()
+	ctx := logtest.WithT(context.Background(), t)
+
+	uut := NewSnapshotter(cache, fetchOkSnapshotter)
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
 		{"Walk", func() error {
 			var callback = func(c context.Context, i snapshots.Info) error { return nil }
 			return uut.Walk(ctx, callback)
@@ -80,8 +101,8 @@ func TestReturnErrorWhenCalledWithoutNamespacedContext(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if err := test.run(); err == nil {
-			t.Fatal(test.name + " call did not return error")
+		if err := test.run(); err != nil {
+			t.Fatalf("%s call returned error on no namespace execution", test.name)
 		}
 	}
 }
@@ -116,7 +137,7 @@ func TestReturnErrorWhenSnapshotterNotFound(t *testing.T) {
 
 	for _, test := range tests {
 		if err := test.run(); err == nil {
-			t.Fatal(test.name + " call did not return error")
+			t.Fatalf("%s call did not return error", test.name)
 		}
 	}
 }
@@ -153,7 +174,7 @@ func TestReturnErrorAfterProxyFunctionFailure(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name+"ProxyFailure", func(t *testing.T) {
 			if err := test.run(); err == nil {
-				t.Fatal(test.name + " call did not return error")
+				t.Fatalf("%s call did not return error", test.name)
 			}
 		})
 	}
@@ -191,7 +212,7 @@ func TestNoErrorIsReturnedOnSuccessfulProxyExecution(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name+"SuccessfulProxyCall", func(t *testing.T) {
 			if err := test.run(); err != nil {
-				t.Fatal(test.name + " call incorrectly returned an error")
+				t.Fatalf("%s call incorrectly returned an error", test.name)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*
#652 

*Description of changes:*
This PR adds the ability for no namespaced walks on the demux snapshotter to be broadcasted to all cached snapshotters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
