### PR TITLE
add gcc to quickstart yum packages and getting started prerequisites

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,6 +38,7 @@ You need to have the following things in order to use firecracker-containerd:
 
   </details>
 * git
+* gcc, required by the Firecracker agent for building
 * A recent installation of [Docker CE](https://docker.com).
 * Go 1.16 or later, which you can download from [here](https://golang.org/dl/).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,7 +84,8 @@ sudo yum -y install \
   e2fsprogs \
   util-linux \
   bc \
-  gnupg
+  gnupg \
+  gcc
 
 
 # Amazon Linux 2 packages can sometimes be dated, so let's install using


### PR DESCRIPTION
Signed-off-by: Gavin Inglis <giinglis@amazon.com>

*Issue #, if available:*

n/a

*Description of changes:*

Noticed in going through the firecracker-containerd quickstart for Amazon Linux that by
default, gcc is not installed. add that as a yum package to be
installed. Just copy-pasting as is will run into an error of gcc not found.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
