### PR TITLE
fix: remove snapshot cleanup from remote snapshotter integration test

### DIFF
--- a/snapshotter/service_integ_test.go
+++ b/snapshotter/service_integ_test.go
@@ -162,7 +162,7 @@ func launchContainerWithRemoteSnapshotterInVM(ctx context.Context, vmID string) 
 	if err != nil {
 		return fmt.Errorf("Failed to create container in VM: %s, [%v]", vmID, err)
 	}
-	defer container.Delete(ctx, containerd.WithSnapshotCleanup)
+	defer container.Delete(ctx)
 
 	_, err = integtest.RunTask(ctx, container)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*

*Description of changes:*
Removing snapshot cleanup from remote snapshotter integration tests. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
