### PR TITLE
Use unique VMIDs in integ tests

### DIFF
--- a/internal/integtest/vmid.go
+++ b/internal/integtest/vmid.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integtest
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// VMIDGen generates namespaced VMIDs that are unique across different VMIDGens.
+// We have many tests which use a numeric ID as the VMID which could conflict with
+// concurrently running test. VMIDGen guarantees uniqueness across different tests.
+type VMIDGen struct {
+	prefix string
+}
+
+// NewVMIDGen creates a new VMIDGen
+func NewVMIDGen() (*VMIDGen, error) {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return &VMIDGen{hex.EncodeToString(b)}, nil
+}
+
+// VMID creates a namespaced VMID given an integer seed.
+// A VMIDGen will generate the same VMID multiple times given the same seed,
+// but two different VMIDGens will generate different ids given the same seed.
+func (gen *VMIDGen) VMID(seed int) string {
+	return fmt.Sprintf("%s-%d", gen.prefix, seed)
+}

--- a/snapshotter/service_integ_test.go
+++ b/snapshotter/service_integ_test.go
@@ -16,7 +16,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/containerd/containerd"
@@ -51,25 +50,28 @@ const (
 func TestLaunchContainerWithRemoteSnapshotter_Isolated(t *testing.T) {
 	integtest.Prepare(t, integtest.WithDefaultNetwork())
 
-	vmID := 0
-	err := launchContainerWithRemoteSnapshotterInVM(context.Background(), strconv.Itoa(vmID))
+	gen, err := integtest.NewVMIDGen()
+	require.NoError(t, err, "Failed to create a VMIDGen")
+	err = launchContainerWithRemoteSnapshotterInVM(context.Background(), gen.VMID(0))
 	require.NoError(t, err)
 }
 
 func TestLaunchMultipleContainersWithRemoteSnapshotter_Isolated(t *testing.T) {
 	integtest.Prepare(t, integtest.WithDefaultNetwork())
+	gen, err := integtest.NewVMIDGen()
+	require.NoError(t, err, "Failed to create a VMIDGen")
 
 	eg, ctx := errgroup.WithContext(context.Background())
 
 	numberOfVms := integtest.NumberOfVms
 	for vmID := 0; vmID < numberOfVms; vmID++ {
 		ctx := ctx
-		id := vmID
+		id := gen.VMID(vmID)
 		eg.Go(func() error {
-			return launchContainerWithRemoteSnapshotterInVM(ctx, strconv.Itoa(id))
+			return launchContainerWithRemoteSnapshotterInVM(ctx, id)
 		})
 	}
-	err := eg.Wait()
+	err = eg.Wait()
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Many of our integ tests use an integer as the VMID. Some of the test suites run in parallel which risks either creating the same ID multiple times or one test tearing down another test's resources.

This change makes each test's VMIDs unique


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
