### PR TITLE
#819: fix: enable static linking for docker-credential-mmds to resolve glib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ INTEG_TEST_SUBDIRS:=$(addprefix integ-test-,$(SUBDIRS))
 
 export INSTALLROOT?=/usr/local
 export STATIC_AGENT
+export STATIC_DOCKER_CREDENTIAL_MMDS
 
 export DOCKER_IMAGE_TAG?=latest
 
@@ -89,6 +90,7 @@ $(SUBDIRS):
 		--env GOPATH=/go \
 		--env GO111MODULES=on \
 		--env STATIC_AGENT=on \
+		--env STATIC_DOCKER_CREDENTIAL_MMDS=on \
 		--env GOPROXY=$(shell go env GOPROXY) \
 		--workdir /src \
 		$(FIRECRACKER_CONTAINERD_BUILDER_IMAGE) \

--- a/docker-credential-mmds/Makefile
+++ b/docker-credential-mmds/Makefile
@@ -22,7 +22,11 @@ all: credential-helper
 credential-helper: docker-credential-mmds
 
 docker-credential-mmds: $(SOURCES) $(GOMOD) $(GOSUM)
+ifneq ($(STATIC_DOCKER_CREDENTIAL_MMDS),)
+	CGO_ENABLED=0 go build -o docker-credential-mmds $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)"
+else
 	go build -o docker-credential-mmds $(EXTRAGOARGS) -ldflags "-X main.revision=$(REVISION)"
+endif
 
 test:
 	go test ./... $(EXTRAGOARGS)


### PR DESCRIPTION
*Issue #819, if available:*

*Description of changes:*

Add a `STATIC_DOCKER_CREDENTIAL_MMDS` flag to the `docker-credential-mmds` build process (similar to the agent's build process) to enable static linking ( set `CGO_ENABLED=0`) and avoid dependency on the host's glibc version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
