### PR TITLE
Update protoc-gen-go to v1.33 in proto-builder container

### DIFF
--- a/tools/docker/Dockerfile.proto-builder
+++ b/tools/docker/Dockerfile.proto-builder
@@ -16,7 +16,7 @@ FROM golang:1.21-bullseye
 RUN apt-get update && apt-get install --yes --no-install-recommends \
 	libprotobuf-dev \
 	protobuf-compiler \
-	&& go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28 \
+	&& go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.33 \
 	&& go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@v1.2.3 \
 	&& mkdir /protobuf
 


### PR DESCRIPTION
*Issue #, if available:*
Proto checks can failure intermittently due to outdated protoc-gen-go tooling in proto-builder container.
See https://github.com/firecracker-microvm/firecracker-containerd/actions/runs/8942291119

*Description of changes:*
This change updates the protoc-gen-go tooling to v1.33 to align with the version used to generate the protogen code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
