### PR TITLE
Update Makefile support bookworm debian release

### DIFF
--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -46,7 +46,7 @@ define run_debootstrap =
 	debootstrap \
 		--variant=minbase \
 		--include=$(subst $(SPACE),$(COMMA),$(PACKAGES))\
-		bullseye \
+		bookworm \
 		"$(WORKDIR)" $(DEBMIRROR)
 	rm -rf "$(WORKDIR)/var/cache/apt/archives" \
 	       "$(WORKDIR)/usr/share/doc" \


### PR DESCRIPTION


*Issue #, if available:*
[827](https://github.com/firecracker-microvm/firecracker-containerd/issues/827)

*Description of changes:*
update 2.31 to 2.34 
fix:     /usr/local/bin/agent: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/bin/agent)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
