### PR TITLE
fix: tune vsock dial for buildkite hosts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -88,10 +88,6 @@ steps:
     command:
       - make -C runtime integ-test FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_runtime
 
-  - wait
-
-  # Let's isolate the remote snapshotter integration tests.
-  # See https://github.com/firecracker-microvm/firecracker-containerd/issues/673
   - label: ":running: snapshotter isolated tests"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
@@ -107,8 +103,6 @@ steps:
     command:
       - make -C snapshotter integ-test FICD_DM_POOL=build_${BUILDKITE_BUILD_NUMBER}_snapshotter
     timeout_in_minutes: 10
-
-  - wait
 
   - label: ":weight_lifter: stress tests"
     concurrency_group: stress

--- a/snapshotter/app/service.go
+++ b/snapshotter/app/service.go
@@ -177,9 +177,12 @@ func initSnapshotter(ctx context.Context, config config.Config, cache cache.Cach
 			return nil, err
 		}
 
-		ackMsgTimeout := time.Duration(config.Snapshotter.Dialer.AckMsgTimeoutInSeconds) * time.Second
+		// TODO: https://github.com/firecracker-microvm/firecracker-containerd/issues/689
 		snapshotterDialer := func(ctx context.Context, namespace string) (net.Conn, error) {
-			return vsock.DialContext(ctx, host, uint32(port), vsock.WithLogger(log.G(ctx)), vsock.WithAckMsgTimeout(ackMsgTimeout))
+			return vsock.DialContext(ctx, host, uint32(port), vsock.WithLogger(log.G(ctx)),
+				vsock.WithAckMsgTimeout(2*time.Second),
+				vsock.WithRetryInterval(200*time.Millisecond),
+			)
 		}
 
 		var metricsProxy *metrics.Proxy

--- a/snapshotter/config/config.go
+++ b/snapshotter/config/config.go
@@ -32,7 +32,6 @@ type Config struct {
 
 type snapshotter struct {
 	Listener listener `toml:"listener"`
-	Dialer   dialer   `toml:"dialer"`
 	Proxy    proxy    `toml:"proxy"`
 	Metrics  metrics  `toml:"metrics"`
 }
@@ -40,10 +39,6 @@ type snapshotter struct {
 type listener struct {
 	Network string `toml:"network" default:"unix"`
 	Address string `toml:"address" default:"/var/lib/demux-snapshotter/snapshotter.sock"`
-}
-
-type dialer struct {
-	AckMsgTimeoutInSeconds int `toml:"ack_msg_timeout_in_seconds" default:"1"`
 }
 
 type proxy struct {

--- a/snapshotter/config/config_test.go
+++ b/snapshotter/config/config_test.go
@@ -62,9 +62,6 @@ func defaultConfig() error {
 				Network: "unix",
 				Address: "/var/lib/demux-snapshotter/snapshotter.sock",
 			},
-			Dialer: dialer{
-				AckMsgTimeoutInSeconds: 1,
-			},
 			Metrics: metrics{
 				Enable: false,
 			},
@@ -82,8 +79,6 @@ func parseExampleConfig() error {
 	  [snapshotter.listener]
 	    network = "unix"
 	    address = "/var/lib/demux-snapshotter/non-default-snapshotter.vsock"
-	  [snapshotter.dialer]
-	    ack_msg_timeout_in_seconds = 4
 	  [snapshotter.proxy.address.resolver]
 	    type = "http"
 	    address = "localhost:10001"
@@ -100,9 +95,6 @@ func parseExampleConfig() error {
 			Listener: listener{
 				Network: "unix",
 				Address: "/var/lib/demux-snapshotter/non-default-snapshotter.vsock",
-			},
-			Dialer: dialer{
-				AckMsgTimeoutInSeconds: 4,
 			},
 			Proxy: proxy{
 				Address: address{

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -42,9 +42,6 @@ EOF
 
 mkdir -p /etc/demux-snapshotter /var/lib/demux-snapshotter
 cat > /etc/demux-snapshotter/config.toml <<EOF
-[snapshotter.dialer]
-  ack_msg_timeout_in_seconds = 2
-
 [snapshotter.proxy.address.resolver]
   type = "http"
   address = "http://127.0.0.1:10001"


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*
#673 

*Description of changes:*
Tune vsock dial based on Buildkite host performance. Should be made more robust by #689 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
