### PR TITLE
Do not wait for vm ready during shim clean up

### DIFF
--- a/runtime/service.go
+++ b/runtime/service.go
@@ -1671,12 +1671,6 @@ func (s *service) Wait(requestCtx context.Context, req *taskAPI.WaitRequest) (*t
 func (s *service) Cleanup(requestCtx context.Context) (*taskAPI.DeleteResponse, error) {
 	defer logPanicAndDie(log.G(requestCtx))
 
-	err := s.waitVMReady()
-	if err != nil {
-		s.logger.WithError(err).Error()
-		return nil, err
-	}
-
 	log.G(requestCtx).Debug("cleanup")
 	// Destroy VM/etc here?
 	// copied from runcs impl, nothing to cleanup atm


### PR DESCRIPTION
Signed-off-by: Henry Wang <henwang@amazon.com>

Do not wait for vm ready during shim clean up.

*Description of changes:*

Sample log lines:

```
ul 22 19:53:50 ip-10-194-10-130 firecracker-containerd: time="2022-07-22T19:53:50.067507228Z" level=error msg="failed to delete" cmd="/usr/sbin/containerd-shim-aws-firecracker -namespace TestSchema1Image
Manifest1658519613 -address /run/firecracker-containerd/containerd.sock -publish-binary /usr/sbin/firecracker-containerd -id TestSchema1ImageManifest-3684275467 -bundle /run/firecracker-containerd/io.cont
ainerd.runtime.v2.task/TestSchema1ImageManifest1658519613/TestSchema1ImageManifest-3684275467 delete" error="exit status 1"
Jul 22 19:53:50 ip-10-194-10-130 firecracker-containerd: time="2022-07-22T19:53:50.067562517Z" level=warning msg="failed to clean up after shim disconnected" error="aws.firecracker: rpc error: code = Dead
lineExceeded desc = timed out waiting for VM start\n: exit status 1" id=TestSchema1ImageManifest-3684275467 namespace=TestSchema1ImageManifest1658519613
```

It's caused by a failure in fccd's [clean up routine](https://github.com/firecracker-microvm/firecracker-containerd/blob/main/runtime/service.go#L1674). The failure is due to timeout on receiving VM ready event. This routine is invoked by containerd [here](https://github.com/containerd/containerd/blob/main/runtime/v2/binary.go#L157), invoked in the following manner:

```
/usr/sbin/containerd-shim-aws-firecracker -namespace TestSchema1ImageManifest1658517639 -address /run/firecracker-containerd/containerd.sock -publish-binary /usr/sbin/firecracker-containerd -id TestSchema1ImageManifest-3684275467 -bundle /run/firecracker-containerd/io.containerd.runtime.v2.task/TestSchema1ImageManifest1658517639/TestSchema1ImageManifest-3684275467 delete
```

The problem here is that the clean up logic is invoked as a separate process, which does not start a VM, therefore the clean up process will never receive a VM ready event. Furthermore, the clean up routine is basically a noop, so i doubt the necessity of the extra waiting on vm ready event. I think it should be removed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
