### PR TITLE
Upgrade golangci-lint to v1.48.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ tidy:
 	./tools/tidy.sh
 
 $(BINPATH)/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(BINPATH) v1.46.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(BINPATH) v1.48.0
 	$(BINPATH)/golangci-lint --version
 
 $(BINPATH)/git-validation:

--- a/internal/vm/oci.go
+++ b/internal/vm/oci.go
@@ -82,7 +82,8 @@ func updateUserInSpec(ctx context.Context, s *specs.Spec, rootfsMount mount.Moun
 
 // withUser sets the user to be used within the container.
 // It accepts a valid user string in OCI Image Spec v1.0.0:
-//   user, uid, user:group, uid:gid, uid:group, user:gid
+//
+// user, uid, user:group, uid:gid, uid:group, user:gid
 func withUser(ctx context.Context, s *specs.Spec, rootfsMount mount.Mount, userstr string) error {
 	parts := strings.Split(userstr, ":")
 	switch len(parts) {

--- a/runtime/cpuset/cpuset_builder.go
+++ b/runtime/cpuset/cpuset_builder.go
@@ -23,31 +23,32 @@ import (
 // cpuset.mems
 //
 // Example:
-//	cset := cpuset.Builder{}.
-//		AddCPU(0).
-//		AddMemRange(0).
-//		Build()
 //
-//	fcClient, err := fcclient.New(containerdTTRPCAddress)
-//	if err != nil {
-//		return err
-//	}
+//		cset := cpuset.Builder{}.
+//	     			AddCPU(0).
+//	     			AddMemRange(0).
+//	     			Build()
 //
-//	defer fcClient.Close()
+//		fcClient, err := fcclient.New(containerdTTRPCAddress)
+//		if err != nil {
+//		    return err
+//		}
 //
-//	vmID := "cpuset-builder-example"
-//	createVMRequest := &proto.CreateVMRequest{
-//		VMID: vmID,
-//		JailerConfig: proto.JailerConfig{
-//			CPUs: cset.CPUs(),
-//			Mems: cset.Mems(),
-//		},
-//	}
+//		defer fcClient.Close()
 //
-//	_, err = fcClient.CreateVM(ctx, createVMRequest)
-//	if err != nil {
-//      return fmt.Errorf("failed to create VM: %w", err)
-//	}
+//		vmID := "cpuset-builder-example"
+//		createVMRequest := &proto.CreateVMRequest{
+//		    VMID: vmID,
+//		    JailerConfig: proto.JailerConfig{
+//		        CPUs: cset.CPUs(),
+//		        Mems: cset.Mems(),
+//		    },
+//		}
+//
+//		_, err = fcClient.CreateVM(ctx, createVMRequest)
+//		if err != nil {
+//		    return fmt.Errorf("failed to create VM: %w", err)
+//		}
 type Builder struct {
 	cpus      []int
 	cpuRanges []_range

--- a/snapshotter/demux/metrics/discovery/service_discovery.go
+++ b/snapshotter/demux/metrics/discovery/service_discovery.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/containerd/containerd/log"
 	"github.com/firecracker-microvm/firecracker-containerd/snapshotter/demux/cache"
@@ -37,7 +38,8 @@ type ServiceDiscovery struct {
 func NewServiceDiscovery(host string, port int, c *cache.RemoteSnapshotterCache) *ServiceDiscovery {
 	return &ServiceDiscovery{
 		server: &http.Server{
-			Addr: host + ":" + strconv.Itoa(port),
+			Addr:              host + ":" + strconv.Itoa(port),
+			ReadHeaderTimeout: 2 * time.Second,
 		},
 		cache: c,
 	}

--- a/snapshotter/demux/metrics/proxy.go
+++ b/snapshotter/demux/metrics/proxy.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/containerd/containerd/log"
 )
@@ -143,8 +144,9 @@ func (mp *Proxy) Serve(ctx context.Context) error {
 	mux.HandleFunc("/metrics", mp.metrics)
 
 	mp.server = &http.Server{
-		Addr:    mp.host + ":" + strconv.Itoa(mp.Port),
-		Handler: mux,
+		Addr:              mp.host + ":" + strconv.Itoa(mp.Port),
+		Handler:           mux,
+		ReadHeaderTimeout: 2 * time.Second,
 	}
 
 	err := mp.server.ListenAndServe()

--- a/snapshotter/internal/http_address_resolver.go
+++ b/snapshotter/internal/http_address_resolver.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/containerd/containerd/namespaces"
 	"github.com/sirupsen/logrus"
@@ -56,10 +57,11 @@ func init() {
 // curl -X GET "http://localhost:10001/address?namespace=ns-1"
 //
 // Response:
-// {
-//     "network": "unix",
-//     "address": "/var/lib/firecracker-containerd/shim-base/default#cbfad871-0862-4dd6-ae7a-52e9b1c16ede/firecracker.vsock"
-// }
+//
+//	{
+//	    "network": "unix",
+//	    "address": "/var/lib/firecracker-containerd/shim-base/default#cbfad871-0862-4dd6-ae7a-52e9b1c16ede/firecracker.vsock"
+//	}
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -77,7 +79,8 @@ func main() {
 
 	http.HandleFunc("/address", queryAddress)
 	httpServer := &http.Server{
-		Addr: fmt.Sprintf("127.0.0.1:%d", port),
+		Addr:              fmt.Sprintf("127.0.0.1:%d", port),
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	logger.Info(fmt.Sprintf("http resolver serving at port %d", port))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Go 1.19 support was added in golangci-lint v1.48.0. Resolves new warnings from gofmt and gosec.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>
