### PR TITLE
Upgrade to Debian 11(Bullseye) everywhere

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,9 +15,9 @@ files into `/usr/local/bin`.
 1. Get an AWS account (see
    [this article](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
    if you need help creating one)
-2. Launch an i3.metal instance running Debian Buster (you can find it in the
-   [AWS marketplace](https://aws.amazon.com/marketplace/pp/B0859NK4HC) or
-   on [this page](https://wiki.debian.org/Cloud/AmazonEC2Image/Buster).
+2. Launch an i3.metal instance running Debian Bullseye (you can find it in the
+   [AWS marketplace](https://aws.amazon.com/marketplace/pp/prodview-l5gv52ndg5q6i) or
+   on [this page](https://wiki.debian.org/Cloud/AmazonEC2Image/Bullseye).
    If you need help launching an EC2 instance, see the
    [EC2 getting started guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html).
 3. Run the script below to download and install all the required dependencies on a debian based instance.
@@ -30,8 +30,8 @@ cd ~
 
 # Install git, Go 1.16, make, curl
 sudo mkdir -p /etc/apt/sources.list.d
-echo "deb http://ftp.debian.org/debian buster-backports main" | \
-  sudo tee /etc/apt/sources.list.d/buster-backports.list
+echo "deb http://ftp.debian.org/debian bullseye-backports main" | \
+  sudo tee /etc/apt/sources.list.d/bullseye-backports.list
 sudo DEBIAN_FRONTEND=noninteractive apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get \
   install --yes \

--- a/tools/docker/Dockerfile.proto-builder
+++ b/tools/docker/Dockerfile.proto-builder
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.17-stretch
+FROM golang:1.17-bullseye
 
 RUN apt-get update && apt-get install --yes --no-install-recommends \
 	libprotobuf-dev \

--- a/tools/docker/Dockerfile.runc-builder
+++ b/tools/docker/Dockerfile.runc-builder
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.17-stretch
+FROM golang:1.17-bullseye
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install libseccomp-dev pkg-config

--- a/tools/image-builder/README.md
+++ b/tools/image-builder/README.md
@@ -46,7 +46,7 @@ Alternatively, to build outside a container, you'll need:
 * [`debootstrap`](https://salsa.debian.org/installer-team/debootstrap)
   (Install via the package of the same name on Debian and Ubuntu)
 * `mksquashfs`, available in the
-   [`squashfs-tools`](https://packages.debian.org/stretch/squashfs-tools)
+   [`squashfs-tools`](https://packages.debian.org/bullseye/squashfs-tools)
    package on Debian and Ubuntu.
 * To run the image build process as root.
 
@@ -79,7 +79,7 @@ A complete command line, settable via the `kernel_args` setting in `/etc/contain
 
 In order to ensure sufficient entropy is consistently available within 
 the VM, the rootfs is configured to start the 
-[`haveged`](https://manpages.debian.org/buster/haveged/haveged.8.en.html)
+[`haveged`](https://manpages.debian.org/bullseye/haveged/haveged.8.en.html)
 daemon during boot. [More information on its method of operation and other
 details can be found in its FAQ](https://issihosts.com/haveged/faq.html).
 Users of the image created by this utility are encouraged to evaluate 


### PR DESCRIPTION
*Issue #, if available:*
In #726 we upgraded to Debian 11 most of the places. 
We have some leftovers in the repo using Debian 9(stretch) which was out of support and the [stretch package repo seems removed](https://packages.debian.org/stretch/) recently causing [apt-get installation issue](https://github.com/firecracker-microvm/firecracker-containerd/actions/runs/4799041254/jobs/8538393247?pr=742#step:9:115) in CI. 

*Description of changes:*
This PR upgrades reminder of Debian 9(stretch) and Debian 10(buster) to Debian 11.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
