### PR TITLE
Exclude _submodules/firecracker from the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 tools/image-builder/rootfs/
 tmp/
+
+_submodules/firecracker/
+!_submodules/firecracker/build/kernel/linux-4.14/*.bin

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 FIRECRACKER_TARGET?=$(host_arch)-unknown-linux-musl
 
 FIRECRACKER_DIR=$(SUBMODULES)/firecracker
-FIRECRACKER_BIN=$(FIRECRACKER_DIR)/build/cargo_target/$(FIRECRACKER_TARGET)/release/firecracker
+FIRECRACKER_BIN=bin/firecracker
 FIRECRACKER_BUILDER_NAME?=firecracker-builder
 CARGO_CACHE_VOLUME_NAME?=cargocache
 
@@ -337,6 +337,7 @@ $(FIRECRACKER_DIR)/Cargo.toml:
 $(FIRECRACKER_BIN): $(FIRECRACKER_DIR)/Cargo.toml
 	$(FIRECRACKER_DIR)/tools/devtool -y build --release && \
 		$(FIRECRACKER_DIR)/tools/devtool strip
+	cp $(FIRECRACKER_DIR)/build/cargo_target/$(FIRECRACKER_TARGET)/release/firecracker $@
 
 .PHONY: firecracker-clean
 firecracker-clean:

--- a/tools/docker/Dockerfile.integ-test
+++ b/tools/docker/Dockerfile.integ-test
@@ -56,11 +56,12 @@ RUN wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION
   install -D -o root -g root -m755 -t /usr/local/bin /tmp/critest && \
   rm -f critest-$VERSION-linux-amd64.tar.gz /tmp/critest
 
+ADD bin/firecracker /usr/local/bin
+
 # Install everything we need in this image. Due to the bind-mount, if the host has already
 # up-to-date versions of everything built, this step will be a very quick copy
 RUN --mount=type=bind,target=/src make -C /src \
   install \
-  install-firecracker \
   install-runc \
   install-kernel \
   install-default-rootfs \


### PR DESCRIPTION
After having Linux kernel under, _submodules/firecracker is getting too
big to include in the build context.

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#understand-build-context

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
