### PR TITLE
Use Debian 11 (bullseye) everywhere

### DIFF
--- a/.buildkite/al2_pipeline.yml
+++ b/.buildkite/al2_pipeline.yml
@@ -24,7 +24,7 @@ steps:
       FICD_DM_VOLUME_GROUP: "fcci-vg"
     command:
       - ./.buildkite/setup_al2.sh
-      - docker run --rm -v $PWD:/mnt debian:buster-slim rm -rf /mnt/tools/image-builder/rootfs
+      - docker run --rm -v $PWD:/mnt debian:bullseye-slim rm -rf /mnt/tools/image-builder/rootfs
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,7 @@ steps:
       EXTRAGOARGS: "-race"
     command:
       - make test-images
-      - docker run --rm -v $PWD:/mnt debian:buster-slim rm -rf /mnt/tools/image-builder/rootfs
+      - docker run --rm -v $PWD:/mnt debian:bullseye-slim rm -rf /mnt/tools/image-builder/rootfs
       - sudo install -d -o root -g buildkite-agent -m 775 "/local/artifacts/$BUILDKITE_BUILD_NUMBER"
       - cp tools/image-builder/rootfs.img "/local/artifacts/$BUILDKITE_BUILD_NUMBER/"
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SUBMODULES=_submodules
 UID:=$(shell id -u)
 GID:=$(shell id -g)
 
-FIRECRACKER_CONTAINERD_BUILDER_IMAGE?=golang:1.17-buster
+FIRECRACKER_CONTAINERD_BUILDER_IMAGE?=golang:1.17-bullseye
 export FIRECRACKER_CONTAINERD_TEST_IMAGE?=localhost/firecracker-containerd-test
 export GO_CACHE_VOLUME_NAME?=gocache
 

--- a/tools/docker/Dockerfile.integ-test
+++ b/tools/docker/Dockerfile.integ-test
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:experimental
 # Test image that starts up containerd and the devmapper snapshotter. The default CMD will drop to a bash shell. Overrides
 # to CMD will be provided appended to /bin/bash -c
-FROM golang:1.17-stretch
+FROM golang:1.17-bullseye
 ENV PATH="/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/go/bin"
 ENV INSTALLROOT="/usr/local"
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libdevmapper-dev \
   libseccomp-dev \
   tcpdump \
+  iproute2 \
   rng-tools # used for rngtest
 
 RUN mkdir -p \

--- a/tools/image-builder/Dockerfile.debian-image
+++ b/tools/image-builder/Dockerfile.debian-image
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \


### PR DESCRIPTION
We don't have to mix Debian 9 (stretch), 10 (buster) and 11 (bullseye).

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
