### PR TITLE
[WPI]Fix broken CI

### DIFF
--- a/.buildkite/al2_pipeline.yml
+++ b/.buildkite/al2_pipeline.yml
@@ -12,7 +12,15 @@
 # permissions and limitations under the License.
 
 steps:
-
+  # Add the step to better know the environment running on
+  - label: ':ec2: show environment'
+    command:
+      - uname -a
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
+      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
+      
   - label: ":docker: Build"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,11 +23,11 @@ steps:
       EXTRAGOARGS: "-race"
     command:
       - uname -a
+      - pwd
+      - whoami
       - docker build -t localhost/runc-builder:80 -f tools/docker/Dockerfile.runc-builder tools/
-      - make test-images
-      - docker run --rm -v $PWD:/mnt debian:bullseye-slim rm -rf /mnt/tools/image-builder/rootfs
-      - sudo install -d -o root -g buildkite-agent -m 775 "/local/artifacts/$BUILDKITE_BUILD_NUMBER"
-      - cp tools/image-builder/rootfs.img "/local/artifacts/$BUILDKITE_BUILD_NUMBER/"
+      - stop_command
+
 
   # Just in case, list loopback devices to make sure there are no leaks.
   # We probably should move that to metrics later.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,6 +22,8 @@ steps:
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
       EXTRAGOARGS: "-race"
     command:
+      - uname -a
+      - docker build -t localhost/runc-builder:80 -f tools/docker/Dockerfile.runc-builder tools/
       - make test-images
       - docker run --rm -v $PWD:/mnt debian:bullseye-slim rm -rf /mnt/tools/image-builder/rootfs
       - sudo install -d -o root -g buildkite-agent -m 775 "/local/artifacts/$BUILDKITE_BUILD_NUMBER"


### PR DESCRIPTION
*Issue #, if available:*
Current HEAD of main branch is failing with issue
```
docker build \
--
  | -t localhost/runc-builder:3327 \
  | -f tools/docker/Dockerfile.runc-builder \
  | tools/
  | WARNING: Error loading config file: /local/home/buildkite-agent/.docker/config.json: open /local/home/buildkite-agent/.docker/config.json: permission denied
  | unknown shorthand flag: 't' in -t
  | make: *** [Makefile:378: tools/runc-builder-stamp] Error 1
  | 🚨 Error: The command exited with status 2
```
*Description of changes:*
 - Add show environment step to better know the running environment
 - 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Signed-off-by: Tony Fang <nhfang@amazon.com>