### PR TITLE
Remove Ubuntu 20.04 runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04']
+        os: ['ubuntu-22.04']
         go: ['1.23', '1.24']
       # Build all variants regardless of failures
       fail-fast: false


### PR DESCRIPTION
Ubuntu 20.04 is no longer supported from GitHub actions, so this change removes them to avoid failing our CI.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
