### PR TITLE
Don't force image builder to  clean-in-docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ clean:
 	$(MAKE) -C $(RUNC_DIR) clean
 	$(MAKE) firecracker-clean
 	rm -f tools/*stamp *stamp
-	$(MAKE) -C tools/image-builder clean-in-docker
+	$(MAKE) -C tools/image-builder clean
 	rm -f $(DEFAULT_VMLINUX_NAME)
 
 rmi-if-exists = $(if $(shell docker images -q $(1)),docker rmi $(1),true)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

    FCCD's `make clean` used to call `make clean-in-docker` for the image
    builder. The image builder builds a docker image if necessary, then
    mounts all the directories and calls clean. This is because some of the
    resources were built in docker which may be owned by root.
    
    On the buildkite runners, make clean is run as root because some of the
    subdirectores need root permission to clean appropriately. This was causing
    docker to build an image and to create a buildkit lock as root which caused
    subsequent steps in the pipeline to fail if they tried to build a container
    as non-root.
    
    The solution here is to call the image builder's regular clean target
    which will directly delete resources if it is root, otherwise it will
    call clean-in-docker. Thist way, the clean will not need to create a
    container to do the cleanup and will not create a lock as root.
    
    An alternative would be to go through all the subdirectories' clean
    targets to make sure they have an equivalent clean-in-docker that is
    only run if the clean target is run as root. This would be a good follow
    up once tests are passing again.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
