### PR TITLE
Remove create task stdin/stdout/stderr fields.

### DIFF
--- a/runtime/service.go
+++ b/runtime/service.go
@@ -1146,12 +1146,10 @@ func (s *service) Create(requestCtx context.Context, request *taskAPI.CreateTask
 		return nil, err
 	}
 
+	// We don't log request.Stdin, request.Stdout, or request.Stderr as they may contain sensitive information.
 	logger.WithFields(logrus.Fields{
 		"bundle":     request.Bundle,
 		"terminal":   request.Terminal,
-		"stdin":      request.Stdin,
-		"stdout":     request.Stdout,
-		"stderr":     request.Stderr,
 		"checkpoint": request.Checkpoint,
 	}).Debug("creating task")
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Stdin/stdout/stderr fields can container full shim logger binary URIs which may container sensitive information such as logging credentials. Since there is no simple method for redacting this information at runtime, the best solution is to not log them to disk.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
