### PR TITLE
Support cgroup v2

### DIFF
--- a/runtime/integ_test.go
+++ b/runtime/integ_test.go
@@ -13,6 +13,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/firecracker-microvm/firecracker-containerd/internal"
@@ -37,4 +39,16 @@ var testNameToVMIDReplacer = strings.NewReplacer("/", "-", "_", "-")
 
 func testNameToVMID(s string) string {
 	return testNameToVMIDReplacer.Replace(s)
+}
+
+func cgroupExists(name string) bool {
+	// cgroups v1
+	_, err := os.Stat(filepath.Join("/sys/fs/cgroup/cpu", name))
+	if err == nil {
+		return true
+	}
+
+	// cgroups v2
+	_, err = os.Stat(filepath.Join("/sys/fs/cgroup", name))
+	return err == nil
 }

--- a/runtime/jailer_integ_test.go
+++ b/runtime/jailer_integ_test.go
@@ -40,21 +40,28 @@ const (
 	jailerGID = 300001
 )
 
+func assertEmptyShimDir(tb testing.TB, ns, vmID string) {
+	_, err := os.Stat(filepath.Join(integtest.ShimBaseDir(), ns+"#"+vmID))
+	assert.Error(tb, err)
+	assert.True(tb, os.IsNotExist(err))
+
+	shimContents, err := os.ReadDir(integtest.ShimBaseDir())
+	require.NoError(tb, err)
+	assert.Len(tb, shimContents, 0)
+}
+
 func TestJailer_Isolated(t *testing.T) {
 	integtest.Prepare(t)
 	t.Run("Without Jailer", func(t *testing.T) {
-		t.Parallel()
 		testJailer(t, nil)
 	})
 	t.Run("With Jailer", func(t *testing.T) {
-		t.Parallel()
 		testJailer(t, &proto.JailerConfig{
 			UID: jailerUID,
 			GID: jailerGID,
 		})
 	})
 	t.Run("With Jailer and bind-mount", func(t *testing.T) {
-		t.Parallel()
 		testJailer(t, &proto.JailerConfig{
 			UID:               jailerUID,
 			GID:               jailerGID,
@@ -66,18 +73,15 @@ func TestJailer_Isolated(t *testing.T) {
 func TestAttachBlockDevice_Isolated(t *testing.T) {
 	integtest.Prepare(t)
 	t.Run("Without Jailer", func(t *testing.T) {
-		t.Parallel()
 		testAttachBlockDevice(t, nil)
 	})
 	t.Run("With Jailer", func(t *testing.T) {
-		t.Parallel()
 		testAttachBlockDevice(t, &proto.JailerConfig{
 			UID: jailerUID,
 			GID: jailerGID,
 		})
 	})
 	t.Run("With Jailer and bind-mount", func(t *testing.T) {
-		t.Parallel()
 		testAttachBlockDevice(t, &proto.JailerConfig{
 			UID:               jailerUID,
 			GID:               jailerGID,
@@ -178,13 +182,7 @@ func testJailer(t *testing.T, jailerConfig *proto.JailerConfig) {
 	_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: vmID})
 	require.NoError(t, err)
 
-	_, err = os.Stat(filepath.Join(integtest.ShimBaseDir(), "default#"+vmID))
-	assert.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
-
-	shimContents, err := os.ReadDir(integtest.ShimBaseDir())
-	require.NoError(t, err)
-	assert.Len(t, shimContents, 0)
+	assertEmptyShimDir(t, "default", vmID)
 }
 
 func TestJailerCPUSet_Isolated(t *testing.T) {
@@ -288,11 +286,5 @@ func testAttachBlockDevice(tb testing.TB, jailerConfig *proto.JailerConfig) {
 	_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: vmID})
 	require.NoError(tb, err)
 
-	_, err = os.Stat(filepath.Join(integtest.ShimBaseDir(), "default#"+vmID))
-	assert.Error(tb, err)
-	assert.True(tb, os.IsNotExist(err))
-
-	shimContents, err := os.ReadDir(integtest.ShimBaseDir())
-	require.NoError(tb, err)
-	assert.Len(tb, shimContents, 0)
+	assertEmptyShimDir(tb, "default", vmID)
 }

--- a/runtime/jailer_integ_test.go
+++ b/runtime/jailer_integ_test.go
@@ -140,8 +140,12 @@ func testJailer(t *testing.T, jailerConfig *proto.JailerConfig) {
 	fcClient, err := integtest.NewFCControlClient(integtest.ContainerdSockPath)
 	require.NoError(t, err)
 
-	_, err = fcClient.CreateVM(ctx, &request)
+	resp, err := fcClient.CreateVM(ctx, &request)
 	require.NoError(t, err)
+
+	if jailerConfig != nil {
+		assert.True(t, cgroupExists(resp.CgroupPath))
+	}
 
 	c, err := client.NewContainer(ctx,
 		vmID+"-container",

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -612,9 +612,8 @@ func testMultipleExecs(
 		if err != nil {
 			return err
 		}
-		_, err = os.Stat(filepath.Join("/sys/fs/cgroup/cpu", cgroupPath))
-		if err != nil {
-			return err
+		if !cgroupExists(cgroupPath) {
+			return fmt.Errorf("failed to find %q", cgroupPath)
 		}
 
 		ok, err := regexp.Match(".+/"+vmIDStr, []byte(cgroupPath))


### PR DESCRIPTION
Some of our tests are assuming cgroups v1, but our BuildKite hosts are
now using cgroups v2.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
