### PR TITLE
fix: fetch snapshotter proxy object without holding cache lock

### DIFF
--- a/snapshotter/demux/cache/snapshotter_cache.go
+++ b/snapshotter/demux/cache/snapshotter_cache.go
@@ -43,16 +43,18 @@ func (cache *SnapshotterCache) Get(ctx context.Context, key string, fetch Snapsh
 
 	if !ok {
 		cache.mutex.Lock()
-		defer cache.mutex.Unlock()
-
 		snapshotter, ok = cache.snapshotters[key]
+		cache.mutex.Unlock()
+
 		if !ok {
 			newSnapshotter, err := fetch(ctx, key)
 			if err != nil {
 				return nil, err
 			}
 
+			cache.mutex.Lock()
 			cache.snapshotters[key] = newSnapshotter
+			cache.mutex.Unlock()
 			snapshotter = newSnapshotter
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*
None

*Description of changes:*
`fetch` operation should not occur while the cache lock is held.

This unblocks snapshot requests whom have dialed their microVM to continue in the edge case where the lock has been acquired by a slow dialer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
