### PR TITLE
build and push esgz image for all platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,8 +431,8 @@ DEFAULT_BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:latest
 DEFAULT_ESGZ_IMAGE=ghcr.io/firecracker-microvm/firecracker-containerd/amazonlinux:latest-esgz
 .PHONY: esgz-test-image push-esgz-test-image
 esgz-test-image: stargz-snapshotter
-	$(CTR_REMOTE_BIN) image pull $(DEFAULT_BASE_IMAGE)
-	$(CTR_REMOTE_BIN) image optimize --oci $(DEFAULT_BASE_IMAGE) $(DEFAULT_ESGZ_IMAGE)
+	$(CTR_REMOTE_BIN) image pull --all-platforms $(DEFAULT_BASE_IMAGE)
+	$(CTR_REMOTE_BIN) image optimize --all-platforms --oci $(DEFAULT_BASE_IMAGE) $(DEFAULT_ESGZ_IMAGE)
 
 push-esgz-test-image:
 	$(CTR_REMOTE_BIN) image push -u $(GH_USER):$(GH_PERSONAL_ACCESS_TOKEN) $(DEFAULT_ESGZ_IMAGE) $(DEFAULT_ESGZ_IMAGE)


### PR DESCRIPTION


Signed-off-by: Gavin Inglis <giinglis@amazon.com>

*Issue #, if available:*

Closes #723 

*Description of changes:*

As the project's BuildKite infrastructure is expanding to test against the ARM architecture, the image used for remote snapshotter testing will need to be built for ARM. By pulling the image and optimizing with the --all-platforms flag, we can provide ARM support.

The image can be found at https://github.com/orgs/firecracker-microvm/packages/container/package/firecracker-containerd%2Famazonlinux. 

*Testing*

I followed the guide in https://github.com/firecracker-microvm/firecracker-containerd/tree/main/snapshotter/demux to build and push the image. 

I pulled the esgz image, ref `ghcr.io/firecracker-microvm/firecracker-containerd/amazonlinux:latest-esgz`, and ensured the arm platform was present in the image manifest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
