### PR TITLE
fix: avoid protobuf copylocks in runtime

### DIFF
--- a/runtime/benchmark_test.go
+++ b/runtime/benchmark_test.go
@@ -25,6 +25,7 @@ import (
 	fccontrol "github.com/firecracker-microvm/firecracker-containerd/proto/service/fccontrol/ttrpc"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 const benchmarkCount = 10
@@ -32,17 +33,18 @@ const benchmarkCount = 10
 func createAndStopVM(
 	ctx context.Context,
 	fcClient fccontrol.FirecrackerService,
-	request proto.CreateVMRequest,
+	request *proto.CreateVMRequest,
 ) (time.Duration, error) {
 	uuid, err := uuid.NewV4()
 	if err != nil {
 		return 0, err
 	}
 
+	request = gproto.Clone(request).(*proto.CreateVMRequest)
 	request.VMID = uuid.String()
 
 	t0 := time.Now()
-	_, err = fcClient.CreateVM(ctx, &request)
+	_, err = fcClient.CreateVM(ctx, request)
 	if err != nil {
 		return 0, err
 	}
@@ -81,7 +83,7 @@ func benchmarkCreateAndStopVM(t *testing.T, vcpuCount uint32, kernelArgs string)
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 
-		elapsed, err := createAndStopVM(ctx, fcClient, request)
+		elapsed, err := createAndStopVM(ctx, fcClient, &request)
 		if err != nil {
 			return
 		}

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -54,6 +54,7 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
 
 	"github.com/firecracker-microvm/firecracker-containerd/config"
 	"github.com/firecracker-microvm/firecracker-containerd/eventbridge"
@@ -1031,9 +1032,9 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 	// If no value for NetworkInterfaces was specified (not even an empty but non-nil list) and
 	// the runtime config specifies a default list, use those defaults
 	if req.NetworkInterfaces == nil {
-		for _, ni := range s.config.DefaultNetworkInterfaces {
-			niCopy := ni // we don't want to allow any further calls to modify structs in s.config.DefaultNetworkInterfaces
-			req.NetworkInterfaces = append(req.NetworkInterfaces, &niCopy)
+		for i := range s.config.DefaultNetworkInterfaces {
+			ni := &s.config.DefaultNetworkInterfaces[i]
+			req.NetworkInterfaces = append(req.NetworkInterfaces, gproto.Clone(ni).(*proto.FirecrackerNetworkInterface))
 		}
 	}
 

--- a/runtime/service_integ_test.go
+++ b/runtime/service_integ_test.go
@@ -60,6 +60,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 const (
@@ -743,18 +744,18 @@ func TestLongUnixSocketPath_Isolated(t *testing.T) {
 
 	subtests := []struct {
 		name    string
-		request proto.CreateVMRequest
+		request *proto.CreateVMRequest
 	}{
 		{
 			name: "Without Jailer",
-			request: proto.CreateVMRequest{
+			request: &proto.CreateVMRequest{
 				VMID:              vmID,
 				NetworkInterfaces: []*proto.FirecrackerNetworkInterface{},
 			},
 		},
 		{
 			name: "With Jailer",
-			request: proto.CreateVMRequest{
+			request: &proto.CreateVMRequest{
 				VMID:              vmID,
 				NetworkInterfaces: []*proto.FirecrackerNetworkInterface{},
 				JailerConfig: &proto.JailerConfig{
@@ -766,10 +767,10 @@ func TestLongUnixSocketPath_Isolated(t *testing.T) {
 	}
 
 	for _, subtest := range subtests {
-		request := subtest.request
+		request := gproto.Clone(subtest.request).(*proto.CreateVMRequest)
 		vmID := request.VMID
 		t.Run(subtest.name, func(t *testing.T) {
-			_, err = fcClient.CreateVM(ctx, &request)
+			_, err = fcClient.CreateVM(ctx, request)
 			require.NoError(t, err, "failed to create VM")
 
 			// double-check that the sockets are at the expected path and that their absolute
@@ -1703,8 +1704,8 @@ func TestStopVM_Isolated(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		createVMRequest proto.CreateVMRequest
-		stopFunc        func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req proto.CreateVMRequest)
+		createVMRequest *proto.CreateVMRequest
+		stopFunc        func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req *proto.CreateVMRequest)
 		withStopVM      bool
 	}{
 
@@ -1712,8 +1713,8 @@ func TestStopVM_Isolated(t *testing.T) {
 			name:       "Successful",
 			withStopVM: true,
 
-			createVMRequest: proto.CreateVMRequest{},
-			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req proto.CreateVMRequest) {
+			createVMRequest: &proto.CreateVMRequest{},
+			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req *proto.CreateVMRequest) {
 				_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{
 					VMID:           req.VMID,
 					TimeoutSeconds: 30,
@@ -1728,13 +1729,13 @@ func TestStopVM_Isolated(t *testing.T) {
 			name:       "Timeout",
 			withStopVM: true,
 
-			createVMRequest: proto.CreateVMRequest{
+			createVMRequest: &proto.CreateVMRequest{
 				KernelArgs: kernelArgs + " failure=slow-reboot",
 				RootDrive: &proto.FirecrackerRootDrive{
 					HostPath: "/var/lib/firecracker-containerd/runtime/rootfs-debug.img",
 				},
 			},
-			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req proto.CreateVMRequest) {
+			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req *proto.CreateVMRequest) {
 				_, err = fcClient.StopVM(ctx, &proto.StopVMRequest{VMID: req.VMID})
 				require.Error(tb, err)
 				assert.Equal(tb, codes.Internal, status.Code(err))
@@ -1747,8 +1748,8 @@ func TestStopVM_Isolated(t *testing.T) {
 			name:       "SIGKILLFirecracker",
 			withStopVM: false,
 
-			createVMRequest: proto.CreateVMRequest{},
-			stopFunc: func(ctx context.Context, tb testing.TB, _ fccontrol.FirecrackerService, _ proto.CreateVMRequest) {
+			createVMRequest: &proto.CreateVMRequest{},
+			stopFunc: func(ctx context.Context, tb testing.TB, _ fccontrol.FirecrackerService, _ *proto.CreateVMRequest) {
 				firecrackerProcesses, err := findProcess(ctx, findFirecracker)
 				require.NoError(tb, err, "failed waiting for expected firecracker process %q to come up", firecrackerProcessName)
 				require.Len(tb, firecrackerProcesses, 1, "expected only one firecracker process to exist")
@@ -1765,13 +1766,13 @@ func TestStopVM_Isolated(t *testing.T) {
 			name:       "ErrorExit",
 			withStopVM: true,
 
-			createVMRequest: proto.CreateVMRequest{
+			createVMRequest: &proto.CreateVMRequest{
 				KernelArgs: kernelArgs + " failure=slow-reboot",
 				RootDrive: &proto.FirecrackerRootDrive{
 					HostPath: "/var/lib/firecracker-containerd/runtime/rootfs-debug.img",
 				},
 			},
-			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req proto.CreateVMRequest) {
+			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req *proto.CreateVMRequest) {
 				firecrackerProcesses, err := findProcess(ctx, findFirecracker)
 				require.NoError(tb, err, "failed waiting for expected firecracker process %q to come up", firecrackerProcessName)
 				require.Len(tb, firecrackerProcesses, 1, "expected only one firecracker process to exist")
@@ -1801,8 +1802,8 @@ func TestStopVM_Isolated(t *testing.T) {
 			name:       "PauseStop",
 			withStopVM: true,
 
-			createVMRequest: proto.CreateVMRequest{},
-			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req proto.CreateVMRequest) {
+			createVMRequest: &proto.CreateVMRequest{},
+			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req *proto.CreateVMRequest) {
 				_, err = fcClient.PauseVM(ctx, &proto.PauseVMRequest{VMID: req.VMID})
 				require.Equal(tb, status.Code(err), codes.OK)
 
@@ -1817,8 +1818,8 @@ func TestStopVM_Isolated(t *testing.T) {
 			name:       "Suspend",
 			withStopVM: true,
 
-			createVMRequest: proto.CreateVMRequest{},
-			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req proto.CreateVMRequest) {
+			createVMRequest: &proto.CreateVMRequest{},
+			stopFunc: func(ctx context.Context, tb testing.TB, fcClient fccontrol.FirecrackerService, req *proto.CreateVMRequest) {
 				firecrackerProcesses, err := findProcess(ctx, findFirecracker)
 				require.NoError(tb, err, "failed waiting for expected firecracker process %q to come up", firecrackerProcessName)
 				require.Len(tb, firecrackerProcesses, 1, "expected only one firecracker process to exist")
@@ -1839,13 +1840,13 @@ func TestStopVM_Isolated(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, test := range tests {
-		testFunc := func(tb testing.TB, createVMRequest proto.CreateVMRequest) {
+		testFunc := func(tb testing.TB, createVMRequest *proto.CreateVMRequest) {
 			ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 			defer cancel()
 
 			vmID := createVMRequest.VMID
 
-			_, err = fcClient.CreateVM(ctx, &createVMRequest)
+			_, err = fcClient.CreateVM(ctx, createVMRequest)
 			require.NoError(tb, err)
 
 			c, err := client.NewContainer(ctx,
@@ -1892,7 +1893,7 @@ func TestStopVM_Isolated(t *testing.T) {
 			if test.name == "SIGKILLFirecracker" || test.name == "ErrorExit" || test.name == "PauseStop" || test.name == "Suspend" {
 				t.Skip("Skipping test - investigating runc 1.2 behavior")
 			}
-			req := test.createVMRequest
+			req := gproto.Clone(test.createVMRequest).(*proto.CreateVMRequest)
 			req.VMID = testNameToVMID(t.Name())
 			testFunc(t, req)
 		})
@@ -1902,7 +1903,7 @@ func TestStopVM_Isolated(t *testing.T) {
 			if test.name == "SIGKILLFirecracker" || test.name == "ErrorExit" || test.name == "PauseStop" || test.name == "Suspend" {
 				t.Skip("Skipping jailer test - investigating runc 1.2 behavior")
 			}
-			req := test.createVMRequest
+			req := gproto.Clone(test.createVMRequest).(*proto.CreateVMRequest)
 			req.VMID = testNameToVMID(t.Name())
 			req.JailerConfig = &proto.JailerConfig{
 				UID: 300000,

--- a/runtime/service_test.go
+++ b/runtime/service_test.go
@@ -277,6 +277,46 @@ func TestBuildVMConfiguration(t *testing.T) {
 	}
 }
 
+func TestBuildVMConfiguration_DefaultNetworkInterfacesAreCloned(t *testing.T) {
+	debugHelper, err := debug.New()
+	require.NoError(t, err, "failed to create debug helper")
+
+	svc := &service{
+		namespace: "TestBuildVMConfiguration_DefaultNetworkInterfacesAreCloned",
+		logger:    logrus.WithField("test", t.Name()),
+		config: &config.Config{
+			KernelArgs:      "KERNEL ARGS",
+			KernelImagePath: "KERNEL IMAGE",
+			RootDrive:       "ROOT DRIVE",
+			DebugHelper:     debugHelper,
+			DefaultNetworkInterfaces: []proto.FirecrackerNetworkInterface{
+				{
+					StaticConfig: &proto.StaticNetworkConfiguration{
+						MacAddress:  mac,
+						HostDevName: hostDevName,
+					},
+				},
+			},
+		},
+	}
+
+	tempDir := t.TempDir()
+	svc.shimDir = vm.Dir(tempDir)
+	svc.jailer = newNoopJailer(context.Background(), svc.logger, svc.shimDir)
+
+	req := &proto.CreateVMRequest{}
+
+	_, err = svc.buildVMConfiguration(req)
+	require.NoError(t, err)
+	require.Len(t, req.NetworkInterfaces, 1)
+
+	req.NetworkInterfaces[0].AllowMMDS = true
+	req.NetworkInterfaces[0].StaticConfig.MacAddress = "AA:FC:00:00:00:FF"
+
+	assert.False(t, svc.config.DefaultNetworkInterfaces[0].AllowMMDS)
+	assert.Equal(t, mac, svc.config.DefaultNetworkInterfaces[0].StaticConfig.MacAddress)
+}
+
 func TestDebugConfig(t *testing.T) {
 	emptyDebugHelper, err := debug.New()
 	require.NoError(t, err, "failed to create empty debug helper")


### PR DESCRIPTION
Fixes #811

`go vet ./...` on `main` reports `copylocks` warnings in the runtime paths, same deal in a few tests too.

This switches those cases to pointers or `proto.Clone(...)`, so we stop copying protobuf message state by value. also keeps default network interfaces detached from runtime config.

repro
1. checkout `main`
2. run `go vet ./...`
3. see `copylocks` warnings from `runtime/service.go`, `runtime/benchmark_test.go`, and `runtime/service_integ_test.go`

checks
`go vet ./...`
`make lint`
`DISABLE_ROOT_TESTS=1 go test ./...`