### PR TITLE
fix: add package comments and enable revive check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,9 +38,6 @@ issues:
       - govet
       text: "copylocks"
     - linters:
-      - revive
-      text: package-comments
-    - linters:
       - staticcheck
       text: "Do not rely on the global seed"
   exclude-dirs:

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// agent_test contains tests for helper functions in the agent binary,
+// including validation of TaskExecID behavior.
 package main
 
 import (

--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package client contains helpers for working with containers managed by
+// firecracker-containerd, such as computing rootfs paths inside a microVM.
 package client
 
 import "github.com/firecracker-microvm/firecracker-containerd/internal/bundle"

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package config defines configuration structures and helpers used by
+// firecracker-containerd, including loading and validating config files.
 package config
 
 import (

--- a/eventbridge/eventbridge.go
+++ b/eventbridge/eventbridge.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package eventbridge implements an event forwarding bridge that translates
+// and relays containerd events to firecracker-containerd components.
 package eventbridge
 
 import (

--- a/firecracker-control/client/client.go
+++ b/firecracker-control/client/client.go
@@ -11,6 +11,9 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package client implements a Go client for interacting with the
+// firecracker-control service, providing access to VM and lifecycle
+// management APIs.
 package client
 
 import (

--- a/firecracker-control/cmd/containerd/gomod_test.go
+++ b/firecracker-control/cmd/containerd/gomod_test.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// gomod_test keeps the firecracker-control containerd command and its
+// dependencies visible to Go's module tooling so they are not pruned.
 package main
 
 import "github.com/containerd/containerd/cmd/ctr/app"

--- a/firecracker-control/common.go
+++ b/firecracker-control/common.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package service defines common constants shared by the firecracker-control
+// service implementation, such as plugin identifiers.
 package service
 
 const (

--- a/internal/common.go
+++ b/internal/common.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package internal contains shared helpers and internal utilities used
+// across firecracker-containerd components.
 package internal
 
 import (

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package debug provides helpers for configuring firecracker-containerd
+// logging and managing debug log levels across components.
 package debug
 
 import (

--- a/internal/event/exchange.go
+++ b/internal/event/exchange.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package event provides internal event exchange utilities, supporting
+// publish/subscribe patterns for firecracker-containerd components.
 package event
 
 import (

--- a/internal/integtest/config.go
+++ b/internal/integtest/config.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package integtest provides shared configuration and utilities for
+// integration tests across firecracker-containerd.
 package integtest
 
 import (

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package shim provides helpers for working with the containerd shim,
+// including construction of Firecracker control socket addresses.
 package shim
 
 import (

--- a/internal/vm/agent.go
+++ b/internal/vm/agent.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package vm provides helpers for managing Firecracker VMs, including
+// agent-related IO handling utilities.
 package vm
 
 import (

--- a/runtime/cpuset/cpuset_builder.go
+++ b/runtime/cpuset/cpuset_builder.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package cpuset provides helpers for constructing and managing cpusets
+// used by Firecracker VMs and container workloads.
 package cpuset
 
 import (

--- a/runtime/firecrackeroci/annotation.go
+++ b/runtime/firecrackeroci/annotation.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package firecrackeroci defines OCI annotations and related helpers used by
+// the Firecracker runtime integration.
 package firecrackeroci
 
 import (

--- a/runtime/vm/mount.go
+++ b/runtime/vm/mount.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package vm contains Firecracker VM runtime helpers, including utilities
+// for preparing and managing container filesystem mounts inside VMs.
 package vm
 
 import (

--- a/snapshotter/app/service.go
+++ b/snapshotter/app/service.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package app implements the application layer for the snapshotter,
+// including service initialization and GRPC wiring.
 package app
 
 import (

--- a/snapshotter/config/config.go
+++ b/snapshotter/config/config.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package config defines configuration structures and helpers for the
+// demux snapshotter, including loading configuration from TOML files.
 package config
 
 import (

--- a/snapshotter/demux/cache/cache.go
+++ b/snapshotter/demux/cache/cache.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package cache implements a cache of remote snapshotters used by the
+// demux snapshotter for routing requests and service discovery.
 package cache
 
 import (

--- a/snapshotter/demux/internal/failing_snapshotter.go
+++ b/snapshotter/demux/internal/failing_snapshotter.go
@@ -11,6 +11,9 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package internal contains internal test and helper implementations for
+// the demux snapshotter, including a snapshotter that intentionally fails
+// for error-path validation.
 package internal
 
 import (

--- a/snapshotter/demux/metrics/discovery/service_discovery.go
+++ b/snapshotter/demux/metrics/discovery/service_discovery.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package discovery provides metrics and helpers for discovering remote
+// snapshotter services used by the demux snapshotter.
 package discovery
 
 import (

--- a/snapshotter/demux/metrics/proxy.go
+++ b/snapshotter/demux/metrics/proxy.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package metrics exposes Prometheus metrics for the demux snapshotter's
+// proxy operations, providing visibility into request handling and failures.
 package metrics
 
 import (

--- a/snapshotter/demux/proxy/address/http_resolver.go
+++ b/snapshotter/demux/proxy/address/http_resolver.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package address defines resolvers for locating proxy network addresses
+// used by the demux snapshotter's HTTP services.
 package address
 
 import (

--- a/snapshotter/demux/proxy/snapshotter.go
+++ b/snapshotter/demux/proxy/snapshotter.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package proxy implements the proxy snapshotter used by the demux
+// snapshotter to route requests to remote snapshotter backends.
 package proxy
 
 import (

--- a/snapshotter/demux/snapshotter.go
+++ b/snapshotter/demux/snapshotter.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package demux implements the demux snapshotter, which routes snapshotter
+// operations to remote backends based on image configuration.
 package demux
 
 import (

--- a/snapshotter/internal/http_address_resolver.go
+++ b/snapshotter/internal/http_address_resolver.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// http-address-resolver runs a small HTTP service that resolves snapshotter
+// namespaces to proxy addresses for the demux snapshotter.
 package main
 
 import (

--- a/snapshotter/internal/integtest/stargz/fs/config/config.go
+++ b/snapshotter/internal/integtest/stargz/fs/config/config.go
@@ -38,6 +38,8 @@
    license that can be found in the NOTICE.md file.
 */
 
+// Package config defines labels used to configure the Stargz remote
+// snapshotter behavior in integration tests.
 package config
 
 const (

--- a/snapshotter/internal/integtest/stargz/fs/source/source.go
+++ b/snapshotter/internal/integtest/stargz/fs/source/source.go
@@ -32,6 +32,8 @@
    limitations under the License.
 */
 
+// Package source builds source information for stargz-based remote
+// snapshots in integration tests by annotating image descriptors.
 package source
 
 import (

--- a/snapshotter/internal/mount/collection.go
+++ b/snapshotter/internal/mount/collection.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package mount provides helpers for working with collections of
+// containerd mounts.
 package mount
 
 import "github.com/containerd/containerd/mount"

--- a/volume/cmd/volume-init/main.go
+++ b/volume/cmd/volume-init/main.go
@@ -11,6 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// volume-init reads volume mapping configuration from stdin and copies
+// the requested directories into the guest volume image.
 package main
 
 import (


### PR DESCRIPTION
This change enables the revive `package-comments` check and fixes the existing violations.

Changes:
- Add package comments for packages that were missing them across runtime, snapshotter, internal utilities, and test helpers.
- Remove the revive `package-comments` exclusion from `.golangci.yml`.

Verification:
- `make lint`
- `go test ./...`

Fixes #812.