### PR TITLE
Downgrading rootfs from bookworm to bullseye

### DIFF
--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -46,7 +46,7 @@ define run_debootstrap =
 	debootstrap \
 		--variant=minbase \
 		--include=$(subst $(SPACE),$(COMMA),$(PACKAGES))\
-		bookworm \
+		bullseye \
 		"$(WORKDIR)" $(DEBMIRROR)
 	rm -rf "$(WORKDIR)/var/cache/apt/archives" \
 	       "$(WORKDIR)/usr/share/doc" \


### PR DESCRIPTION
Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>

*Issue:*
Kernel is panicking and not syncing with AMD instance while working with firecracker-containerd.
*Description of changes:*
During performing sanity checks on Firecracker-containerd, the AMD ec2 instance got failed. It is due to panicking of kernel and systemd causes segmentation fault while pulling an image. Then we downgraded the Debian version of rootfs from bokworm to bullseye to work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
