### PR TITLE
Upgrade golangci-lint to v1.50.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ tidy:
 	./tools/tidy.sh
 
 $(BINPATH)/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(BINPATH) v1.46.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(BINPATH) v1.50.1
 	$(BINPATH)/golangci-lint --version
 
 $(BINPATH)/git-validation:


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*

*Description of changes:*
Upgrades golangci-lint to v1.50.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
