### PR TITLE
prepareBindMounts must not modify files outside of the jail

### DIFF
--- a/runtime/runc_jailer.go
+++ b/runtime/runc_jailer.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/continuity/fs"
 	"github.com/containerd/go-runc"
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -144,7 +145,11 @@ func (j *runcJailer) prepareBindMounts(mounts []*proto.FirecrackerDriveMount) er
 		// Only bindMount regular file.
 		// To avoid duplicate files, for block device, we will use system call to create device file for it.
 		if stat.Mode&syscall.S_IFMT == syscall.S_IFREG {
-			err := j.bindMountFileToJail(m.HostPath, filepath.Join(j.RootPath(), m.HostPath))
+			dest, err := fs.RootPath(j.RootPath(), m.HostPath)
+			if err != nil {
+				return err
+			}
+			err = j.bindMountFileToJail(m.HostPath, dest)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Since m.HostPath could take arbitrary strings, the result of
filepath.Join() could point files outside of the jail (j.RootPath).

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
