### PR TITLE
Make agent static build the default for host build as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TEST_SUBDIRS:=$(addprefix test-,$(SUBDIRS))
 INTEG_TEST_SUBDIRS:=$(addprefix integ-test-,$(SUBDIRS))
 
 export INSTALLROOT?=/usr/local
-export STATIC_AGENT
+export STATIC_AGENT=on
 
 export DOCKER_IMAGE_TAG?=latest
 


### PR DESCRIPTION
*Issue #472*

*Description of changes:*
Change the default agent build type when done on host to static as is done when using Docker. This will ensure that people have a working version of the agent when building the microVM image.

The build can still be turned back to dynamic by calling `make STATIC_AGENT=`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
