### PR TITLE
Upgrade actions/setup-go to v4 in CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,9 +37,11 @@ jobs:
           # So, we will fetch 30 commits just in case to have
           # 20 actual commits with associated merged commits.
           fetch-depth: 30
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
+          # Disable Go caching feature when compiling across Linux distributions due to collisions until https://github.com/actions/setup-go/issues/368 is resolved.
+          cache: false
       - run: make
       - run: make lint
       - name: make test


### PR DESCRIPTION
Adds protections to disable caching for corner case when compiling across multiple Linux distribution versions would result in collisions.

*Issue #, if available:*
N/A

*Description of changes:*
Upgrades actions/setup-go to v4 which has Go caching enabled by default. Explicitly disabling Go caching right now due to an upstream bug which will result in collisions when compiling across multiple versions of the same Linux distribution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
