### PR TITLE
fix: do not pass testing.T to goroutines in remote snapshotter tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,20 +73,6 @@ steps:
       - make test-in-docker
     timeout_in_minutes: 10
 
-  - label: ":running: snapshotter isolated tests"
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
-      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
-      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
-    env:
-      DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
-      NUMBER_OF_VMS: 10
-      EXTRAGOARGS: "-v -count=1 -race"
-    artifact_paths:
-      - "snapshotter/logs/*"
-    command:
-      - make -C snapshotter integ-test
-
   - label: ":running: runtime isolated tests"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
@@ -101,6 +87,26 @@ steps:
       - "runtime/logs/*"
     command:
       - make -C runtime integ-test FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_runtime
+
+  - wait
+
+  # Let's isolate the remote snapshotter integration tests.
+  # See https://github.com/firecracker-microvm/firecracker-containerd/issues/673
+  - label: ":running: snapshotter isolated tests"
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
+      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
+    env:
+      DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
+      NUMBER_OF_VMS: 10
+      EXTRAGOARGS: "-v -count=1 -race"
+    artifact_paths:
+      - "snapshotter/logs/*"
+    command:
+      - make -C snapshotter integ-test
+
+  - wait
 
   - label: ":weight_lifter: stress tests"
     concurrency_group: stress

--- a/snapshotter/service_integ_test.go
+++ b/snapshotter/service_integ_test.go
@@ -99,8 +99,13 @@ func launchContainerWithRemoteSnapshotterInVM(ctx context.Context, vmID string) 
 		return fmt.Errorf("Failed to create fccontrol client. [%v]", err)
 	}
 
+	// Disable 8250 serial device and lessen the number of log messages written to the serial console.
+	// https://github.com/firecracker-microvm/firecracker/blob/v1.1.0/docs/prod-host-setup.md
+	kernelArgs := integtest.DefaultRuntimeConfig.KernelArgs + " 8250.nr_uarts=0 quiet loglevel=1"
+
 	_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{
-		VMID: vmID,
+		VMID:       vmID,
+		KernelArgs: kernelArgs,
 		RootDrive: &proto.FirecrackerRootDrive{
 			HostPath: "/var/lib/firecracker-containerd/runtime/rootfs-stargz.img",
 		},
@@ -117,6 +122,7 @@ func launchContainerWithRemoteSnapshotterInVM(ctx context.Context, vmID string) 
 			VcpuCount:  1,
 			MemSizeMib: 1024,
 		},
+		TimeoutSeconds: 60,
 		ContainerCount: 1,
 	})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*

*Description of changes:*
As noted in #671, do not pass `*testing.T` to goroutines.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
