### PR TITLE
Send to copyDone when err == nil

### DIFF
--- a/internal/vm/ioproxy.go
+++ b/internal/vm/ioproxy.go
@@ -152,8 +152,8 @@ func (connectorPair *IOConnectorPair) proxy(
 			} else {
 				logger.WithError(err).Error("error copying io")
 			}
-			copyDone <- err
 		}
+		copyDone <- err
 		defer logClose(logger, reader, writer)
 	}()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The ioproxy helps copy container logs from the normal container fifos to the firecracker uvm's vsock. The copying happens in a go-routine and when complete, it send a notification over the `copyDone` channel to signal to the agent/runtime to cleanup the ioproxy.

This change fixes a bug where, if the iopoxy copy finished without an error (i.e. `io.CopyBuffer` got an `EOF` from the read end), the `copyDone` channel was not notified leaving the ioproxy connected to the vsock, but not the container. This change always notifies `copyDone` when the copy finishes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
