### PR TITLE
add: remote snapshotter dialer timeouts to service config

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -88,10 +88,6 @@ steps:
     command:
       - make -C runtime integ-test FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_runtime
 
-  - wait
-
-  # Let's isolate the remote snapshotter integration tests.
-  # See https://github.com/firecracker-microvm/firecracker-containerd/issues/673
   - label: ":running: snapshotter isolated tests"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
@@ -100,15 +96,13 @@ steps:
     env:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
       NUMBER_OF_VMS: 10
-      EXTRAGOARGS: "-v -count=1 -race -timeout 3m"
+      EXTRAGOARGS: "-v -count=1 -race -timeout 5m"
       FICD_DM_VOLUME_GROUP: fcci-vg
     artifact_paths:
       - "snapshotter/logs/*"
     command:
       - make -C snapshotter integ-test FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_snapshotter
     timeout_in_minutes: 10
-
-  - wait
 
   - label: ":weight_lifter: stress tests"
     concurrency_group: stress

--- a/snapshotter/config/config.go
+++ b/snapshotter/config/config.go
@@ -43,7 +43,11 @@ type listener struct {
 }
 
 type dialer struct {
-	AckMsgTimeoutInSeconds int `toml:"ack_msg_timeout_in_seconds" default:"1"`
+	DialTimeout       string `toml:"dial_timeout" default:"100ms"`
+	RetryTimeout      string `toml:"retry_timeout" default:"10s"`
+	RetryInterval     string `toml:"retry_interval" default:"5s"`
+	ConnectMsgTimeout string `toml:"connect_msg_timeout" default:"500ms"`
+	AckMsgTimeout     string `toml:"ack_msg_timeout" default:"1s"`
 }
 
 type proxy struct {

--- a/snapshotter/config/config_test.go
+++ b/snapshotter/config/config_test.go
@@ -63,7 +63,11 @@ func defaultConfig() error {
 				Address: "/var/lib/demux-snapshotter/snapshotter.sock",
 			},
 			Dialer: dialer{
-				AckMsgTimeoutInSeconds: 1,
+				DialTimeout:       "100ms",
+				RetryTimeout:      "10s",
+				RetryInterval:     "5s",
+				ConnectMsgTimeout: "500ms",
+				AckMsgTimeout:     "1s",
 			},
 			Metrics: metrics{
 				Enable: false,
@@ -78,23 +82,27 @@ func defaultConfig() error {
 
 func parseExampleConfig() error {
 	fileContents := []byte(`
-	[snapshotter]
-	  [snapshotter.listener]
+    [snapshotter]
+      [snapshotter.listener]
 	    network = "unix"
 	    address = "/var/lib/demux-snapshotter/non-default-snapshotter.vsock"
-	  [snapshotter.dialer]
-	    ack_msg_timeout_in_seconds = 4
-	  [snapshotter.proxy.address.resolver]
-	    type = "http"
-	    address = "localhost:10001"
-	  [snapshotter.metrics]
+      [snapshotter.dialer]
+        dial_timeout = "250ms"
+        retry_timeout = "10s"
+        retry_interval = "5s"
+        connect_msg_timeout = "1s"
+        ack_msg_timeout = "2s"
+      [snapshotter.proxy.address.resolver]
+        type = "http"
+        address = "localhost:10001"
+      [snapshotter.metrics]
         enable = true
-		port_range = "9000-9999"
-		host = "0.0.0.0"
-		service_discovery_port = 8080
-	[debug]
-	  logLevel = "debug"
-	`)
+        port_range = "9000-9999"
+        host = "0.0.0.0"
+        service_discovery_port = 8080
+    [debug]
+      logLevel = "debug"
+    `)
 	expected := Config{
 		Snapshotter: snapshotter{
 			Listener: listener{
@@ -102,7 +110,11 @@ func parseExampleConfig() error {
 				Address: "/var/lib/demux-snapshotter/non-default-snapshotter.vsock",
 			},
 			Dialer: dialer{
-				AckMsgTimeoutInSeconds: 4,
+				DialTimeout:       "250ms",
+				RetryTimeout:      "10s",
+				RetryInterval:     "5s",
+				ConnectMsgTimeout: "1s",
+				AckMsgTimeout:     "2s",
 			},
 			Proxy: proxy{
 				Address: address{

--- a/snapshotter/service_integ_test.go
+++ b/snapshotter/service_integ_test.go
@@ -49,7 +49,7 @@ const (
 )
 
 func TestLaunchContainerWithRemoteSnapshotter_Isolated(t *testing.T) {
-	integtest.Prepare(t, integtest.WithDefaultNetwork())
+	integtest.Prepare(t)
 
 	vmID := 0
 	err := launchContainerWithRemoteSnapshotterInVM(context.Background(), strconv.Itoa(vmID))
@@ -57,7 +57,7 @@ func TestLaunchContainerWithRemoteSnapshotter_Isolated(t *testing.T) {
 }
 
 func TestLaunchMultipleContainersWithRemoteSnapshotter_Isolated(t *testing.T) {
-	integtest.Prepare(t, integtest.WithDefaultNetwork())
+	integtest.Prepare(t)
 
 	eg, ctx := errgroup.WithContext(context.Background())
 
@@ -89,13 +89,9 @@ func launchContainerWithRemoteSnapshotterInVM(ctx context.Context, vmID string) 
 		return fmt.Errorf("Failed to create fccontrol client. [%v]", err)
 	}
 
-	// Disable 8250 serial device and lessen the number of log messages written to the serial console.
-	// https://github.com/firecracker-microvm/firecracker/blob/v1.1.0/docs/prod-host-setup.md
-	kernelArgs := integtest.DefaultRuntimeConfig.KernelArgs + " 8250.nr_uarts=0 quiet loglevel=1"
-
 	_, err = fcClient.CreateVM(ctx, &proto.CreateVMRequest{
 		VMID:       vmID,
-		KernelArgs: kernelArgs,
+		KernelArgs: integtest.DefaultRuntimeConfig.KernelArgs,
 		RootDrive: &proto.FirecrackerRootDrive{
 			HostPath: "/var/lib/firecracker-containerd/runtime/rootfs-stargz.img",
 		},
@@ -104,7 +100,7 @@ func launchContainerWithRemoteSnapshotterInVM(ctx context.Context, vmID string) 
 				AllowMMDS: true,
 				CNIConfig: &proto.CNIConfiguration{
 					NetworkName:   "fcnet",
-					InterfaceName: "veth0",
+					InterfaceName: fmt.Sprintf("veth%s", vmID),
 				},
 			},
 		},
@@ -112,7 +108,6 @@ func launchContainerWithRemoteSnapshotterInVM(ctx context.Context, vmID string) 
 			VcpuCount:  1,
 			MemSizeMib: 1024,
 		},
-		TimeoutSeconds: 60,
 		ContainerCount: 1,
 	})
 	if err != nil {

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -43,7 +43,8 @@ EOF
 mkdir -p /etc/demux-snapshotter /var/lib/demux-snapshotter
 cat > /etc/demux-snapshotter/config.toml <<EOF
 [snapshotter.dialer]
-  ack_msg_timeout_in_seconds = 2
+  connect_msg_timeout = "1s"
+  ack_msg_timeout = "2s"
 
 [snapshotter.proxy.address.resolver]
   type = "http"


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*
#673 

*Description of changes:*
Expose all the dialer timeout knobs at the snapshotter service level. This enables tuning by users based on their host stability.

Buildkite instances used by the pipeline tend to be somewhat slower compared to developer instances, so this helps enable stabilizing remote snapshotter integration tests.

Additionally, remove some unneeded code from the remote snapshotter integration tests and make the tests run in parallel again to speed up the build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
